### PR TITLE
fix: bundle litellm data files in backend.spec

### DIFF
--- a/backend.spec
+++ b/backend.spec
@@ -13,7 +13,7 @@
 # - Test the frozen executable to ensure files are accessible
 # - Check server/utils/migrations.py for path resolution logic
 
-from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 
 datas_with_metadata = [
     # Application-specific data files
@@ -29,6 +29,9 @@ datas_with_metadata = [
 # Add package metadata for packages that use importlib.metadata at runtime
 datas_with_metadata += copy_metadata('duckdb')
 datas_with_metadata += copy_metadata('fastmcp')
+
+# litellm reads model_prices_and_context_window_backup.json at import time; bundle data files
+datas_with_metadata += collect_data_files('litellm')
 
 a = Analysis(
     ['server/main.py'],


### PR DESCRIPTION
## Summary

Tells PyInstaller to bundle litellm's data files (incl. model_prices_and_context_window_backup.json) into frozen app. litellm 1.83.x  reads that JSON at import → file was missing from bundle → boot crash. Now bundled → boots.

## Testing

- [x] Backend tests run, or not applicable
- [x] Frontend build/lint run, or not applicable
- [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
- [x] Docs updated, or not applicable

## Security And Data Access

- [x] This change does not weaken read-only database guardrails
- [x] This change does not expose secrets, credentials, private schemas, or sensitive data
- [x] This change does not add a privileged workflow path for untrusted pull request code
- [x] New database/MCP/auth behavior is documented
