### PR TITLE
fix: preserve scroll position on preview toggle and home page

### DIFF
--- a/client/src/components/ResizableSplitPanel.tsx
+++ b/client/src/components/ResizableSplitPanel.tsx
@@ -6,6 +6,7 @@ interface ResizableSplitPanelProps {
   defaultLeftWidth?: number // percentage (0-100)
   minLeftWidth?: number // percentage
   maxLeftWidth?: number // percentage
+  isRightPanelOpen?: boolean
 }
 
 interface ResizableVerticalPanelProps {
@@ -22,6 +23,7 @@ export function ResizableSplitPanel({
   defaultLeftWidth = 40,
   minLeftWidth = 25,
   maxLeftWidth = 60,
+  isRightPanelOpen = true,
 }: ResizableSplitPanelProps) {
   const [leftWidth, setLeftWidth] = useState(defaultLeftWidth)
   const [isDragging, setIsDragging] = useState(false)
@@ -102,10 +104,11 @@ export function ResizableSplitPanel({
       {/* Left Panel */}
       <div
         style={{
-          width: `${leftWidth}%`,
+          width: isRightPanelOpen ? `${leftWidth}%` : '100%',
+          transition: !isDragging ? 'width 300ms cubic-bezier(0.4, 0, 0.2, 1)' : 'none',
           willChange: isDragging ? 'width' : 'auto',
           pointerEvents: isDragging ? 'none' : 'auto',
-          contain: isDragging ? 'layout style paint' : 'none'
+          contain: isDragging ? 'layout style paint' : 'none',
         }}
         className="flex-shrink-0 h-full overflow-hidden"
       >
@@ -115,6 +118,7 @@ export function ResizableSplitPanel({
       {/* Resizable Divider */}
       <div
         onMouseDown={handleMouseDown}
+        style={{ display: isRightPanelOpen ? undefined : 'none' }}
         className={`w-1 bg-[#2a2a2a] hover:bg-[#404040] cursor-col-resize flex-shrink-0 relative group ${
           isDragging ? 'bg-[#4a9eff]' : 'transition-colors'
         }`}
@@ -131,11 +135,14 @@ export function ResizableSplitPanel({
 
       {/* Right Panel */}
       <div
-        className="flex-1 h-full overflow-hidden"
+        className="h-full overflow-hidden"
         style={{
+          flex: isRightPanelOpen ? '1' : '0 0 0px',
+          width: isRightPanelOpen ? undefined : 0,
+          pointerEvents: isRightPanelOpen ? 'auto' : 'none',
+          transition: !isDragging ? 'flex 300ms cubic-bezier(0.4, 0, 0.2, 1), width 300ms cubic-bezier(0.4, 0, 0.2, 1)' : 'none',
           willChange: isDragging ? 'width' : 'auto',
-          pointerEvents: isDragging ? 'none' : 'auto',
-          contain: isDragging ? 'layout style paint' : 'none'
+          contain: isDragging ? 'layout style paint' : 'none',
         }}
       >
         {rightPanel}

--- a/client/src/pages/ChatPreview.tsx
+++ b/client/src/pages/ChatPreview.tsx
@@ -3932,9 +3932,6 @@ Can you help me fix this query?`
       <div className="flex-1 overflow-hidden flex">
         <ResizableSplitPanel
           isRightPanelOpen={isPreviewOpen}
-          defaultLeftWidth={45}
-          minLeftWidth={25}
-          maxLeftWidth={75}
           leftPanel={
             <div className={`chat-area flex flex-col h-full ${isPreviewOpen ? 'chat-area-with-preview' : 'chat-area-centered'}`}>
                 <div className="flex flex-col h-full w-full">
@@ -4081,6 +4078,9 @@ Can you help me fix this query?`
                 </div>
               </div>
             }
+          defaultLeftWidth={25}
+          minLeftWidth={25}
+          maxLeftWidth={75}
         />
       </div>
 

--- a/client/src/pages/ChatPreview.tsx
+++ b/client/src/pages/ChatPreview.tsx
@@ -3930,10 +3930,13 @@ Can you help me fix this query?`
 
       {/* Centered Chat + Resizable Preview Layout */}
       <div className="flex-1 overflow-hidden flex">
-        {isPreviewOpen ? (
-          <ResizableSplitPanel
-            leftPanel={
-              <div className="chat-area flex flex-col h-full chat-area-with-preview">
+        <ResizableSplitPanel
+          isRightPanelOpen={isPreviewOpen}
+          defaultLeftWidth={45}
+          minLeftWidth={25}
+          maxLeftWidth={75}
+          leftPanel={
+            <div className={`chat-area flex flex-col h-full ${isPreviewOpen ? 'chat-area-with-preview' : 'chat-area-centered'}`}>
                 <div className="flex flex-col h-full w-full">
                   {existingSchedule && !isScheduleMode && (
                     <div className="max-w-3xl min-[1440px]:max-w-4xl min-[2560px]:max-w-[1400px] mx-auto w-full">
@@ -4078,74 +4081,7 @@ Can you help me fix this query?`
                 </div>
               </div>
             }
-            defaultLeftWidth={45}
-            minLeftWidth={25}
-            maxLeftWidth={75}
-          />
-        ) : (
-          <div className="chat-area flex flex-col h-full chat-area-centered">
-            <div className="flex flex-col h-full w-full">
-              {existingSchedule && !isScheduleMode && (
-                <div className="max-w-3xl min-[1440px]:max-w-4xl min-[2560px]:max-w-[1400px] mx-auto w-full">
-                  <ScheduleBanner
-                    schedule={existingSchedule}
-                    onEdit={handleEnterScheduleMode}
-                    onToggle={handleToggleSchedule}
-                    onDelete={handleDeleteSchedule}
-                    slackChannelName={existingSchedule.slack_channel_id ? slackChannelNames[existingSchedule.slack_channel_id] : undefined}
-                  />
-                </div>
-              )}
-
-              <MessageList
-                notebookId={notebookId}
-                handleCodeInject={handleCodeInject}
-                currentActivity={currentActivity}
-              />
-
-              <div className="max-w-3xl min-[1440px]:max-w-4xl min-[2560px]:max-w-[1400px] mx-auto w-full">
-                <ChatInput
-                  notebookId={notebookId}
-                  datasources={schemaDatasets}
-                  tableNames={tableNames}
-                  getTableColumns={getTableColumns}
-                  onSubmit={async (msg, attachments) => {
-                    if (isScheduleMode) {
-                      setScheduleInstruction(msg)
-                    }
-                    await handleSubmitMessage(msg, attachments)
-                  }}
-                  selectedProvider={selectedProvider}
-                  selectedModel={selectedModel}
-                  handleCancelGeneration={handleCancelGeneration}
-                  selectedDatasourceIds={pendingDatasourceIds}
-                  onDatasourceChange={handleDatasourceChange}
-                  onUploadFiles={handleUploadFilesForChat}
-                  onAddNewConnection={handleAddNewConnection}
-                  agentSelectedDatasourceId={agentSelectedDatasourceId}
-                  onSchedule={isScheduleMode ? undefined : handleEnterScheduleMode}
-                  hasSchedule={!!existingSchedule}
-                  isScheduleMode={isScheduleMode}
-                  onCancelSchedule={handleCancelScheduleMode}
-                  onInputChange={setScheduleInstruction}
-                  grabbedElementText={grabbedElementText}
-                />
-
-                {isScheduleMode && !isNotebookStreaming && messages.length > 0 && (
-                  <ScheduleConfigPanel
-                    config={scheduleConfig}
-                    onConfigChange={setScheduleConfig}
-                    onCancel={handleCancelScheduleMode}
-                    onSave={handleSaveSchedule}
-                    isSaving={createScheduleMutation.isPending || updateScheduleMutation.isPending}
-                    existingScheduleId={existingSchedule?.id}
-                    instruction={scheduleInstruction}
-                  />
-                )}
-              </div>
-            </div>
-          </div>
-        )}
+        />
       </div>
 
       {/* Query Panel Overlay */}

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback, useLayoutEffect } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { AlertTriangle, Database, FolderPlus, Folder, Github, Plug } from 'lucide-react'
 import WelcomeSection from '../components/home/WelcomeSection'
@@ -40,6 +40,24 @@ export default function HomePage() {
   const [activeTab, setActiveTab] = useState<TabType>(() => getInitialTab(isViewer, isSelfHosted))
   const [showCreateFolderModal, setShowCreateFolderModal] = useState(false)
   const [mcpModalOpen, setMcpModalOpen] = useState(false)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const scrollSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleScroll = useCallback(() => {
+    if (scrollSaveTimerRef.current) clearTimeout(scrollSaveTimerRef.current)
+    scrollSaveTimerRef.current = setTimeout(() => {
+      if (scrollContainerRef.current) {
+        sessionStorage.setItem(`home_scroll_${activeTab}`, String(scrollContainerRef.current.scrollTop))
+      }
+    }, 100)
+  }, [activeTab])
+
+  useLayoutEffect(() => {
+    const saved = sessionStorage.getItem(`home_scroll_${activeTab}`)
+    if (saved && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = Number(saved)
+    }
+  }, [activeTab])
   const [mcpDismissed, setMcpDismissed] = useState(() => localStorage.getItem('byaan_mcp_setup_dismissed') === 'true')
 
   useEffect(() => {
@@ -200,7 +218,7 @@ export default function HomePage() {
       </div>
 
       {/* Scrollable Content Section */}
-      <div className="flex-1 overflow-y-auto custom-scrollbar min-h-0">
+      <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto custom-scrollbar min-h-0">
         <div className="w-full px-8 pb-6">
           <div className="max-w-[850px] mx-auto">
             {activeTab === 'dashboards' ? (


### PR DESCRIPTION
## Summary

Fixes two scroll position bugs in the UI:

1. Chat scroll jumps on preview toggle (#57) — when preview panel opened or closed, MessageList was fully unmounted and remounted (conditional rendering), resetting scrollTop to 0. Fixed by always rendering a single ResizableSplitPanel and collapsing the right panel via CSS/inline styles (width: 0, flex: 0) instead of swapping JSX trees. MessageList never unmounts, scroll position is preserved naturally.                                                                                                                          
2. Home page notebook list resets scroll on navigation — navigating to a notebook and back always reset the list to the top. Fixed by saving scroll position to sessionStorage per tab (home_scroll_<tab>) on scroll (debounced 100ms) and restoring via useLayoutEffect before paint. Each tab independently remembers its position; resets on browser close.  
   
## Testing                                                                                                                                                                          
                                                                                                                                                                                 
  - Backend tests run, or not applicable
  - Frontend build/lint run, or not applicable
  - GitHub Actions PR checks are expected to pass, or the failing check is explained below
  - Docs updated, or not applicable                                                                                                                                                
   
## Security And Data Access                                                                                                                                                         
                                                                                                                                                                                 
  - This change does not weaken read-only database guardrails
  - This change does not expose secrets, credentials, private schemas, or sensitive data
  - This change does not add a privileged workflow path for untrusted pull request code                                                                                            
  - New database/MCP/auth behavior is documented
                                                                                                                                                                                   
## Notes                                                                                                                                                                          

  - ResizableSplitPanel now accepts isRightPanelOpen?: boolean — when false, the divider is hidden and the right panel collapses to width: 0 with a 300ms transition matching the  
  existing animation timing.
  - User-dragged panel width is preserved across open/close cycles (no reset to defaultLeftWidth).                                                                                 
  - Scroll persistence uses sessionStorage (not localStorage) — intentionally clears when the browser closes. 