### PR TITLE
Add Opus 4.8 model

### DIFF
--- a/client/src/components/ModelSelector.tsx
+++ b/client/src/components/ModelSelector.tsx
@@ -68,10 +68,10 @@ function formatModelName(modelPath: string): string {
 
   // Format specific model names for better readability
   const formatMap: Record<string, string> = {
+    "claude-opus-4.8": "Claude Opus 4.8",
+    "claude-opus-4-8": "Claude Opus 4.8",
     "claude-opus-4.7": "Claude Opus 4.7",
     "claude-opus-4-7": "Claude Opus 4.7",
-    "claude-opus-4.6": "Claude Opus 4.6",
-    "claude-opus-4-6": "Claude Opus 4.6",
     "claude-sonnet-4.6": "Claude Sonnet 4.6",
     "claude-sonnet-4-6": "Claude Sonnet 4.6",
     "claude-sonnet-4.5": "Claude Sonnet 4.5",

--- a/client/src/utils/connectionValidator.ts
+++ b/client/src/utils/connectionValidator.ts
@@ -152,9 +152,9 @@ class ConnectionValidator {
 
     // Preferred models in order
     const preferredModels = [
+      'anthropic/claude-opus-4-8',
       'anthropic/claude-opus-4-7',
       'anthropic/claude-sonnet-4-6',
-      'anthropic/claude-opus-4-6',
     ]
 
     // First, try to find a connection with a preferred model

--- a/server/constants/models.py
+++ b/server/constants/models.py
@@ -4,15 +4,15 @@ OPENAI_MODELS = [
 ]
 
 ANTHROPIC_MODELS = [
+    "anthropic/claude-opus-4-8",
     "anthropic/claude-opus-4-7",
     "anthropic/claude-sonnet-4-6",
-    "anthropic/claude-opus-4-6",
 ]
 
 CLAUDE_CODE_MODELS = [
+    "claude_code/claude-opus-4.8",
     "claude_code/claude-opus-4.7",
     "claude_code/claude-sonnet-4.6",
-    "claude_code/claude-opus-4.6",
 ]
 
 OPENROUTER_SPECIFIC_MODELS = [

--- a/server/utils/model_limits.py
+++ b/server/utils/model_limits.py
@@ -8,10 +8,10 @@ MODEL_CONTEXT_LIMITS: dict[str, int] = {
     "gpt-5": 128_000,
     "gpt-4o": 128_000,
     # Anthropic
+    "claude-opus-4-8": 1_000_000,
+    "claude-opus-4.8": 1_000_000,
     "claude-opus-4-7": 1_000_000,
     "claude-opus-4.7": 1_000_000,
-    "claude-opus-4-6": 1_000_000,
-    "claude-opus-4.6": 1_000_000,
     "claude-sonnet-4-6": 200_000,
     "claude-sonnet-4.6": 200_000,
     "claude-3-opus": 200_000,


### PR DESCRIPTION
## Summary

Added opus 4.8 model and removed opus 4.6
## Testing

- [x] Backend tests run, or not applicable
- [x] Frontend build/lint run, or not applicable
- [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
- [x] Docs updated, or not applicable

## Security And Data Access

- [x] This change does not weaken read-only database guardrails
- [x] This change does not expose secrets, credentials, private schemas, or sensitive data
- [x] This change does not add a privileged workflow path for untrusted pull request code
- [x] New database/MCP/auth behavior is documented

