### PR TITLE
Fixed the Tauri build error

### DIFF
--- a/backend.spec
+++ b/backend.spec
@@ -13,7 +13,7 @@
 # - Test the frozen executable to ensure files are accessible
 # - Check server/utils/migrations.py for path resolution logic
 
-from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 
 datas_with_metadata = [
     # Application-specific data files


### PR DESCRIPTION

## Summary

Fixed the'name 'collect_data_files' is not defined' error for Tauri build error

## Testing

- [x] Backend tests run, or not applicable
- [x] Frontend build/lint run, or not applicable
- [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
- [x] Docs updated, or not applicable

## Security And Data Access

- [x] This change does not weaken read-only database guardrails
- [x] This change does not expose secrets, credentials, private schemas, or sensitive data
- [x] This change does not add a privileged workflow path for untrusted pull request code
- [x] New database/MCP/auth behavior is documented