### PR TITLE
Feat/databricks connector

### DIFF
--- a/client/src/components/DatabaseConnectionDialog.tsx
+++ b/client/src/components/DatabaseConnectionDialog.tsx
@@ -10,6 +10,7 @@ import { ApiService } from '../services/api'
 import type { ConnectionType, Datasource, DatabricksCatalog, DatabricksOAuthTokens, DatabricksWarehouse } from '../services/api'
 import { DatabricksOAuthSettings } from './databricks/DatabricksOAuthSettings'
 import { useAppConfig } from '../hooks/useAppConfig'
+import { openExternalUrl } from '../lib/tauri-api'
 
 type DatabricksPair = { catalog: string; schema: string | null }
 const pairKey = (p: DatabricksPair) => `${p.catalog}::${p.schema ?? '*'}`
@@ -404,7 +405,7 @@ export function DatabaseConnectionDialog({
     try {
       const { auth_url, state } = await ApiService.startDatabricksOAuth(connectionConfig.serverHostname.trim())
       setOauthState(state)
-      window.open(auth_url, '_blank', 'noopener,noreferrer')
+      await openExternalUrl(auth_url)
 
       const deadline = Date.now() + 5 * 60 * 1000
       while (Date.now() < deadline) {

--- a/client/src/components/DatabaseConnectionDialog.tsx
+++ b/client/src/components/DatabaseConnectionDialog.tsx
@@ -9,6 +9,7 @@ import { Loader2, Upload, FileText, X, Link as LinkIcon, Leaf, Cylinder, Server,
 import { ApiService } from '../services/api'
 import type { ConnectionType, Datasource, DatabricksCatalog, DatabricksOAuthTokens, DatabricksWarehouse } from '../services/api'
 import { DatabricksOAuthSettings } from './databricks/DatabricksOAuthSettings'
+import { useAppConfig } from '../hooks/useAppConfig'
 
 type DatabricksPair = { catalog: string; schema: string | null }
 const pairKey = (p: DatabricksPair) => `${p.catalog}::${p.schema ?? '*'}`
@@ -70,6 +71,7 @@ export function DatabaseConnectionDialog({
   multiSelect = false,
   onDatabricksConnectionsCreated,
 }: DatabaseConnectionDialogProps) {
+  const { isSelfHosted } = useAppConfig()
   // Handle dialog close - only close if in select mode or no previous connections
   const handleClose = () => {
     if (isLoading) return
@@ -131,7 +133,9 @@ export function DatabaseConnectionDialog({
   } | null>(null)
   const [databricksCatalogFilter, setDatabricksCatalogFilter] = useState('')
 
-  const [databricksOAuthConfigured, setDatabricksOAuthConfigured] = useState<boolean>(false)
+  const [databricksOAuthConfigured, setDatabricksOAuthConfigured] = useState<boolean>(!isSelfHosted)
+  const [databricksOAuthCanConfigure, setDatabricksOAuthCanConfigure] = useState<boolean>(false)
+  const [showManageDatabricksOAuth, setShowManageDatabricksOAuth] = useState<boolean>(false)
   const [oauthTokens, setOauthTokens] = useState<DatabricksOAuthTokens | null>(null)
   const [oauthState, setOauthState] = useState<string | null>(null)
   const [oauthSigningIn, setOauthSigningIn] = useState(false)
@@ -140,12 +144,24 @@ export function DatabaseConnectionDialog({
   const [selectedWarehouseId, setSelectedWarehouseId] = useState<string | null>(null)
   const [loadingWarehouses, setLoadingWarehouses] = useState(false)
 
-  useEffect(() => {
-    if (!open) return
+  const refreshDatabricksAuthStatus = () => {
     ApiService.getDatabricksAuthStatus()
-      .then(s => setDatabricksOAuthConfigured(!!s.configured))
-      .catch(() => setDatabricksOAuthConfigured(false))
+      .then(s => {
+        setDatabricksOAuthConfigured(!!s.configured)
+        setDatabricksOAuthCanConfigure(!!s.can_configure)
+      })
+      .catch(() => {
+        setDatabricksOAuthConfigured(!isSelfHosted)
+        setDatabricksOAuthCanConfigure(false)
+      })
+  }
+
+  useEffect(() => {
+    if (open) refreshDatabricksAuthStatus()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
+
+  const databricksTileVisible = !isSelfHosted || databricksOAuthConfigured || databricksOAuthCanConfigure
 
   // Helper functions
   const formatDbType = (type: string): string => {
@@ -809,19 +825,21 @@ export function DatabaseConnectionDialog({
                   <span className="text-sm font-medium">DynamoDB</span>
                 </button>
 
-                {/* Databricks */}
-                <button
-                  onClick={() => handleTypeChange('databricks')}
-                  disabled={isLoading}
-                  className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md transition-all text-left ${
-                    selectedType === 'databricks'
-                      ? 'bg-brand-orange/10 text-white border-l-3 border-brand-orange'
-                      : 'text-gray-400 hover:text-white hover:bg-[#2a2a2a]'
-                  } ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
-                >
-                  <Database className="w-5 h-5 flex-shrink-0 text-red-400" />
-                  <span className="text-sm font-medium">Databricks</span>
-                </button>
+                {/* Databricks: hidden for non-admin team members until admin configures OAuth */}
+                {databricksTileVisible && (
+                  <button
+                    onClick={() => handleTypeChange('databricks')}
+                    disabled={isLoading}
+                    className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md transition-all text-left ${
+                      selectedType === 'databricks'
+                        ? 'bg-brand-orange/10 text-white border-l-3 border-brand-orange'
+                        : 'text-gray-400 hover:text-white hover:bg-[#2a2a2a]'
+                    } ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  >
+                    <Database className="w-5 h-5 flex-shrink-0 text-red-400" />
+                    <span className="text-sm font-medium">Databricks</span>
+                  </button>
+                )}
               </div>
             </div>
 
@@ -1154,24 +1172,40 @@ export function DatabaseConnectionDialog({
                     </div>
                   )}
 
-                  {selectedType === 'databricks' && databricksStep === 1 && !databricksOAuthConfigured && (
+                  {selectedType === 'databricks' && databricksStep === 1 && isSelfHosted && !databricksOAuthConfigured && !databricksOAuthCanConfigure && (
+                    <div className="bg-amber-900/20 border border-amber-700/40 rounded-md p-3 text-sm text-amber-200">
+                      Databricks OAuth isn't configured for this workspace. Ask your admin to register a custom OAuth app in the Databricks Account Console and add the credentials in Settings.
+                    </div>
+                  )}
+
+                  {selectedType === 'databricks' && databricksStep === 1 && isSelfHosted && !databricksOAuthConfigured && databricksOAuthCanConfigure && (
                     <div className="space-y-3">
                       <div className="bg-amber-900/20 border border-amber-700/40 rounded-md p-3 text-sm text-amber-200">
-                        Databricks OAuth isn't configured yet. An admin needs to register Byaan as a custom OAuth app in the Databricks Account Console and paste the credentials below. After saving, every user can sign in with Databricks.
+                        Databricks OAuth isn't configured yet. Register Byaan as a custom OAuth app in the Databricks Account Console and paste the credentials below. After saving, every user can sign in with Databricks.
                       </div>
-                      <DatabricksOAuthSettings onConfigChanged={() => {
-                        ApiService.getDatabricksAuthStatus()
-                          .then(s => setDatabricksOAuthConfigured(!!s.configured))
-                          .catch(() => {})
-                      }} />
+                      <DatabricksOAuthSettings onConfigChanged={refreshDatabricksAuthStatus} />
                     </div>
                   )}
 
                   {selectedType === 'databricks' && databricksStep === 1 && databricksOAuthConfigured && (
                     <div className="space-y-4">
-                      <p className="text-xs text-gray-400">
-                        Sign in with your Databricks account. Byaan will list available warehouses, then catalogs and schemas to pick from.
-                      </p>
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="text-xs text-gray-400 flex-1">
+                          Sign in with your Databricks account. Byaan will list available warehouses, then catalogs and schemas to pick from.
+                        </p>
+                        {databricksOAuthCanConfigure && (
+                          <button
+                            type="button"
+                            onClick={() => setShowManageDatabricksOAuth(v => !v)}
+                            className="text-xs text-brand-orange hover:underline whitespace-nowrap"
+                          >
+                            {showManageDatabricksOAuth ? 'Hide OAuth settings' : 'Manage OAuth credentials'}
+                          </button>
+                        )}
+                      </div>
+                      {showManageDatabricksOAuth && databricksOAuthCanConfigure && (
+                        <DatabricksOAuthSettings onConfigChanged={refreshDatabricksAuthStatus} />
+                      )}
                       <div>
                         <Label htmlFor="serverHostname" className="text-white">Workspace URL <span className="text-red-400">*</span></Label>
                         <Input

--- a/client/src/components/DatabaseConnectionDialog.tsx
+++ b/client/src/components/DatabaseConnectionDialog.tsx
@@ -7,7 +7,8 @@ import { Label } from './ui/label'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog'
 import { Loader2, Upload, FileText, X, Link as LinkIcon, Leaf, Cylinder, Server, HardDrive, Database, Cloud, ChevronDown, ChevronRight, CheckCircle2, AlertCircle, Search } from 'lucide-react'
 import { ApiService } from '../services/api'
-import type { ConnectionType, Datasource, DatabricksCatalog } from '../services/api'
+import type { ConnectionType, Datasource, DatabricksCatalog, DatabricksOAuthTokens, DatabricksWarehouse } from '../services/api'
+import { DatabricksOAuthSettings } from './databricks/DatabricksOAuthSettings'
 
 type DatabricksPair = { catalog: string; schema: string | null }
 const pairKey = (p: DatabricksPair) => `${p.catalog}::${p.schema ?? '*'}`
@@ -115,7 +116,7 @@ export function DatabaseConnectionDialog({
   // URL upload state
   const [uploadURLs, setUploadURLs] = useState<string[]>([''])
 
-  // Databricks 2-step wizard state
+  // Databricks 3-step wizard state (Sign in → Pick warehouse → Pick catalogs/schemas)
   const [databricksStep, setDatabricksStep] = useState<1 | 2>(1)
   const [discoveredCatalogs, setDiscoveredCatalogs] = useState<DatabricksCatalog[] | null>(null)
   const [discovering, setDiscovering] = useState(false)
@@ -129,6 +130,22 @@ export function DatabaseConnectionDialog({
     failures: Array<{ pair: DatabricksPair; error: string }>
   } | null>(null)
   const [databricksCatalogFilter, setDatabricksCatalogFilter] = useState('')
+
+  const [databricksOAuthConfigured, setDatabricksOAuthConfigured] = useState<boolean>(false)
+  const [oauthTokens, setOauthTokens] = useState<DatabricksOAuthTokens | null>(null)
+  const [oauthState, setOauthState] = useState<string | null>(null)
+  const [oauthSigningIn, setOauthSigningIn] = useState(false)
+  const [oauthError, setOauthError] = useState<string | null>(null)
+  const [warehouses, setWarehouses] = useState<DatabricksWarehouse[] | null>(null)
+  const [selectedWarehouseId, setSelectedWarehouseId] = useState<string | null>(null)
+  const [loadingWarehouses, setLoadingWarehouses] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    ApiService.getDatabricksAuthStatus()
+      .then(s => setDatabricksOAuthConfigured(!!s.configured))
+      .catch(() => setDatabricksOAuthConfigured(false))
+  }, [open])
 
   // Helper functions
   const formatDbType = (type: string): string => {
@@ -202,12 +219,10 @@ export function DatabaseConnectionDialog({
     }
 
     if (selectedType === 'databricks') {
-      const credsOk =
-        connectionConfig.serverHostname.trim().length > 0 &&
-        connectionConfig.httpPath.trim().length > 0 &&
-        connectionConfig.accessToken.trim().length > 0
-      if (databricksStep === 1) return credsOk
-      return credsOk && selectedPairs.length > 0
+      const signedIn = !!oauthTokens?.access_token
+      const warehousePicked = !!selectedWarehouseId
+      if (databricksStep === 1) return signedIn && warehousePicked
+      return signedIn && warehousePicked && selectedPairs.length > 0
     }
 
     // PostgreSQL, MySQL, MSSQL
@@ -218,10 +233,17 @@ export function DatabaseConnectionDialog({
       connectionConfig.user.trim().length > 0 &&
       connectionConfig.password.trim().length > 0
     )
-  }, [selectedType, connectionConfig, uploadFileType, uploadFiles, uploadURLs, databricksStep, selectedPairs])
+  }, [selectedType, connectionConfig, uploadFileType, uploadFiles, uploadURLs, databricksStep, selectedPairs, oauthTokens, selectedWarehouseId])
 
   const resetDatabricksWizard = () => {
     setDatabricksStep(1)
+    setOauthTokens(null)
+    setOauthState(null)
+    setOauthError(null)
+    setOauthSigningIn(false)
+    setWarehouses(null)
+    setSelectedWarehouseId(null)
+    setLoadingWarehouses(false)
     setDiscoveredCatalogs(null)
     setDiscovering(false)
     setDiscoverError(null)
@@ -356,16 +378,68 @@ export function DatabaseConnectionDialog({
   const isPairSelected = (pair: DatabricksPair) =>
     selectedPairs.some(p => pairKey(p) === pairKey(pair))
 
+  const handleDatabricksSignIn = async () => {
+    if (!connectionConfig.serverHostname.trim()) {
+      setOauthError('Enter your Databricks workspace URL first')
+      return
+    }
+    setOauthError(null)
+    setOauthSigningIn(true)
+    try {
+      const { auth_url, state } = await ApiService.startDatabricksOAuth(connectionConfig.serverHostname.trim())
+      setOauthState(state)
+      window.open(auth_url, '_blank', 'noopener,noreferrer')
+
+      const deadline = Date.now() + 5 * 60 * 1000
+      while (Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 2000))
+        try {
+          const res = await ApiService.pollDatabricksOAuthResult(state)
+          if (res.status === 'success' && res.tokens) {
+            setOauthTokens(res.tokens)
+            setConnectionConfig(prev => ({ ...prev, serverHostname: res.tokens!.server_hostname }))
+            await loadWarehouses(res.tokens.server_hostname, res.tokens.access_token)
+            return
+          }
+        } catch (err: any) {
+          console.warn('OAuth poll failed:', err?.message)
+        }
+      }
+      setOauthError('Sign-in timed out. Please try again.')
+    } catch (err: any) {
+      setOauthError(err?.message || 'Failed to start Databricks sign-in')
+    } finally {
+      setOauthSigningIn(false)
+    }
+  }
+
+  const loadWarehouses = async (host: string, token: string) => {
+    setLoadingWarehouses(true)
+    try {
+      const ws = await ApiService.listDatabricksWarehouses(host, token)
+      setWarehouses(ws)
+      if (ws.length === 1) setSelectedWarehouseId(ws[0].id)
+    } catch (err: any) {
+      setOauthError(err?.message || 'Failed to list warehouses')
+    } finally {
+      setLoadingWarehouses(false)
+    }
+  }
+
   const handleDatabricksDiscover = async () => {
+    if (!oauthTokens || !selectedWarehouseId) return
+    const warehouse = warehouses?.find(w => w.id === selectedWarehouseId)
+    if (!warehouse) return
     setDiscoverError(null)
     setDiscovering(true)
     try {
       const res = await ApiService.discoverDatabricks({
-        server_hostname: connectionConfig.serverHostname,
-        http_path: connectionConfig.httpPath,
-        access_token: connectionConfig.accessToken,
+        server_hostname: oauthTokens.server_hostname,
+        access_token: oauthTokens.access_token,
+        http_path: warehouse.http_path,
       })
       setDiscoveredCatalogs(res.catalogs)
+      setConnectionConfig(prev => ({ ...prev, httpPath: warehouse.http_path }))
       setDatabricksStep(2)
     } catch (err: any) {
       setDiscoverError(err?.message || 'Failed to discover Databricks catalogs')
@@ -386,15 +460,22 @@ export function DatabaseConnectionDialog({
         const prefix = databricksNamePrefix.trim()
         const suffix = `${pair.catalog}.${pair.schema ?? '*'}`
         const name = prefix ? `${prefix} · ${suffix}` : ''
+        if (!oauthTokens) throw new Error('Not signed in to Databricks')
         await ApiService.createConnection({
           type: 'databricks',
           name: name || undefined,
           connection_obj: {
-            server_hostname: connectionConfig.serverHostname,
+            server_hostname: oauthTokens.server_hostname,
             http_path: connectionConfig.httpPath,
-            access_token: connectionConfig.accessToken,
             catalog: pair.catalog,
             schema: pair.schema ?? undefined,
+            oauth: {
+              access_token: oauthTokens.access_token,
+              refresh_token: oauthTokens.refresh_token,
+              expires_at: oauthTokens.expires_at,
+              scope: oauthTokens.scope,
+              server_hostname: oauthTokens.server_hostname,
+            },
           },
         })
       } catch (err: any) {
@@ -452,12 +533,19 @@ export function DatabaseConnectionDialog({
           query_mode: connectionConfig.queryMode,
         }
       } else if (selectedType === 'databricks') {
+        if (!oauthTokens) throw new Error('Sign in to Databricks first')
         connectionObj = {
-          server_hostname: connectionConfig.serverHostname,
+          server_hostname: oauthTokens.server_hostname,
           http_path: connectionConfig.httpPath,
-          access_token: connectionConfig.accessToken,
           catalog: connectionConfig.catalog || undefined,
           schema: connectionConfig.databricksSchema || undefined,
+          oauth: {
+            access_token: oauthTokens.access_token,
+            refresh_token: oauthTokens.refresh_token,
+            expires_at: oauthTokens.expires_at,
+            scope: oauthTokens.scope,
+            server_hostname: oauthTokens.server_hostname,
+          },
         }
       } else {
         connectionObj = {
@@ -1066,48 +1154,101 @@ export function DatabaseConnectionDialog({
                     </div>
                   )}
 
-                  {selectedType === 'databricks' && databricksStep === 1 && (
+                  {selectedType === 'databricks' && databricksStep === 1 && !databricksOAuthConfigured && (
+                    <div className="space-y-3">
+                      <div className="bg-amber-900/20 border border-amber-700/40 rounded-md p-3 text-sm text-amber-200">
+                        Databricks OAuth isn't configured yet. An admin needs to register Byaan as a custom OAuth app in the Databricks Account Console and paste the credentials below. After saving, every user can sign in with Databricks.
+                      </div>
+                      <DatabricksOAuthSettings onConfigChanged={() => {
+                        ApiService.getDatabricksAuthStatus()
+                          .then(s => setDatabricksOAuthConfigured(!!s.configured))
+                          .catch(() => {})
+                      }} />
+                    </div>
+                  )}
+
+                  {selectedType === 'databricks' && databricksStep === 1 && databricksOAuthConfigured && (
                     <div className="space-y-4">
-                      <p className="text-xs text-gray-400">Enter your Databricks workspace credentials. Next, we'll list available catalogs and schemas to pick from.</p>
+                      <p className="text-xs text-gray-400">
+                        Sign in with your Databricks account. Byaan will list available warehouses, then catalogs and schemas to pick from.
+                      </p>
                       <div>
-                        <Label htmlFor="serverHostname" className="text-white">Server Hostname <span className="text-red-400">*</span></Label>
+                        <Label htmlFor="serverHostname" className="text-white">Workspace URL <span className="text-red-400">*</span></Label>
                         <Input
                           id="serverHostname"
                           placeholder="adb-1234.azuredatabricks.net"
                           value={connectionConfig.serverHostname}
                           onChange={(e) => setConnectionConfig(prev => ({ ...prev, serverHostname: e.target.value }))}
-                          disabled={isLoading || discovering}
+                          disabled={isLoading || oauthSigningIn || !!oauthTokens}
                           className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
                         />
+                        <p className="text-xs text-gray-400 mt-1">No scheme — just the host, e.g. <code>adb-1234.azuredatabricks.net</code>.</p>
                       </div>
-                      <div>
-                        <Label htmlFor="httpPath" className="text-white">HTTP Path <span className="text-red-400">*</span></Label>
-                        <Input
-                          id="httpPath"
-                          placeholder="/sql/1.0/warehouses/abc123"
-                          value={connectionConfig.httpPath}
-                          onChange={(e) => setConnectionConfig(prev => ({ ...prev, httpPath: e.target.value }))}
-                          disabled={isLoading || discovering}
-                          className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
-                        />
-                        <p className="text-xs text-gray-400 mt-1">Find in Databricks: SQL Warehouse → Connection Details → HTTP Path</p>
-                      </div>
-                      <div>
-                        <Label htmlFor="accessToken" className="text-white">Access Token (PAT) <span className="text-red-400">*</span></Label>
-                        <Input
-                          id="accessToken"
-                          type="password"
-                          placeholder="dapi..."
-                          value={connectionConfig.accessToken}
-                          onChange={(e) => setConnectionConfig(prev => ({ ...prev, accessToken: e.target.value }))}
-                          disabled={isLoading || discovering}
-                          className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
-                        />
-                      </div>
-                      {discoverError && (
+
+                      {!oauthTokens ? (
+                        <Button
+                          onClick={handleDatabricksSignIn}
+                          disabled={isLoading || oauthSigningIn || !connectionConfig.serverHostname.trim()}
+                          className="w-full bg-brand-orange hover:bg-brand-orange/90"
+                        >
+                          {oauthSigningIn ? (
+                            <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Waiting for sign-in…</>
+                          ) : (
+                            <>Sign in with Databricks</>
+                          )}
+                        </Button>
+                      ) : (
+                        <div className="flex items-start gap-2 bg-green-900/20 border border-green-700/50 rounded-md p-3 text-sm text-green-200">
+                          <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                          <div className="flex-1">
+                            <div className="font-medium">Signed in to {oauthTokens.server_hostname}</div>
+                            <button
+                              type="button"
+                              onClick={resetDatabricksWizard}
+                              className="text-xs text-green-300/80 hover:underline mt-0.5"
+                            >
+                              Sign out
+                            </button>
+                          </div>
+                        </div>
+                      )}
+
+                      {oauthTokens && (
+                        <div>
+                          <Label className="text-white">SQL Warehouse <span className="text-red-400">*</span></Label>
+                          {loadingWarehouses ? (
+                            <div className="mt-2 flex items-center gap-2 text-sm text-gray-400">
+                              <Loader2 className="w-4 h-4 animate-spin" /> Loading warehouses…
+                            </div>
+                          ) : warehouses && warehouses.length > 0 ? (
+                            <div className="mt-1 border border-[#444444] rounded-md divide-y divide-[#3a3a3a] max-h-[220px] overflow-y-auto custom-scrollbar">
+                              {warehouses.map(w => (
+                                <button
+                                  key={w.id}
+                                  type="button"
+                                  onClick={() => setSelectedWarehouseId(w.id)}
+                                  className={`w-full text-left px-3 py-2 text-sm hover:bg-[#2a2a2a] ${selectedWarehouseId === w.id ? 'bg-[#2a2a2a] border-l-2 border-brand-orange' : ''}`}
+                                >
+                                  <div className="flex items-center justify-between">
+                                    <span className="text-white font-medium">{w.name || w.id}</span>
+                                    <span className="text-xs text-gray-400">{w.state}{w.size ? ` · ${w.size}` : ''}</span>
+                                  </div>
+                                  <div className="text-xs text-gray-500 font-mono mt-0.5">{w.http_path}</div>
+                                </button>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="mt-1 p-3 text-sm text-gray-400 border border-[#444444] rounded-md">
+                              No SQL warehouses visible to this account.
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                      {(oauthError || discoverError) && (
                         <div className="flex items-start gap-2 bg-red-900/20 border border-red-700/50 rounded-md p-3 text-sm text-red-200">
                           <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-                          <span>{discoverError}</span>
+                          <span>{oauthError || discoverError}</span>
                         </div>
                       )}
                     </div>

--- a/client/src/components/DatabaseConnectionDialog.tsx
+++ b/client/src/components/DatabaseConnectionDialog.tsx
@@ -138,7 +138,7 @@ export function DatabaseConnectionDialog({
   const [databricksOAuthCanConfigure, setDatabricksOAuthCanConfigure] = useState<boolean>(false)
   const [showManageDatabricksOAuth, setShowManageDatabricksOAuth] = useState<boolean>(false)
   const [oauthTokens, setOauthTokens] = useState<DatabricksOAuthTokens | null>(null)
-  const [oauthState, setOauthState] = useState<string | null>(null)
+  const [, setOauthState] = useState<string | null>(null)
   const [oauthSigningIn, setOauthSigningIn] = useState(false)
   const [oauthError, setOauthError] = useState<string | null>(null)
   const [warehouses, setWarehouses] = useState<DatabricksWarehouse[] | null>(null)

--- a/client/src/components/databricks/DatabricksOAuthSettings.tsx
+++ b/client/src/components/databricks/DatabricksOAuthSettings.tsx
@@ -22,23 +22,17 @@ function SetupStepsAccordion({ callbackUrl }: { callbackUrl: string }) {
           <li className="flex items-start gap-2">
             <span className="text-gray-500 mt-0.5">•</span>
             <span>
-              Open the Databricks{' '}
+              Open{' '}
               <a
-                href="https://accounts.cloud.databricks.com/"
+                href="https://accounts.cloud.databricks.com/settings/app-integrations"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-brand-orange hover:underline inline-flex items-center gap-1"
               >
-                Account Console
+                Databricks App integrations
                 <ExternalLink className="w-3 h-3" />
               </a>
-              {' '}as an account admin.
-            </span>
-          </li>
-          <li className="flex items-start gap-2">
-            <span className="text-gray-500 mt-0.5">•</span>
-            <span>
-              Go to <strong className="text-gray-300">Settings → App connections → Add connection</strong>.
+              {' '}as an account admin and click <strong className="text-gray-300">Add connection</strong>. One-time setup — all your users sign in through this app.
             </span>
           </li>
           <li className="flex items-start gap-2">

--- a/client/src/components/databricks/DatabricksOAuthSettings.tsx
+++ b/client/src/components/databricks/DatabricksOAuthSettings.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from 'react'
+import { Button } from '../ui/button'
+import { Card } from '../ui/card'
+import { Input } from '../ui/input'
+import { Switch } from '../ui/switch'
+import { Loader2, Trash2, Settings2, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
+import { ApiService } from '../../services/api'
+
+interface DatabricksOAuthSettingsProps {
+  onConfigChanged?: () => void
+}
+
+function SetupStepsAccordion({ callbackUrl }: { callbackUrl: string }) {
+  const [expandedStep, setExpandedStep] = useState(0)
+
+  const steps = [
+    {
+      id: 1,
+      title: 'Register Byaan as a custom OAuth app integration',
+      content: (
+        <ul className="space-y-2 text-sm text-gray-400">
+          <li className="flex items-start gap-2">
+            <span className="text-gray-500 mt-0.5">•</span>
+            <span>
+              Open the Databricks{' '}
+              <a
+                href="https://accounts.cloud.databricks.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-brand-orange hover:underline inline-flex items-center gap-1"
+              >
+                Account Console
+                <ExternalLink className="w-3 h-3" />
+              </a>
+              {' '}as an account admin.
+            </span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-gray-500 mt-0.5">•</span>
+            <span>
+              Go to <strong className="text-gray-300">Settings → App connections → Add connection</strong>.
+            </span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-gray-500 mt-0.5">•</span>
+            <span>
+              Name it <strong className="text-gray-300">"Byaan"</strong>. Set the redirect URL to:
+            </span>
+          </li>
+          <li className="ml-4">
+            <code className="text-xs text-brand-orange bg-gray-800 px-2 py-1 rounded block break-all">
+              {callbackUrl}
+            </code>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-gray-500 mt-0.5">•</span>
+            <span>
+              Scopes: <code className="text-gray-300">sql</code>, <code className="text-gray-300">offline_access</code>, <code className="text-gray-300">all-apis</code>.
+            </span>
+          </li>
+        </ul>
+      ),
+    },
+    {
+      id: 2,
+      title: 'Copy the Client ID and Client Secret',
+      content: (
+        <ul className="space-y-2 text-sm text-gray-400">
+          <li className="flex items-start gap-2">
+            <span className="text-gray-500 mt-0.5">•</span>
+            <span>Copy the generated <strong className="text-gray-300">Client ID</strong> and <strong className="text-gray-300">Client Secret</strong>.</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-gray-500 mt-0.5">•</span>
+            <span>Paste both below — they are stored encrypted at rest.</span>
+          </li>
+        </ul>
+      ),
+    },
+  ]
+
+  return (
+    <div className="bg-[#0d0d0d] rounded-lg border border-gray-800 overflow-hidden mb-4">
+      <h3 className="text-sm font-medium text-white px-4 py-3 border-b border-gray-800">Setup Guide</h3>
+      <div className="divide-y divide-gray-800">
+        {steps.map((step) => (
+          <div key={step.id}>
+            <button
+              type="button"
+              onClick={() => setExpandedStep(expandedStep === step.id ? 0 : step.id)}
+              className="w-full px-4 py-3 flex items-center gap-3 text-left hover:bg-gray-800/50 transition-colors"
+            >
+              {expandedStep === step.id ? (
+                <ChevronDown className="w-4 h-4 text-brand-orange flex-shrink-0" />
+              ) : (
+                <ChevronRight className="w-4 h-4 text-gray-500 flex-shrink-0" />
+              )}
+              <span className="text-brand-orange font-mono text-sm w-4">{step.id}.</span>
+              <span className={`text-sm ${expandedStep === step.id ? 'text-white' : 'text-gray-400'}`}>
+                {step.title}
+              </span>
+            </button>
+            {expandedStep === step.id && <div className="px-4 pb-4 pl-14">{step.content}</div>}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function DatabricksOAuthSettings({ onConfigChanged }: DatabricksOAuthSettingsProps) {
+  const [clientId, setClientId] = useState('')
+  const [clientSecret, setClientSecret] = useState('')
+  const [secretConfigured, setSecretConfigured] = useState(false)
+  const [redirectUri, setRedirectUri] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [removing, setRemoving] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
+  useEffect(() => {
+    ApiService.getDatabricksOAuthSettings()
+      .then((data) => {
+        setClientId(data.client_id)
+        setSecretConfigured(data.client_secret_configured)
+        setRedirectUri(data.redirect_uri)
+        if (data.client_secret_configured) setExpanded(true)
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleSave = async () => {
+    if (!clientId.trim() || !clientSecret.trim()) return
+    setSaving(true)
+    try {
+      await ApiService.saveDatabricksOAuthSettings(clientId.trim(), clientSecret.trim())
+      setSecretConfigured(true)
+      setClientSecret('')
+      onConfigChanged?.()
+    } catch (err) {
+      console.error('Failed to save Databricks OAuth config:', err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleRemove = async () => {
+    setRemoving(true)
+    try {
+      await ApiService.deleteDatabricksOAuthSettings()
+      setClientId('')
+      setClientSecret('')
+      setSecretConfigured(false)
+      setExpanded(false)
+      onConfigChanged?.()
+    } catch (err) {
+      console.error('Failed to remove Databricks OAuth config:', err)
+    } finally {
+      setRemoving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card className="bg-[#1a1a1a] border-gray-800 p-6 mb-8">
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="w-5 h-5 animate-spin text-gray-400" />
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="bg-[#1a1a1a] border-gray-800 p-6 mb-8">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Settings2 className="w-5 h-5 text-gray-400" />
+          <div>
+            <h3 className="text-white font-medium">Enable Databricks OAuth</h3>
+            <p className="text-xs text-gray-500">
+              Required so users can sign in to Databricks instead of pasting personal access tokens.
+            </p>
+          </div>
+        </div>
+        <Switch checked={expanded} onCheckedChange={setExpanded} />
+      </div>
+
+      {expanded && (
+        <div className="mt-5 pt-5 border-t border-gray-800">
+          <SetupStepsAccordion callbackUrl={redirectUri} />
+
+          <div className="space-y-3">
+            <div>
+              <label className="text-xs text-gray-400 mb-1 block">Client ID</label>
+              <Input
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+                placeholder="00000000-0000-0000-0000-000000000000"
+                className="bg-[#111] border-gray-700 text-white text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="text-xs text-gray-400 mb-1 block">
+                Client Secret {secretConfigured && <span className="text-green-400 ml-1">(configured)</span>}
+              </label>
+              <Input
+                type="password"
+                value={clientSecret}
+                onChange={(e) => setClientSecret(e.target.value)}
+                placeholder={secretConfigured ? '••••••••••••••••' : 'Enter client secret'}
+                className="bg-[#111] border-gray-700 text-white text-sm"
+              />
+            </div>
+
+            <div className="flex items-center justify-end gap-2 pt-2">
+              {secretConfigured && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleRemove}
+                  disabled={removing}
+                  className="border-red-800 text-red-400 hover:bg-red-900/20"
+                >
+                  {removing ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : <Trash2 className="w-4 h-4 mr-1" />}
+                  Remove
+                </Button>
+              )}
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={saving || !clientId.trim() || !clientSecret.trim()}
+                className="bg-brand-orange hover:bg-brand-orange/90"
+              >
+                {saving && <Loader2 className="w-4 h-4 animate-spin mr-1" />}
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Card>
+  )
+}

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo } from 'react'
+import { useState, useRef, useMemo, useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '../components/ui/button'
 import { Badge } from '../components/ui/badge'
@@ -7,7 +7,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../components/
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { Trash2, Loader2, Database, Pencil, Upload, FileText, X, Search, Link as LinkIcon, Leaf, Cylinder, Server, HardDrive, Users, Lock, Cloud, ChevronDown, ChevronRight, CheckCircle2, AlertCircle } from 'lucide-react'
-import { ApiService, type ConnectionCreateRequest, type ConnectionType, type Datasource, type DatabricksCatalog } from '../services/api'
+import { ApiService, type ConnectionCreateRequest, type ConnectionType, type Datasource, type DatabricksCatalog, type DatabricksOAuthTokens, type DatabricksWarehouse } from '../services/api'
+import { DatabricksOAuthSettings } from '../components/databricks/DatabricksOAuthSettings'
 
 type DatabricksPair = { catalog: string; schema: string | null }
 const pairKey = (p: DatabricksPair) => `${p.catalog}::${p.schema ?? '*'}`
@@ -91,6 +92,21 @@ export default function DatabasesPage() {
   } | null>(null)
   const [databricksCatalogFilter, setDatabricksCatalogFilter] = useState('')
 
+  // Databricks OAuth state
+  const [databricksOAuthConfigured, setDatabricksOAuthConfigured] = useState<boolean>(false)
+  const [oauthTokens, setOauthTokens] = useState<DatabricksOAuthTokens | null>(null)
+  const [oauthSigningIn, setOauthSigningIn] = useState(false)
+  const [oauthError, setOauthError] = useState<string | null>(null)
+  const [warehouses, setWarehouses] = useState<DatabricksWarehouse[] | null>(null)
+  const [selectedWarehouseId, setSelectedWarehouseId] = useState<string | null>(null)
+  const [loadingWarehouses, setLoadingWarehouses] = useState(false)
+
+  useEffect(() => {
+    ApiService.getDatabricksAuthStatus()
+      .then(s => setDatabricksOAuthConfigured(!!s.configured))
+      .catch(() => setDatabricksOAuthConfigured(false))
+  }, [])
+
   // Use React Query hooks
   const { data: datasourcesResponse, isLoading: loading, error } = useDatasources()
   const createMutation = useCreateDBConnection()
@@ -168,12 +184,10 @@ export default function DatabasesPage() {
   const isCreateFormValid = useMemo(() => {
     // Databricks wizard uses its own validation (name is auto-generated server-side).
     if (selectedType === 'databricks') {
-      const credsOk =
-        connectionConfig.serverHostname.trim().length > 0 &&
-        connectionConfig.httpPath.trim().length > 0 &&
-        connectionConfig.accessToken.trim().length > 0
-      if (databricksStep === 1) return credsOk
-      return credsOk && selectedPairs.length > 0
+      const signedIn = !!oauthTokens?.access_token
+      const warehousePicked = !!selectedWarehouseId
+      if (databricksStep === 1) return signedIn && warehousePicked
+      return signedIn && warehousePicked && selectedPairs.length > 0
     }
 
     // Connection name is always required
@@ -200,7 +214,7 @@ export default function DatabasesPage() {
         connectionConfig.password.trim().length > 0
       )
     }
-  }, [selectedType, connectionConfig, databricksStep, selectedPairs])
+  }, [selectedType, connectionConfig, databricksStep, selectedPairs, oauthTokens, selectedWarehouseId])
 
   const resetDatabricksWizard = () => {
     setDatabricksStep(1)
@@ -212,6 +226,58 @@ export default function DatabasesPage() {
     setDatabricksNamePrefix('')
     setBatchProgress(null)
     setDatabricksCatalogFilter('')
+    setOauthTokens(null)
+    setOauthError(null)
+    setOauthSigningIn(false)
+    setWarehouses(null)
+    setSelectedWarehouseId(null)
+    setLoadingWarehouses(false)
+  }
+
+  const loadWarehouses = async (host: string, token: string) => {
+    setLoadingWarehouses(true)
+    try {
+      const ws = await ApiService.listDatabricksWarehouses(host, token)
+      setWarehouses(ws)
+      if (ws.length === 1) setSelectedWarehouseId(ws[0].id)
+    } catch (err: any) {
+      setOauthError(err?.message || 'Failed to list warehouses')
+    } finally {
+      setLoadingWarehouses(false)
+    }
+  }
+
+  const handleDatabricksSignIn = async () => {
+    if (!connectionConfig.serverHostname.trim()) {
+      setOauthError('Enter your Databricks workspace URL first')
+      return
+    }
+    setOauthError(null)
+    setOauthSigningIn(true)
+    try {
+      const { auth_url, state } = await ApiService.startDatabricksOAuth(connectionConfig.serverHostname.trim())
+      window.open(auth_url, '_blank', 'noopener,noreferrer')
+      const deadline = Date.now() + 5 * 60 * 1000
+      while (Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 2000))
+        try {
+          const res = await ApiService.pollDatabricksOAuthResult(state)
+          if (res.status === 'success' && res.tokens) {
+            setOauthTokens(res.tokens)
+            setConnectionConfig(prev => ({ ...prev, serverHostname: res.tokens!.server_hostname }))
+            await loadWarehouses(res.tokens.server_hostname, res.tokens.access_token)
+            return
+          }
+        } catch (err: any) {
+          console.warn('OAuth poll failed:', err?.message)
+        }
+      }
+      setOauthError('Sign-in timed out. Please try again.')
+    } catch (err: any) {
+      setOauthError(err?.message || 'Failed to start Databricks sign-in')
+    } finally {
+      setOauthSigningIn(false)
+    }
   }
 
   const togglePair = (pair: DatabricksPair) => {
@@ -230,15 +296,19 @@ export default function DatabasesPage() {
     selectedPairs.some(p => pairKey(p) === pairKey(pair))
 
   const handleDatabricksDiscover = async () => {
+    if (!oauthTokens || !selectedWarehouseId) return
+    const warehouse = warehouses?.find(w => w.id === selectedWarehouseId)
+    if (!warehouse) return
     setDiscoverError(null)
     setDiscovering(true)
     try {
       const res = await ApiService.discoverDatabricks({
-        server_hostname: connectionConfig.serverHostname,
-        http_path: connectionConfig.httpPath,
-        access_token: connectionConfig.accessToken,
+        server_hostname: oauthTokens.server_hostname,
+        access_token: oauthTokens.access_token,
+        http_path: warehouse.http_path,
       })
       setDiscoveredCatalogs(res.catalogs)
+      setConnectionConfig(prev => ({ ...prev, httpPath: warehouse.http_path }))
       setDatabricksStep(2)
     } catch (err: any) {
       setDiscoverError(err?.message || 'Failed to discover Databricks catalogs')
@@ -259,15 +329,22 @@ export default function DatabasesPage() {
         const prefix = databricksNamePrefix.trim()
         const suffix = `${pair.catalog}.${pair.schema ?? '*'}`
         const name = prefix ? `${prefix} · ${suffix}` : ''
+        if (!oauthTokens) throw new Error('Not signed in to Databricks')
         await ApiService.createConnection({
           type: 'databricks',
           name: name || undefined,
           connection_obj: {
-            server_hostname: connectionConfig.serverHostname,
+            server_hostname: oauthTokens.server_hostname,
             http_path: connectionConfig.httpPath,
-            access_token: connectionConfig.accessToken,
             catalog: pair.catalog,
             schema: pair.schema ?? undefined,
+            oauth: {
+              access_token: oauthTokens.access_token,
+              refresh_token: oauthTokens.refresh_token,
+              expires_at: oauthTokens.expires_at,
+              scope: oauthTokens.scope,
+              server_hostname: oauthTokens.server_hostname,
+            },
           },
         })
       } catch (err: any) {
@@ -319,12 +396,22 @@ export default function DatabasesPage() {
         query_mode: connectionConfig.queryMode,
       }
     } else if (selectedType === 'databricks') {
+      if (!oauthTokens) {
+        alert('Sign in to Databricks first')
+        return
+      }
       connectionObj = {
-        server_hostname: connectionConfig.serverHostname,
+        server_hostname: oauthTokens.server_hostname,
         http_path: connectionConfig.httpPath,
-        access_token: connectionConfig.accessToken,
         catalog: connectionConfig.catalog || undefined,
         schema: connectionConfig.databricksSchema || undefined,
+        oauth: {
+          access_token: oauthTokens.access_token,
+          refresh_token: oauthTokens.refresh_token,
+          expires_at: oauthTokens.expires_at,
+          scope: oauthTokens.scope,
+          server_hostname: oauthTokens.server_hostname,
+        },
       }
     } else {
       // PostgreSQL, MySQL, MSSQL - send components, backend builds URL with driver
@@ -1479,48 +1566,101 @@ export default function DatabasesPage() {
                       </div>
                     )}
 
-                    {selectedType === 'databricks' && databricksStep === 1 && (
+                    {selectedType === 'databricks' && databricksStep === 1 && !databricksOAuthConfigured && (
+                      <div className="space-y-3">
+                        <div className="bg-amber-900/20 border border-amber-700/40 rounded-md p-3 text-sm text-amber-200">
+                          Databricks OAuth isn't configured yet. An admin needs to register Byaan as a custom OAuth app in the Databricks Account Console and paste the credentials below. After saving, every user can sign in with Databricks.
+                        </div>
+                        <DatabricksOAuthSettings onConfigChanged={() => {
+                          ApiService.getDatabricksAuthStatus()
+                            .then(s => setDatabricksOAuthConfigured(!!s.configured))
+                            .catch(() => {})
+                        }} />
+                      </div>
+                    )}
+
+                    {selectedType === 'databricks' && databricksStep === 1 && databricksOAuthConfigured && (
                       <div className="space-y-4">
-                        <p className="text-xs text-gray-400">Enter your Databricks workspace credentials. Next, we'll list available catalogs and schemas to pick from.</p>
+                        <p className="text-xs text-gray-400">
+                          Sign in with your Databricks account. Byaan will list available warehouses, then catalogs and schemas to pick from.
+                        </p>
                         <div>
-                          <Label htmlFor="serverHostname" className="text-white">Server Hostname <span className="text-red-400">*</span></Label>
+                          <Label htmlFor="serverHostname" className="text-white">Workspace URL <span className="text-red-400">*</span></Label>
                           <Input
                             id="serverHostname"
                             placeholder="adb-1234.azuredatabricks.net"
                             value={connectionConfig.serverHostname}
                             onChange={(e) => setConnectionConfig(prev => ({ ...prev, serverHostname: e.target.value }))}
-                            disabled={discovering}
+                            disabled={oauthSigningIn || !!oauthTokens}
                             className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
                           />
+                          <p className="text-xs text-gray-400 mt-1">No scheme — just the host, e.g. <code>adb-1234.azuredatabricks.net</code>.</p>
                         </div>
-                        <div>
-                          <Label htmlFor="httpPath" className="text-white">HTTP Path <span className="text-red-400">*</span></Label>
-                          <Input
-                            id="httpPath"
-                            placeholder="/sql/1.0/warehouses/abc123"
-                            value={connectionConfig.httpPath}
-                            onChange={(e) => setConnectionConfig(prev => ({ ...prev, httpPath: e.target.value }))}
-                            disabled={discovering}
-                            className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
-                          />
-                          <p className="text-xs text-gray-400 mt-1">Find in Databricks: SQL Warehouse → Connection Details → HTTP Path</p>
-                        </div>
-                        <div>
-                          <Label htmlFor="accessToken" className="text-white">Access Token (PAT) <span className="text-red-400">*</span></Label>
-                          <Input
-                            id="accessToken"
-                            type="password"
-                            placeholder="dapi..."
-                            value={connectionConfig.accessToken}
-                            onChange={(e) => setConnectionConfig(prev => ({ ...prev, accessToken: e.target.value }))}
-                            disabled={discovering}
-                            className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
-                          />
-                        </div>
-                        {discoverError && (
+
+                        {!oauthTokens ? (
+                          <Button
+                            onClick={handleDatabricksSignIn}
+                            disabled={oauthSigningIn || !connectionConfig.serverHostname.trim()}
+                            className="w-full bg-brand-orange hover:bg-brand-orange/90"
+                          >
+                            {oauthSigningIn ? (
+                              <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Waiting for sign-in…</>
+                            ) : (
+                              <>Sign in with Databricks</>
+                            )}
+                          </Button>
+                        ) : (
+                          <div className="flex items-start gap-2 bg-green-900/20 border border-green-700/50 rounded-md p-3 text-sm text-green-200">
+                            <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                            <div className="flex-1">
+                              <div className="font-medium">Signed in to {oauthTokens.server_hostname}</div>
+                              <button
+                                type="button"
+                                onClick={resetDatabricksWizard}
+                                className="text-xs text-green-300/80 hover:underline mt-0.5"
+                              >
+                                Sign out
+                              </button>
+                            </div>
+                          </div>
+                        )}
+
+                        {oauthTokens && (
+                          <div>
+                            <Label className="text-white">SQL Warehouse <span className="text-red-400">*</span></Label>
+                            {loadingWarehouses ? (
+                              <div className="mt-2 flex items-center gap-2 text-sm text-gray-400">
+                                <Loader2 className="w-4 h-4 animate-spin" /> Loading warehouses…
+                              </div>
+                            ) : warehouses && warehouses.length > 0 ? (
+                              <div className="mt-1 border border-[#444444] rounded-md divide-y divide-[#3a3a3a] max-h-[220px] overflow-y-auto custom-scrollbar">
+                                {warehouses.map(w => (
+                                  <button
+                                    key={w.id}
+                                    type="button"
+                                    onClick={() => setSelectedWarehouseId(w.id)}
+                                    className={`w-full text-left px-3 py-2 text-sm hover:bg-[#2a2a2a] ${selectedWarehouseId === w.id ? 'bg-[#2a2a2a] border-l-2 border-brand-orange' : ''}`}
+                                  >
+                                    <div className="flex items-center justify-between">
+                                      <span className="text-white font-medium">{w.name || w.id}</span>
+                                      <span className="text-xs text-gray-400">{w.state}{w.size ? ` · ${w.size}` : ''}</span>
+                                    </div>
+                                    <div className="text-xs text-gray-500 font-mono mt-0.5">{w.http_path}</div>
+                                  </button>
+                                ))}
+                              </div>
+                            ) : (
+                              <div className="mt-1 p-3 text-sm text-gray-400 border border-[#444444] rounded-md">
+                                No SQL warehouses visible to this account.
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {(oauthError || discoverError) && (
                           <div className="flex items-start gap-2 bg-red-900/20 border border-red-700/50 rounded-md p-3 text-sm text-red-200">
                             <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-                            <span>{discoverError}</span>
+                            <span>{oauthError || discoverError}</span>
                           </div>
                         )}
                       </div>

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -17,7 +17,7 @@ import { useStore } from '../stores/useStore'
 import { useScopes } from '../hooks/useScopes'
 import { useAppConfig } from '../hooks/useAppConfig'
 import { DatabricksOAuthSettings } from '../components/databricks/DatabricksOAuthSettings'
-import { isTauriApp } from '../lib/tauri-api'
+import { isTauriApp, openExternalUrl } from '../lib/tauri-api'
 
 export default function DatabasesPage() {
   const queryClient = useQueryClient()
@@ -270,7 +270,7 @@ export default function DatabasesPage() {
     setOauthSigningIn(true)
     try {
       const { auth_url, state } = await ApiService.startDatabricksOAuth(connectionConfig.serverHostname.trim())
-      window.open(auth_url, '_blank', 'noopener,noreferrer')
+      await openExternalUrl(auth_url)
       const deadline = Date.now() + 5 * 60 * 1000
       while (Date.now() < deadline) {
         await new Promise(r => setTimeout(r, 2000))

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -8,7 +8,6 @@ import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { Trash2, Loader2, Database, Pencil, Upload, FileText, X, Search, Link as LinkIcon, Leaf, Cylinder, Server, HardDrive, Users, Lock, Cloud, ChevronDown, ChevronRight, CheckCircle2, AlertCircle } from 'lucide-react'
 import { ApiService, type ConnectionCreateRequest, type ConnectionType, type Datasource, type DatabricksCatalog, type DatabricksOAuthTokens, type DatabricksWarehouse } from '../services/api'
-import { DatabricksOAuthSettings } from '../components/databricks/DatabricksOAuthSettings'
 
 type DatabricksPair = { catalog: string; schema: string | null }
 const pairKey = (p: DatabricksPair) => `${p.catalog}::${p.schema ?? '*'}`
@@ -17,6 +16,7 @@ import { showToast } from '../utils/toast'
 import { useStore } from '../stores/useStore'
 import { useScopes } from '../hooks/useScopes'
 import { useAppConfig } from '../hooks/useAppConfig'
+import { DatabricksOAuthSettings } from '../components/databricks/DatabricksOAuthSettings'
 import { isTauriApp } from '../lib/tauri-api'
 
 export default function DatabasesPage() {
@@ -92,8 +92,9 @@ export default function DatabasesPage() {
   } | null>(null)
   const [databricksCatalogFilter, setDatabricksCatalogFilter] = useState('')
 
-  // Databricks OAuth state
-  const [databricksOAuthConfigured, setDatabricksOAuthConfigured] = useState<boolean>(false)
+  const [databricksOAuthConfigured, setDatabricksOAuthConfigured] = useState<boolean>(!isSelfHosted)
+  const [databricksOAuthCanConfigure, setDatabricksOAuthCanConfigure] = useState<boolean>(false)
+  const [showManageDatabricksOAuth, setShowManageDatabricksOAuth] = useState<boolean>(false)
   const [oauthTokens, setOauthTokens] = useState<DatabricksOAuthTokens | null>(null)
   const [oauthSigningIn, setOauthSigningIn] = useState(false)
   const [oauthError, setOauthError] = useState<string | null>(null)
@@ -101,11 +102,24 @@ export default function DatabasesPage() {
   const [selectedWarehouseId, setSelectedWarehouseId] = useState<string | null>(null)
   const [loadingWarehouses, setLoadingWarehouses] = useState(false)
 
-  useEffect(() => {
+  const refreshDatabricksAuthStatus = () => {
     ApiService.getDatabricksAuthStatus()
-      .then(s => setDatabricksOAuthConfigured(!!s.configured))
-      .catch(() => setDatabricksOAuthConfigured(false))
+      .then(s => {
+        setDatabricksOAuthConfigured(!!s.configured)
+        setDatabricksOAuthCanConfigure(!!s.can_configure)
+      })
+      .catch(() => {
+        setDatabricksOAuthConfigured(!isSelfHosted)
+        setDatabricksOAuthCanConfigure(false)
+      })
+  }
+
+  useEffect(() => {
+    refreshDatabricksAuthStatus()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const databricksTileVisible = !isSelfHosted || databricksOAuthConfigured || databricksOAuthCanConfigure
 
   // Use React Query hooks
   const { data: datasourcesResponse, isLoading: loading, error } = useDatasources()
@@ -1161,19 +1175,21 @@ export default function DatabasesPage() {
                     <span className="text-sm font-medium">DynamoDB</span>
                   </button>
 
-                  {/* Databricks */}
-                  <button
-                    onClick={() => handleTypeChange('databricks')}
-                    disabled={createMutation.isPending || uploadMultipleFilesMutation.isPending || uploadFromURLMutation.isPending}
-                    className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md transition-all text-left ${
-                      selectedType === 'databricks'
-                        ? 'bg-brand-orange/10 text-white border-l-3 border-brand-orange'
-                        : 'text-gray-400 hover:text-white hover:bg-[#2a2a2a]'
-                    } ${createMutation.isPending || uploadMultipleFilesMutation.isPending || uploadFromURLMutation.isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
-                  >
-                    <Database className="w-5 h-5 flex-shrink-0 text-red-400" />
-                    <span className="text-sm font-medium">Databricks</span>
-                  </button>
+                  {/* Databricks: hidden for non-admin team members until admin configures OAuth */}
+                  {databricksTileVisible && (
+                    <button
+                      onClick={() => handleTypeChange('databricks')}
+                      disabled={createMutation.isPending || uploadMultipleFilesMutation.isPending || uploadFromURLMutation.isPending}
+                      className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-md transition-all text-left ${
+                        selectedType === 'databricks'
+                          ? 'bg-brand-orange/10 text-white border-l-3 border-brand-orange'
+                          : 'text-gray-400 hover:text-white hover:bg-[#2a2a2a]'
+                      } ${createMutation.isPending || uploadMultipleFilesMutation.isPending || uploadFromURLMutation.isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    >
+                      <Database className="w-5 h-5 flex-shrink-0 text-red-400" />
+                      <span className="text-sm font-medium">Databricks</span>
+                    </button>
+                  )}
                 </div>
               </div>
 
@@ -1566,24 +1582,40 @@ export default function DatabasesPage() {
                       </div>
                     )}
 
-                    {selectedType === 'databricks' && databricksStep === 1 && !databricksOAuthConfigured && (
+                    {selectedType === 'databricks' && databricksStep === 1 && isSelfHosted && !databricksOAuthConfigured && !databricksOAuthCanConfigure && (
+                      <div className="bg-amber-900/20 border border-amber-700/40 rounded-md p-3 text-sm text-amber-200">
+                        Databricks OAuth isn't configured for this workspace. Ask your admin to register a custom OAuth app in the Databricks Account Console and add the credentials in Settings.
+                      </div>
+                    )}
+
+                    {selectedType === 'databricks' && databricksStep === 1 && isSelfHosted && !databricksOAuthConfigured && databricksOAuthCanConfigure && (
                       <div className="space-y-3">
                         <div className="bg-amber-900/20 border border-amber-700/40 rounded-md p-3 text-sm text-amber-200">
-                          Databricks OAuth isn't configured yet. An admin needs to register Byaan as a custom OAuth app in the Databricks Account Console and paste the credentials below. After saving, every user can sign in with Databricks.
+                          Databricks OAuth isn't configured yet. Register Byaan as a custom OAuth app in the Databricks Account Console and paste the credentials below. After saving, every user can sign in with Databricks.
                         </div>
-                        <DatabricksOAuthSettings onConfigChanged={() => {
-                          ApiService.getDatabricksAuthStatus()
-                            .then(s => setDatabricksOAuthConfigured(!!s.configured))
-                            .catch(() => {})
-                        }} />
+                        <DatabricksOAuthSettings onConfigChanged={refreshDatabricksAuthStatus} />
                       </div>
                     )}
 
                     {selectedType === 'databricks' && databricksStep === 1 && databricksOAuthConfigured && (
                       <div className="space-y-4">
-                        <p className="text-xs text-gray-400">
-                          Sign in with your Databricks account. Byaan will list available warehouses, then catalogs and schemas to pick from.
-                        </p>
+                        <div className="flex items-start justify-between gap-3">
+                          <p className="text-xs text-gray-400 flex-1">
+                            Sign in with your Databricks account. Byaan will list available warehouses, then catalogs and schemas to pick from.
+                          </p>
+                          {databricksOAuthCanConfigure && (
+                            <button
+                              type="button"
+                              onClick={() => setShowManageDatabricksOAuth(v => !v)}
+                              className="text-xs text-brand-orange hover:underline whitespace-nowrap"
+                            >
+                              {showManageDatabricksOAuth ? 'Hide OAuth settings' : 'Manage OAuth credentials'}
+                            </button>
+                          )}
+                        </div>
+                        {showManageDatabricksOAuth && databricksOAuthCanConfigure && (
+                          <DatabricksOAuthSettings onConfigChanged={refreshDatabricksAuthStatus} />
+                        )}
                         <div>
                           <Label htmlFor="serverHostname" className="text-white">Workspace URL <span className="text-red-400">*</span></Label>
                           <Input

--- a/client/src/pages/auth/Login.tsx
+++ b/client/src/pages/auth/Login.tsx
@@ -267,22 +267,25 @@ export default function Login() {
           )}
 
           {/* Google Sign-In Button */}
-          <div className={features.local_auth_enabled ? "mb-6" : ""}>
-            <GoogleSignInButton
-              onSuccess={handleGoogleSuccess}
-              onError={handleGoogleError}
-              disabled={isSubmitting || isGoogleLoading}
-            />
-          </div>
+          {features.google_oauth_enabled && (
+            <div className={features.local_auth_enabled ? "mb-6" : ""}>
+              <GoogleSignInButton
+                onSuccess={handleGoogleSuccess}
+                onError={handleGoogleError}
+                disabled={isSubmitting || isGoogleLoading}
+              />
+            </div>
+          )}
 
           {features.local_auth_enabled && (
             <>
-              {/* Divider */}
-              <div className="flex items-center mb-6">
-                <div className="flex-1 border-t border-gray-200"></div>
-                <span className="px-4 text-sm text-gray-500">or</span>
-                <div className="flex-1 border-t border-gray-200"></div>
-              </div>
+              {features.google_oauth_enabled && (
+                <div className="flex items-center mb-6">
+                  <div className="flex-1 border-t border-gray-200"></div>
+                  <span className="px-4 text-sm text-gray-500">or</span>
+                  <div className="flex-1 border-t border-gray-200"></div>
+                </div>
+              )}
 
               {/* Login form */}
               <form onSubmit={handleSubmit}>

--- a/client/src/pages/auth/Register.tsx
+++ b/client/src/pages/auth/Register.tsx
@@ -216,22 +216,25 @@ export default function Register() {
           )}
 
           {/* Google Sign-In Button */}
-          <div className={features.local_auth_enabled ? (isFromInvitation ? "mb-4" : "mb-6") : ""}>
-            <GoogleSignInButton
-              onSuccess={handleGoogleSuccess}
-              onError={handleGoogleError}
-              disabled={isLoading || isGoogleLoading}
-            />
-          </div>
+          {features.google_oauth_enabled && (
+            <div className={features.local_auth_enabled ? (isFromInvitation ? "mb-4" : "mb-6") : ""}>
+              <GoogleSignInButton
+                onSuccess={handleGoogleSuccess}
+                onError={handleGoogleError}
+                disabled={isLoading || isGoogleLoading}
+              />
+            </div>
+          )}
 
           {features.local_auth_enabled && (
             <>
-              {/* Divider */}
-              <div className={`flex items-center ${isFromInvitation ? "mb-4" : "mb-6"}`}>
-                <div className="flex-1 border-t border-gray-200"></div>
-                <span className="px-4 text-sm text-gray-500">or</span>
-                <div className="flex-1 border-t border-gray-200"></div>
-              </div>
+              {features.google_oauth_enabled && (
+                <div className={`flex items-center ${isFromInvitation ? "mb-4" : "mb-6"}`}>
+                  <div className="flex-1 border-t border-gray-200"></div>
+                  <span className="px-4 text-sm text-gray-500">or</span>
+                  <div className="flex-1 border-t border-gray-200"></div>
+                </div>
+              )}
 
               {/* Register form */}
               <form onSubmit={handleSubmit}>

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -598,7 +598,6 @@ export interface DatabricksOAuthSettings {
   redirect_uri: string
 }
 
-
 // LLM Connections
 export interface LLMConnection {
   id: string
@@ -1490,14 +1489,14 @@ export class ApiService {
     return extractData<{ warehouses: DatabricksWarehouse[] }>(data).warehouses
   }
 
-  static async getDatabricksAuthStatus(): Promise<{ configured: boolean; redirect_uri: string }> {
+  static async getDatabricksAuthStatus(): Promise<{ configured: boolean; can_configure: boolean; redirect_uri: string }> {
     try {
       const response = await apiFetch(`${API_BASE_URL}/connections/databricks/auth/status`)
-      if (!response.ok) return { configured: false, redirect_uri: '' }
+      if (!response.ok) return { configured: false, can_configure: false, redirect_uri: '' }
       const data = await response.json()
-      return extractData<{ configured: boolean; redirect_uri: string }>(data)
+      return extractData<{ configured: boolean; can_configure: boolean; redirect_uri: string }>(data)
     } catch {
-      return { configured: false, redirect_uri: '' }
+      return { configured: false, can_configure: false, redirect_uri: '' }
     }
   }
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -554,14 +554,48 @@ export interface DatabricksCatalog {
   schemas: string[]
 }
 
+export interface DatabricksWarehouse {
+  id: string
+  name?: string | null
+  state?: string | null
+  size?: string | null
+  http_path: string
+}
+
 export interface DatabricksDiscoverResponse {
   catalogs: DatabricksCatalog[]
+  warehouses?: DatabricksWarehouse[]
 }
 
 export interface DatabricksDiscoverRequest {
   server_hostname: string
-  http_path: string
   access_token: string
+  http_path?: string
+}
+
+export interface DatabricksOAuthTokens {
+  access_token: string
+  refresh_token: string | null
+  expires_at: number
+  scope: string | null
+  server_hostname: string
+}
+
+export interface DatabricksOAuthStartResponse {
+  auth_url: string
+  state: string
+  redirect_uri: string
+}
+
+export interface DatabricksOAuthResultResponse {
+  status: 'pending' | 'success'
+  tokens?: DatabricksOAuthTokens
+}
+
+export interface DatabricksOAuthSettings {
+  client_id: string
+  client_secret_configured: boolean
+  redirect_uri: string
 }
 
 
@@ -1418,6 +1452,83 @@ export class ApiService {
     } catch (error) {
       console.error('Error discovering Databricks catalogs:', error)
       throw error
+    }
+  }
+
+  static async startDatabricksOAuth(server_hostname: string): Promise<DatabricksOAuthStartResponse> {
+    const response = await apiFetch(`${API_BASE_URL}/connections/databricks/oauth/start`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ server_hostname }),
+    })
+    const data = await response.json()
+    if (!response.ok) {
+      throw new Error(extractErrorMessage(data) || `HTTP error! status: ${response.status}`)
+    }
+    return extractData<DatabricksOAuthStartResponse>(data)
+  }
+
+  static async pollDatabricksOAuthResult(state: string): Promise<DatabricksOAuthResultResponse> {
+    const response = await apiFetch(`${API_BASE_URL}/connections/databricks/oauth/result?state=${encodeURIComponent(state)}`)
+    const data = await response.json()
+    if (!response.ok) {
+      throw new Error(extractErrorMessage(data) || `HTTP error! status: ${response.status}`)
+    }
+    return extractData<DatabricksOAuthResultResponse>(data)
+  }
+
+  static async listDatabricksWarehouses(server_hostname: string, access_token: string): Promise<DatabricksWarehouse[]> {
+    const response = await apiFetch(`${API_BASE_URL}/connections/databricks/oauth/warehouses`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ server_hostname, access_token }),
+    })
+    const data = await response.json()
+    if (!response.ok) {
+      throw new Error(extractErrorMessage(data) || `HTTP error! status: ${response.status}`)
+    }
+    return extractData<{ warehouses: DatabricksWarehouse[] }>(data).warehouses
+  }
+
+  static async getDatabricksAuthStatus(): Promise<{ configured: boolean; redirect_uri: string }> {
+    try {
+      const response = await apiFetch(`${API_BASE_URL}/connections/databricks/auth/status`)
+      if (!response.ok) return { configured: false, redirect_uri: '' }
+      const data = await response.json()
+      return extractData<{ configured: boolean; redirect_uri: string }>(data)
+    } catch {
+      return { configured: false, redirect_uri: '' }
+    }
+  }
+
+  static async getDatabricksOAuthSettings(): Promise<DatabricksOAuthSettings> {
+    const response = await apiFetch(`${API_BASE_URL}/connections/databricks/admin/oauth-config`)
+    const data = await response.json()
+    if (!response.ok) {
+      throw new Error(extractErrorMessage(data) || `HTTP error! status: ${response.status}`)
+    }
+    return extractData<DatabricksOAuthSettings>(data)
+  }
+
+  static async saveDatabricksOAuthSettings(client_id: string, client_secret: string): Promise<void> {
+    const response = await apiFetch(`${API_BASE_URL}/connections/databricks/admin/oauth-config`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id, client_secret }),
+    })
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}))
+      throw new Error(extractErrorMessage(data) || `HTTP error! status: ${response.status}`)
+    }
+  }
+
+  static async deleteDatabricksOAuthSettings(): Promise<void> {
+    const response = await apiFetch(`${API_BASE_URL}/connections/databricks/admin/oauth-config`, {
+      method: 'DELETE',
+    })
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}))
+      throw new Error(extractErrorMessage(data) || `HTTP error! status: ${response.status}`)
     }
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       target: runtime
     ports:
       - "${BACKEND_PORT:-17433}:8000"
+      - "8020:8020"
     volumes:
       - .:/app
       - /app/.venv

--- a/server/main.py
+++ b/server/main.py
@@ -52,6 +52,7 @@ from server.routers import claude_oauth as claude_oauth_router
 from server.routers import codex_oauth as codex_oauth_router
 from server.routers import connections as connections_router
 from server.routers import custom_skills as custom_skills_router
+from server.routers import databricks_oauth as databricks_oauth_router
 from server.routers import datasets as datasets_router  # Dataset management
 from server.routers import (
     datasources as datasources_router,
@@ -599,6 +600,7 @@ app.include_router(tenant_router.router, prefix="/api", tags=["tenants"])
 app.include_router(folders_router.router, prefix="/api", tags=["folders"])
 
 app.include_router(github_router.router, prefix="/api", tags=["github"])
+app.include_router(databricks_oauth_router.router, prefix="/api", tags=["databricks-oauth"])
 
 app.include_router(local_repos_router.router, prefix="/api", tags=["local-repos"])
 

--- a/server/routers/connections.py
+++ b/server/routers/connections.py
@@ -18,6 +18,7 @@ from server.schemas.connections import (
     DatabricksDiscoverResponse,
 )
 from server.schemas.standard_response import success_response
+from server.services import databricks_oauth_service
 from server.services.connections import ConnectionService
 from server.services.database_operations import DatabaseOperationsService
 from server.services.databricks_connector import AsyncDatabricksConnector
@@ -35,11 +36,22 @@ async def discover_databricks_endpoint(
     payload: DatabricksDiscoverRequest,
     auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
 ):
+    warehouses: list[dict] = []
+    if not payload.http_path:
+        try:
+            warehouses = await databricks_oauth_service.list_warehouses(payload.server_hostname, payload.access_token)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
     connector = AsyncDatabricksConnector(
         {
             "server_hostname": payload.server_hostname,
-            "http_path": payload.http_path,
-            "access_token": payload.access_token,
+            "http_path": payload.http_path or (warehouses[0]["http_path"] if warehouses else ""),
+            "oauth": {
+                "access_token": payload.access_token,
+                "expires_at": 2**31 - 1,  # treat as non-expiring within discovery
+                "server_hostname": payload.server_hostname,
+            },
         }
     )
     try:
@@ -71,7 +83,7 @@ async def discover_databricks_endpoint(
         except Exception:
             logger.debug("Ignoring close error after Databricks discover", exc_info=True)
 
-    response = DatabricksDiscoverResponse(catalogs=catalogs)
+    response = DatabricksDiscoverResponse(catalogs=catalogs, warehouses=warehouses)
     return success_response(
         data=response.model_dump(),
         message=f"Discovered {len(response.catalogs)} catalog(s)",
@@ -99,6 +111,15 @@ async def create_connection_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid connection type: {payload.type}. Allowed types: {', '.join(ALLOWED_CONN_TYPES)}",
         )
+
+    if payload.type == "databricks":
+        oauth = (payload.connection_obj or {}).get("oauth") or {}
+        if not oauth.get("access_token") or not oauth.get("refresh_token"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Databricks connections require an OAuth block with access_token and refresh_token. "
+                "Use the Sign in with Databricks flow.",
+            )
 
     try:
         connection, schema = await ConnectionService.create_connection_with_schema(

--- a/server/routers/databricks_oauth.py
+++ b/server/routers/databricks_oauth.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import html
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -114,7 +116,7 @@ async def databricks_oauth_callback(
         databricks_oauth_service.store_result(state, tokens, stored)
     except Exception as e:
         logger.error(f"[DATABRICKS OAUTH] Callback failed: {e}", exc_info=True)
-        return HTMLResponse(_ERROR_HTML.format(message=str(e)), status_code=400)
+        return HTMLResponse(_ERROR_HTML.replace("{message}", html.escape(str(e))), status_code=400)
 
     return HTMLResponse(_CALLBACK_HTML)
 

--- a/server/routers/databricks_oauth.py
+++ b/server/routers/databricks_oauth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.auth.dependencies import AuthContext, require_scope
@@ -19,6 +19,7 @@ from server.schemas.connections import (
 )
 from server.schemas.standard_response import success_response
 from server.services import databricks_oauth_service
+from server.utils.config_loader import is_self_hosted
 from server.utils.custom_logger import get_logger
 
 logger = get_logger(__name__)
@@ -33,6 +34,10 @@ _CALLBACK_HTML = """
 </head><body><div style="text-align:center">
 <h2 style="color:#ff7a00">Databricks connected</h2>
 <p>You can close this tab and return to Byaan.</p>
+<script>
+  try { window.close(); } catch (e) {}
+  setTimeout(function(){ try { window.close(); } catch (e) {} }, 300);
+</script>
 </div></body></html>
 """
 
@@ -53,11 +58,17 @@ async def databricks_oauth_start(
     auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
     session: AsyncSession = Depends(get_async_session),
 ):
-    client_id, client_secret = await databricks_oauth_service.get_oauth_credentials(session)
-    if not client_id or not client_secret:
+    if is_self_hosted() and not await databricks_oauth_service.is_oauth_configured(session):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Databricks OAuth is not configured. Ask an admin to set client_id and client_secret in Settings.",
+            detail="Databricks OAuth is not configured. Ask an admin to register a custom OAuth app in the Databricks Account Console and paste the client_id and client_secret in Settings.",
+        )
+
+    client_id, _client_secret = await databricks_oauth_service.get_oauth_credentials(session)
+    if not client_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Databricks OAuth client_id missing.",
         )
 
     auth_url, state = await databricks_oauth_service.create_auth_url(
@@ -91,8 +102,8 @@ async def databricks_oauth_callback(
 
     try:
         client_id, client_secret = await databricks_oauth_service.get_oauth_credentials(session)
-        if not client_id or not client_secret:
-            raise ValueError("Databricks OAuth is not configured")
+        if not client_id:
+            raise ValueError("Databricks OAuth client_id missing")
 
         tokens = await databricks_oauth_service.exchange_code(
             code=code,
@@ -105,9 +116,6 @@ async def databricks_oauth_callback(
         logger.error(f"[DATABRICKS OAUTH] Callback failed: {e}", exc_info=True)
         return HTMLResponse(_ERROR_HTML.format(message=str(e)), status_code=400)
 
-    frontend_url = databricks_oauth_service._get_frontend_url()
-    if frontend_url:
-        return RedirectResponse(url=f"{frontend_url}/databases?databricks_oauth=success&state={state}")
     return HTMLResponse(_CALLBACK_HTML)
 
 
@@ -149,7 +157,33 @@ async def databricks_list_warehouses(
     return success_response(data={"warehouses": warehouses}, message=f"Found {len(warehouses)} warehouse(s)")
 
 
-# ----- admin config endpoints -----
+@router.get("/connections/databricks/auth/status")
+async def databricks_auth_status(
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    configured = await databricks_oauth_service.is_oauth_configured(session)
+    can_configure = is_self_hosted() and bool(getattr(auth, "is_admin", False))
+    return success_response(
+        data={
+            "configured": configured,
+            "can_configure": can_configure,
+            "redirect_uri": databricks_oauth_service.get_redirect_uri(),
+        }
+    )
+
+
+# ----- admin config endpoints (hosted mode only) -----
+
+
+def _require_hosted_admin(auth: AuthContext) -> None:
+    if not is_self_hosted():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Databricks OAuth admin configuration is only available in hosted deployments.",
+        )
+    if not getattr(auth, "is_admin", False):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
 
 
 @router.get("/connections/databricks/admin/oauth-config")
@@ -157,8 +191,7 @@ async def get_databricks_oauth_config(
     auth: AuthContext = Depends(require_scope(Scope.SETTINGS_UPDATE)),
     session: AsyncSession = Depends(get_async_session),
 ):
-    if not auth.is_admin:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+    _require_hosted_admin(auth)
 
     from server.services.settings import SettingsService
 
@@ -183,8 +216,7 @@ async def save_databricks_oauth_config(
     auth: AuthContext = Depends(require_scope(Scope.SETTINGS_UPDATE)),
     session: AsyncSession = Depends(get_async_session),
 ):
-    if not auth.is_admin:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+    _require_hosted_admin(auth)
 
     from server.services.crypto_service import CryptoService
     from server.services.settings import SettingsService
@@ -209,25 +241,10 @@ async def delete_databricks_oauth_config(
     auth: AuthContext = Depends(require_scope(Scope.SETTINGS_UPDATE)),
     session: AsyncSession = Depends(get_async_session),
 ):
-    if not auth.is_admin:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+    _require_hosted_admin(auth)
 
     from server.services.settings import SettingsService
 
     await SettingsService.delete_setting_by_key(session, databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_ID_KEY)
     await SettingsService.delete_setting_by_key(session, databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_SECRET_KEY)
     return success_response(message="Databricks OAuth configuration removed")
-
-
-@router.get("/connections/databricks/auth/status")
-async def databricks_auth_status(
-    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
-    session: AsyncSession = Depends(get_async_session),
-):
-    configured = await databricks_oauth_service.is_oauth_configured(session)
-    return success_response(
-        data={
-            "configured": configured,
-            "redirect_uri": databricks_oauth_service.get_redirect_uri(),
-        }
-    )

--- a/server/routers/databricks_oauth.py
+++ b/server/routers/databricks_oauth.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext, require_scope
+from server.auth.scopes import Scope
+from server.auth.tenant_context import set_tenant_id
+from server.db.session import get_async_session
+from server.schemas.connections import (
+    DatabricksOAuthResultResponse,
+    DatabricksOAuthSettingsRequest,
+    DatabricksOAuthSettingsResponse,
+    DatabricksOAuthStartRequest,
+    DatabricksOAuthStartResponse,
+    DatabricksOAuthTokens,
+    DatabricksWarehousesRequest,
+)
+from server.schemas.standard_response import success_response
+from server.services import databricks_oauth_service
+from server.utils.custom_logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+_CALLBACK_HTML = """
+<!doctype html>
+<html><head><title>Databricks Connected</title>
+<style>body{font-family:system-ui;background:#0d0d0d;color:#eee;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style>
+</head><body><div style="text-align:center">
+<h2 style="color:#ff7a00">Databricks connected</h2>
+<p>You can close this tab and return to Byaan.</p>
+</div></body></html>
+"""
+
+_ERROR_HTML = """
+<!doctype html>
+<html><head><title>Databricks Error</title>
+<style>body{font-family:system-ui;background:#0d0d0d;color:#eee;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style>
+</head><body><div style="text-align:center;max-width:560px">
+<h2 style="color:#f87171">Databricks sign-in failed</h2>
+<p style="color:#aaa">{message}</p>
+</div></body></html>
+"""
+
+
+@router.post("/connections/databricks/oauth/start")
+async def databricks_oauth_start(
+    body: DatabricksOAuthStartRequest,
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    client_id, client_secret = await databricks_oauth_service.get_oauth_credentials(session)
+    if not client_id or not client_secret:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Databricks OAuth is not configured. Ask an admin to set client_id and client_secret in Settings.",
+        )
+
+    auth_url, state = await databricks_oauth_service.create_auth_url(
+        server_hostname=body.server_hostname,
+        client_id=client_id,
+        tenant_id=auth.tenant_id,
+        user_id=auth.user_id,
+    )
+    return success_response(
+        data=DatabricksOAuthStartResponse(
+            auth_url=auth_url,
+            state=state,
+            redirect_uri=databricks_oauth_service.get_redirect_uri(),
+        ).model_dump(),
+        message="Databricks OAuth URL generated",
+    )
+
+
+@router.get("/connections/databricks/oauth/callback")
+async def databricks_oauth_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    session: AsyncSession = Depends(get_async_session),
+):
+    stored = databricks_oauth_service.peek_state(state)
+    if stored and stored.get("tenant_id"):
+        try:
+            set_tenant_id(stored["tenant_id"])
+        except Exception:
+            logger.debug("Failed to set tenant context from OAuth state", exc_info=True)
+
+    try:
+        client_id, client_secret = await databricks_oauth_service.get_oauth_credentials(session)
+        if not client_id or not client_secret:
+            raise ValueError("Databricks OAuth is not configured")
+
+        tokens = await databricks_oauth_service.exchange_code(
+            code=code,
+            state=state,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        databricks_oauth_service.store_result(state, tokens, stored)
+    except Exception as e:
+        logger.error(f"[DATABRICKS OAUTH] Callback failed: {e}", exc_info=True)
+        return HTMLResponse(_ERROR_HTML.format(message=str(e)), status_code=400)
+
+    frontend_url = databricks_oauth_service._get_frontend_url()
+    if frontend_url:
+        return RedirectResponse(url=f"{frontend_url}/databases?databricks_oauth=success&state={state}")
+    return HTMLResponse(_CALLBACK_HTML)
+
+
+@router.get("/connections/databricks/oauth/result")
+async def databricks_oauth_result(
+    state: str = Query(...),
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
+):
+    entry = databricks_oauth_service.pop_result(state)
+    if not entry:
+        return success_response(
+            data=DatabricksOAuthResultResponse(status="pending").model_dump(),
+        )
+    tokens = entry["tokens"]
+    return success_response(
+        data=DatabricksOAuthResultResponse(
+            status="success",
+            tokens=DatabricksOAuthTokens(
+                access_token=tokens["access_token"],
+                refresh_token=tokens.get("refresh_token"),
+                expires_at=tokens["expires_at"],
+                scope=tokens.get("scope"),
+                server_hostname=tokens["server_hostname"],
+            ),
+        ).model_dump(),
+        message="Databricks tokens retrieved",
+    )
+
+
+@router.post("/connections/databricks/oauth/warehouses")
+async def databricks_list_warehouses(
+    body: DatabricksWarehousesRequest,
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
+):
+    try:
+        warehouses = await databricks_oauth_service.list_warehouses(body.server_hostname, body.access_token)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    return success_response(data={"warehouses": warehouses}, message=f"Found {len(warehouses)} warehouse(s)")
+
+
+# ----- admin config endpoints -----
+
+
+@router.get("/connections/databricks/admin/oauth-config")
+async def get_databricks_oauth_config(
+    auth: AuthContext = Depends(require_scope(Scope.SETTINGS_UPDATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    if not auth.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+
+    from server.services.settings import SettingsService
+
+    client_id_setting = await SettingsService.get_setting_by_key(
+        session, databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_ID_KEY
+    )
+    secret_setting = await SettingsService.get_setting_by_key(
+        session, databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_SECRET_KEY
+    )
+    return success_response(
+        data=DatabricksOAuthSettingsResponse(
+            client_id=client_id_setting.setting_value if client_id_setting else "",
+            client_secret_configured=secret_setting is not None,
+            redirect_uri=databricks_oauth_service.get_redirect_uri(),
+        ).model_dump()
+    )
+
+
+@router.put("/connections/databricks/admin/oauth-config")
+async def save_databricks_oauth_config(
+    body: DatabricksOAuthSettingsRequest,
+    auth: AuthContext = Depends(require_scope(Scope.SETTINGS_UPDATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    if not auth.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+
+    from server.services.crypto_service import CryptoService
+    from server.services.settings import SettingsService
+
+    await SettingsService.upsert_setting(
+        session,
+        setting_key=databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_ID_KEY,
+        setting_value=body.client_id,
+    )
+    encrypted_secret = await CryptoService.encrypt_config({"value": body.client_secret}, session)
+    await SettingsService.upsert_setting(
+        session,
+        setting_key=databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_SECRET_KEY,
+        setting_value=encrypted_secret,
+        is_encrypted=True,
+    )
+    return success_response(message="Databricks OAuth configuration saved")
+
+
+@router.delete("/connections/databricks/admin/oauth-config")
+async def delete_databricks_oauth_config(
+    auth: AuthContext = Depends(require_scope(Scope.SETTINGS_UPDATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    if not auth.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+
+    from server.services.settings import SettingsService
+
+    await SettingsService.delete_setting_by_key(session, databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_ID_KEY)
+    await SettingsService.delete_setting_by_key(session, databricks_oauth_service.DATABRICKS_OAUTH_CLIENT_SECRET_KEY)
+    return success_response(message="Databricks OAuth configuration removed")
+
+
+@router.get("/connections/databricks/auth/status")
+async def databricks_auth_status(
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    configured = await databricks_oauth_service.is_oauth_configured(session)
+    return success_response(
+        data={
+            "configured": configured,
+            "redirect_uri": databricks_oauth_service.get_redirect_uri(),
+        }
+    )

--- a/server/schemas/connections.py
+++ b/server/schemas/connections.py
@@ -61,8 +61,8 @@ class ConnectionListSimpleResponse(BaseModel):
 
 class DatabricksDiscoverRequest(BaseModel):
     server_hostname: str
-    http_path: str
     access_token: str
+    http_path: str | None = None
 
 
 class DatabricksCatalog(BaseModel):
@@ -70,5 +70,53 @@ class DatabricksCatalog(BaseModel):
     schemas: list[str]
 
 
+class DatabricksWarehouse(BaseModel):
+    id: str
+    name: str | None = None
+    state: str | None = None
+    size: str | None = None
+    http_path: str
+
+
 class DatabricksDiscoverResponse(BaseModel):
     catalogs: list[DatabricksCatalog]
+    warehouses: list[DatabricksWarehouse] = []
+
+
+class DatabricksOAuthStartRequest(BaseModel):
+    server_hostname: str
+
+
+class DatabricksOAuthStartResponse(BaseModel):
+    auth_url: str
+    state: str
+    redirect_uri: str
+
+
+class DatabricksOAuthTokens(BaseModel):
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: int
+    scope: str | None = None
+    server_hostname: str
+
+
+class DatabricksOAuthResultResponse(BaseModel):
+    status: str
+    tokens: DatabricksOAuthTokens | None = None
+
+
+class DatabricksWarehousesRequest(BaseModel):
+    server_hostname: str
+    access_token: str
+
+
+class DatabricksOAuthSettingsRequest(BaseModel):
+    client_id: str
+    client_secret: str
+
+
+class DatabricksOAuthSettingsResponse(BaseModel):
+    client_id: str
+    client_secret_configured: bool
+    redirect_uri: str

--- a/server/services/database_operations.py
+++ b/server/services/database_operations.py
@@ -1381,12 +1381,35 @@ class AsyncDatabaseService:
 
     @classmethod
     async def get_or_create_databricks_connector(cls, connection_id: str, connection_obj: dict[str, Any]):
-        """Get or create cached Databricks connector."""
+        """Get or create cached Databricks connector.
+
+        Wires a token-refresh callback that re-encrypts the updated OAuth block back
+        into the connection row so the rotated refresh_token survives a process
+        restart. The callback is a no-op when ``connection_id`` is not a real DB id
+        (e.g. the transient discover endpoint).
+        """
         from server.services.databricks_connector import AsyncDatabricksConnector
+
+        async def _persist_refreshed_tokens(new_oauth: dict[str, Any]) -> None:
+            try:
+                from server.db.session import AsyncSessionFactory
+                from server.repositories.connections import ConnectionRepository
+
+                async with AsyncSessionFactory() as session:
+                    repo = ConnectionRepository(session)
+                    connection = await repo.get(connection_id)
+                    if not connection:
+                        return
+                    current = await connection.get_decrypted_connection_obj(session) or {}
+                    current["oauth"] = new_oauth
+                    await connection.set_encrypted_connection_obj(current, session)
+                    await session.commit()
+            except Exception:
+                logger.error("Failed to persist refreshed Databricks tokens", exc_info=True)
 
         async with cls._pool_lock:
             if connection_id not in cls._connection_pools:
-                connector = AsyncDatabricksConnector(connection_obj)
+                connector = AsyncDatabricksConnector(connection_obj, on_token_refresh=_persist_refreshed_tokens)
                 await connector.connect()
                 cls._connection_pools[connection_id] = connector
             return cls._connection_pools[connection_id]

--- a/server/services/databricks_connector.py
+++ b/server/services/databricks_connector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from databricks import sql
@@ -13,34 +14,79 @@ logger = get_logger(__name__)
 
 _LIMIT_RE = re.compile(r"\blimit\s+\d+\b", re.IGNORECASE)
 
+TokenRefreshCallback = Callable[[dict[str, Any]], Awaitable[None]]
+
 
 class AsyncDatabricksConnector:
-    """Async wrapper over the sync databricks-sql-connector driver."""
+    """Async wrapper over the sync databricks-sql-connector driver.
 
-    def __init__(self, connection_obj: dict[str, Any]):
+    Auth: OAuth access_token sourced from ``connection_obj["oauth"]``. The connector
+    transparently refreshes the access token via the OAuth service when it's near
+    expiry and invokes ``on_token_refresh`` so callers can persist the rotated
+    refresh token back to the Connection row.
+    """
+
+    def __init__(
+        self,
+        connection_obj: dict[str, Any],
+        on_token_refresh: TokenRefreshCallback | None = None,
+    ):
         self.connection_obj = connection_obj
         self._connected = False
         self._conn: Any = None
         self._lock = asyncio.Lock()
+        self._on_token_refresh = on_token_refresh
 
-    def _required(self) -> tuple[str, str, str]:
+    def _required(self) -> tuple[str, str]:
         host = self.connection_obj.get("server_hostname")
         http_path = self.connection_obj.get("http_path")
-        token = self.connection_obj.get("access_token")
         if not host:
             raise ValueError("server_hostname is required for Databricks connection")
         if not http_path:
             raise ValueError("http_path is required for Databricks connection")
-        if not token:
-            raise ValueError("access_token is required for Databricks connection")
-        return host, http_path, token
+        return host, http_path
 
-    def _open_sync(self):
-        host, http_path, token = self._required()
+    async def _ensure_fresh_token(self) -> str:
+        """Refresh the OAuth access token if within skew of expiry, persist via callback."""
+        from server.services import databricks_oauth_service
+
+        self._required()
+        oauth = self.connection_obj.get("oauth") or {}
+        if not oauth.get("access_token"):
+            raise ValueError("OAuth access_token is required for Databricks connection")
+
+        if not databricks_oauth_service.is_oauth_block_expired(oauth):
+            return oauth["access_token"]
+
+        if not oauth.get("refresh_token"):
+            logger.warning("[DATABRICKS] Access token expired and no refresh_token present")
+            return oauth["access_token"]
+
+        # Need a DB session to read OAuth client credentials. Open a short-lived one.
+        from server.db.session import AsyncSessionFactory
+
+        async with AsyncSessionFactory() as session:
+            client_id, client_secret = await databricks_oauth_service.get_oauth_credentials(session)
+        if not client_id or not client_secret:
+            raise ValueError("Databricks OAuth credentials are not configured")
+
+        new_oauth = await databricks_oauth_service.refresh_databricks_token(oauth, client_id, client_secret)
+        self.connection_obj["oauth"] = new_oauth
+        if self._on_token_refresh is not None:
+            try:
+                await self._on_token_refresh(new_oauth)
+            except Exception:
+                logger.error("[DATABRICKS] on_token_refresh callback failed", exc_info=True)
+        # New token means existing sync connection holds a stale Authorization header.
+        self._reset_conn_sync()
+        return new_oauth["access_token"]
+
+    def _open_sync(self, access_token: str):
+        host, http_path = self._required()
         kwargs: dict[str, Any] = {
             "server_hostname": host,
             "http_path": http_path,
-            "access_token": token,
+            "access_token": access_token,
         }
         catalog = self.connection_obj.get("catalog")
         schema = self.connection_obj.get("schema")
@@ -50,9 +96,9 @@ class AsyncDatabricksConnector:
             kwargs["schema"] = schema
         return sql.connect(**kwargs)
 
-    def _ensure_conn_sync(self):
+    def _ensure_conn_sync(self, access_token: str):
         if self._conn is None:
-            self._conn = self._open_sync()
+            self._conn = self._open_sync(access_token)
         return self._conn
 
     def _reset_conn_sync(self):
@@ -64,17 +110,19 @@ class AsyncDatabricksConnector:
             self._conn = None
 
     async def connect(self) -> None:
-        def _probe():
-            conn = self._ensure_conn_sync()
-            try:
-                with conn.cursor() as cur:
-                    cur.execute("SELECT 1")
-                    cur.fetchall()
-            except Exception:
-                self._reset_conn_sync()
-                raise
-
         async with self._lock:
+            token = await self._ensure_fresh_token()
+
+            def _probe():
+                conn = self._ensure_conn_sync(token)
+                try:
+                    with conn.cursor() as cur:
+                        cur.execute("SELECT 1")
+                        cur.fetchall()
+                except Exception:
+                    self._reset_conn_sync()
+                    raise
+
             await asyncio.to_thread(_probe)
             self._connected = True
 
@@ -99,24 +147,26 @@ class AsyncDatabricksConnector:
     ) -> dict[str, Any]:
         sql_text = self._apply_limit(query, limit)
 
-        def _run():
-            conn = self._ensure_conn_sync()
-            try:
-                with conn.cursor() as cur:
-                    if params:
-                        cur.execute(sql_text, params)
-                    else:
-                        cur.execute(sql_text)
-                    rows = cur.fetchall()
-                    cols = [d[0] for d in (cur.description or [])]
-                    return cols, rows
-            except Exception:
-                self._reset_conn_sync()
-                raise
-
         start = time.perf_counter()
         try:
             async with self._lock:
+                token = await self._ensure_fresh_token()
+
+                def _run():
+                    conn = self._ensure_conn_sync(token)
+                    try:
+                        with conn.cursor() as cur:
+                            if params:
+                                cur.execute(sql_text, params)
+                            else:
+                                cur.execute(sql_text)
+                            rows = cur.fetchall()
+                            cols = [d[0] for d in (cur.description or [])]
+                            return cols, rows
+                    except Exception:
+                        self._reset_conn_sync()
+                        raise
+
                 cols, rows = await asyncio.wait_for(asyncio.to_thread(_run), timeout=timeout)
         except TimeoutError:
             return {"success": False, "error": f"Query timed out after {timeout}s"}
@@ -187,23 +237,25 @@ class AsyncDatabricksConnector:
         creating a Connection row.
         """
 
-        def _walk():
-            conn = self._ensure_conn_sync()
-            try:
-                out: list[dict[str, Any]] = []
-                for cat in self._list_catalogs_sync(conn):
-                    try:
-                        schemas = self._list_schemas_sync(conn, cat)
-                    except Exception as e:
-                        logger.warning(f"SHOW SCHEMAS failed for catalog {cat}: {e}")
-                        schemas = []
-                    out.append({"name": cat, "schemas": schemas})
-                return out
-            except Exception:
-                self._reset_conn_sync()
-                raise
-
         async with self._lock:
+            token = await self._ensure_fresh_token()
+
+            def _walk():
+                conn = self._ensure_conn_sync(token)
+                try:
+                    out: list[dict[str, Any]] = []
+                    for cat in self._list_catalogs_sync(conn):
+                        try:
+                            schemas = self._list_schemas_sync(conn, cat)
+                        except Exception as e:
+                            logger.warning(f"SHOW SCHEMAS failed for catalog {cat}: {e}")
+                            schemas = []
+                        out.append({"name": cat, "schemas": schemas})
+                    return out
+                except Exception:
+                    self._reset_conn_sync()
+                    raise
+
             return await asyncio.to_thread(_walk)
 
     async def get_schema(self) -> dict[str, Any]:
@@ -211,7 +263,7 @@ class AsyncDatabricksConnector:
         schema_name = self.connection_obj.get("schema")
 
         def _fetch():
-            conn = self._ensure_conn_sync()
+            conn = self._ensure_conn_sync(token)
             try:
                 catalogs_list: list[str] = []
                 schemas_list: list[str] = []
@@ -307,6 +359,7 @@ class AsyncDatabricksConnector:
                 raise
 
         async with self._lock:
+            token = await self._ensure_fresh_token()
             result = await asyncio.to_thread(_fetch)
         return {
             "catalog": catalog,

--- a/server/services/databricks_oauth_service.py
+++ b/server/services/databricks_oauth_service.py
@@ -284,15 +284,15 @@ async def _start_loopback_listener(state: str, client_id: str) -> None:
         except TimeoutError:
             logger.warning(f"[DATABRICKS OAUTH] Loopback listener timed out state={state[:16]}...")
         except asyncio.CancelledError:
-            pass
+            return
         except Exception:
             logger.exception("[DATABRICKS OAUTH] Loopback server crashed")
         finally:
             server.close()
             try:
                 await server.wait_closed()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"[DATABRICKS OAUTH] Ignoring loopback wait_closed() error: {e}")
             _active_loopback_servers.pop(state, None)
             _oauth_state_store.pop(state, None)
 

--- a/server/services/databricks_oauth_service.py
+++ b/server/services/databricks_oauth_service.py
@@ -15,27 +15,35 @@ Databricks account and paste client_id + client_secret in Settings.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import os
 import secrets
 import time
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 from uuid import UUID
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from server.utils.config_loader import get_databricks_oauth_config, get_email_config, is_self_hosted
+from server.utils.config_loader import get_email_config, is_self_hosted
 from server.utils.custom_logger import get_logger
 
 logger = get_logger(__name__)
 
-_oauth_config = get_databricks_oauth_config()
-DATABRICKS_CLIENT_ID = _oauth_config.get("client_id") or ""
-DATABRICKS_CLIENT_SECRET = _oauth_config.get("client_secret") or ""
+# Databricks built-in public OAuth client for U2M PKCE flows. Its only
+# registered redirect URI is http://localhost:8020 (fixed port, no path),
+# so we bind an ephemeral loopback listener on 8020 during each flow.
+# Used in desktop/local mode where browser + backend share a host.
+DATABRICKS_PUBLIC_CLIENT_ID = "databricks-cli"
+DATABRICKS_PUBLIC_REDIRECT_URI = "http://localhost:8020"
+DATABRICKS_LOOPBACK_PORT = 8020
+DATABRICKS_LOOPBACK_TIMEOUT_SECONDS = 300
 
+# In hosted mode an admin registers a custom OAuth app in their Databricks
+# Account Console and stores the credentials in the Settings table.
 DATABRICKS_OAUTH_CLIENT_ID_KEY = "databricks_oauth_client_id"
 DATABRICKS_OAUTH_CLIENT_SECRET_KEY = "databricks_oauth_client_secret"
 
@@ -53,15 +61,18 @@ def _get_frontend_url() -> str:
     if url:
         return url
     if is_self_hosted():
-        return get_email_config().get("frontend_url", "").rstrip("/")
+        return (get_email_config().get("frontend_url") or "").rstrip("/")
     return ""
 
 
 def get_redirect_uri() -> str:
-    frontend_url = _get_frontend_url()
-    if frontend_url:
-        return f"{frontend_url}/api/connections/databricks/oauth/callback"
-    return "byaan://databricks/callback"
+    """In hosted mode, redirect through the FastAPI callback at the public
+    frontend URL. In desktop/local mode, use the public-client loopback URI."""
+    if is_self_hosted():
+        frontend_url = _get_frontend_url()
+        if frontend_url:
+            return f"{frontend_url}/api/connections/databricks/oauth/callback"
+    return DATABRICKS_PUBLIC_REDIRECT_URI
 
 
 def _normalize_host(server_hostname: str) -> str:
@@ -87,38 +98,61 @@ def generate_pkce_pair() -> tuple[str, str]:
 
 
 async def get_oauth_credentials(session: AsyncSession | None = None) -> tuple[str, str]:
-    """Return (client_id, client_secret). Settings-backed in self-hosted, env-backed otherwise."""
-    if not is_self_hosted():
-        return DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
+    """Return (client_id, client_secret).
 
-    if not session:
-        return "", ""
+    - Hosted mode: load admin-configured custom OAuth app from the Settings table.
+    - Desktop/local: fall back to the Databricks built-in public client (PKCE-only,
+      no secret) so users can sign in without any admin configuration.
+    """
+    if is_self_hosted() and session is not None:
+        from server.services.crypto_service import CryptoService
+        from server.services.settings import SettingsService
 
-    from server.services.crypto_service import CryptoService
-    from server.services.settings import SettingsService
+        client_id_setting = await SettingsService.get_setting_by_key(session, DATABRICKS_OAUTH_CLIENT_ID_KEY)
+        if client_id_setting and client_id_setting.setting_value:
+            client_id = client_id_setting.setting_value
+            secret_setting = await SettingsService.get_setting_by_key(session, DATABRICKS_OAUTH_CLIENT_SECRET_KEY)
+            client_secret = ""
+            if secret_setting and secret_setting.setting_value:
+                try:
+                    decrypted = await CryptoService.decrypt_config(secret_setting.setting_value, session)
+                    client_secret = decrypted.get("value", "")
+                except Exception:
+                    logger.error("[DATABRICKS OAUTH] Failed to decrypt client secret")
+            return client_id, client_secret
 
-    client_id_setting = await SettingsService.get_setting_by_key(session, DATABRICKS_OAUTH_CLIENT_ID_KEY)
-    if not client_id_setting:
-        return "", ""
-
-    client_id = client_id_setting.setting_value
-    secret_setting = await SettingsService.get_setting_by_key(session, DATABRICKS_OAUTH_CLIENT_SECRET_KEY)
-    if not secret_setting:
-        return client_id, ""
-
-    try:
-        decrypted = await CryptoService.decrypt_config(secret_setting.setting_value, session)
-        client_secret = decrypted.get("value", "")
-    except Exception:
-        logger.error("[DATABRICKS OAUTH] Failed to decrypt client secret")
-        return client_id, ""
-
-    return client_id, client_secret
+    return DATABRICKS_PUBLIC_CLIENT_ID, ""
 
 
 async def is_oauth_configured(session: AsyncSession | None = None) -> bool:
-    client_id, client_secret = await get_oauth_credentials(session)
-    return bool(client_id and client_secret)
+    """Hosted mode requires admin-supplied credentials; desktop/local always
+    works via the public client."""
+    if not is_self_hosted():
+        return True
+    client_id, _ = await get_oauth_credentials(session)
+    return bool(client_id) and client_id != DATABRICKS_PUBLIC_CLIENT_ID
+
+
+_SUCCESS_PAGE = (
+    b"<!doctype html><html><head><title>Databricks Connected</title>"
+    b"<style>body{font-family:system-ui;background:#0d0d0d;color:#eee;"
+    b"display:flex;align-items:center;justify-content:center;height:100vh;margin:0}</style>"
+    b"</head><body><div style='text-align:center'>"
+    b"<h2 style='color:#ff7a00'>Databricks connected</h2>"
+    b"<p>You can close this tab and return to Byaan.</p>"
+    b"</div></body></html>"
+)
+
+_ERROR_PAGE_TEMPLATE = (
+    "<!doctype html><html><head><title>Databricks Error</title>"
+    "<style>body{{font-family:system-ui;background:#0d0d0d;color:#eee;"
+    "display:flex;align-items:center;justify-content:center;height:100vh;margin:0}}</style>"
+    "</head><body><div style='text-align:center;max-width:560px'>"
+    "<h2 style='color:#f87171'>Databricks sign-in failed</h2>"
+    "<p style='color:#aaa'>{message}</p></div></body></html>"
+)
+
+_active_loopback_servers: dict[str, asyncio.AbstractServer] = {}
 
 
 async def create_auth_url(
@@ -143,6 +177,11 @@ async def create_auth_url(
     }
     logger.info(f"[DATABRICKS OAUTH] Created auth URL for host={host} state={state[:16]}...")
 
+    # databricks-cli public client only accepts http://localhost:8020 as redirect,
+    # so for that flow we must run a loopback listener to receive the code.
+    if redirect_uri == DATABRICKS_PUBLIC_REDIRECT_URI:
+        await _start_loopback_listener(state, client_id)
+
     params = {
         "client_id": client_id,
         "response_type": "code",
@@ -153,6 +192,109 @@ async def create_auth_url(
         "code_challenge_method": "S256",
     }
     return f"{_authorize_url(host)}?{urlencode(params)}", state
+
+
+async def _start_loopback_listener(state: str, client_id: str) -> None:
+    """Bind 127.0.0.1:8020 and wait for the first callback hit. On hit,
+    parse code+state from the GET query, exchange for tokens, store result,
+    and close the listener. Auto-closes on timeout."""
+
+    done = asyncio.Event()
+
+    async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        terminate = False
+        try:
+            request_line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+            try:
+                method, path, _ = request_line.decode("latin-1").split(" ", 2)
+            except ValueError:
+                return
+            while True:
+                line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+                if line in (b"\r\n", b"\n", b""):
+                    break
+
+            qs = parse_qs(urlparse(path).query)
+            code = (qs.get("code") or [None])[0]
+            cb_state = (qs.get("state") or [None])[0]
+            err = (qs.get("error_description") or qs.get("error") or [None])[0]
+
+            # Ignore stray hits (favicon, preflight, browser probes) without
+            # tearing down the listener — only a payload that carries the
+            # OAuth response should complete the flow.
+            if not (code or err):
+                writer.write(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                await writer.drain()
+                return
+
+            terminate = True
+
+            if err or not code or not cb_state:
+                body = _ERROR_PAGE_TEMPLATE.format(message=err or "Missing code/state").encode()
+                writer.write(
+                    b"HTTP/1.1 400 Bad Request\r\nContent-Type: text/html; charset=utf-8\r\n"
+                    b"Content-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+                )
+                await writer.drain()
+                logger.error(f"[DATABRICKS OAUTH] Loopback callback error: {err}")
+                return
+
+            stored = peek_state(cb_state)
+            try:
+                tokens = await exchange_code(code=code, state=cb_state, client_id=client_id, client_secret="")
+                store_result(cb_state, tokens, stored)
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n"
+                    b"Content-Length: " + str(len(_SUCCESS_PAGE)).encode() + b"\r\n\r\n" + _SUCCESS_PAGE
+                )
+            except Exception as e:
+                logger.error(f"[DATABRICKS OAUTH] Token exchange failed in loopback: {e}", exc_info=True)
+                body = _ERROR_PAGE_TEMPLATE.format(message=str(e)).encode()
+                writer.write(
+                    b"HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/html; charset=utf-8\r\n"
+                    b"Content-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+                )
+            await writer.drain()
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+            if terminate:
+                done.set()
+
+    try:
+        server = await asyncio.start_server(handle_client, host="0.0.0.0", port=DATABRICKS_LOOPBACK_PORT)
+    except OSError as e:
+        _oauth_state_store.pop(state, None)
+        raise ValueError(
+            f"Could not bind localhost:{DATABRICKS_LOOPBACK_PORT} for Databricks OAuth callback. "
+            "Make sure no other process (e.g. databricks CLI) is using that port, then retry."
+        ) from e
+
+    _active_loopback_servers[state] = server
+    logger.info(f"[DATABRICKS OAUTH] Loopback listener bound on 127.0.0.1:{DATABRICKS_LOOPBACK_PORT} state={state[:16]}...")
+
+    async def _serve_until_done() -> None:
+        try:
+            await asyncio.wait_for(done.wait(), timeout=DATABRICKS_LOOPBACK_TIMEOUT_SECONDS)
+        except TimeoutError:
+            logger.warning(f"[DATABRICKS OAUTH] Loopback listener timed out state={state[:16]}...")
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("[DATABRICKS OAUTH] Loopback server crashed")
+        finally:
+            server.close()
+            try:
+                await server.wait_closed()
+            except Exception:
+                pass
+            _active_loopback_servers.pop(state, None)
+            _oauth_state_store.pop(state, None)
+
+    asyncio.create_task(_serve_until_done())
 
 
 def pop_state(state: str) -> dict[str, Any] | None:

--- a/server/services/databricks_oauth_service.py
+++ b/server/services/databricks_oauth_service.py
@@ -1,0 +1,299 @@
+"""
+Databricks OAuth (U2M) PKCE Service
+-----------------------------------
+Authorization Code + PKCE flow against a Databricks workspace OIDC endpoint.
+Modelled on `github_service.py` for credential storage and on
+`claude_oauth_service.py` for PKCE mechanics.
+
+Per-workspace endpoints:
+    https://<server_hostname>/oidc/v1/authorize
+    https://<server_hostname>/oidc/v1/token
+
+Admins register Byaan once as a custom OAuth app integration in their
+Databricks account and paste client_id + client_secret in Settings.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+import time
+from typing import Any
+from urllib.parse import urlencode
+from uuid import UUID
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.utils.config_loader import get_databricks_oauth_config, get_email_config, is_self_hosted
+from server.utils.custom_logger import get_logger
+
+logger = get_logger(__name__)
+
+_oauth_config = get_databricks_oauth_config()
+DATABRICKS_CLIENT_ID = _oauth_config.get("client_id") or ""
+DATABRICKS_CLIENT_SECRET = _oauth_config.get("client_secret") or ""
+
+DATABRICKS_OAUTH_CLIENT_ID_KEY = "databricks_oauth_client_id"
+DATABRICKS_OAUTH_CLIENT_SECRET_KEY = "databricks_oauth_client_secret"
+
+DATABRICKS_SCOPES = "sql offline_access all-apis"
+
+REFRESH_SKEW_SECONDS = 300
+RESULT_TTL_SECONDS = 300
+
+_oauth_state_store: dict[str, dict[str, Any]] = {}
+_oauth_result_store: dict[str, dict[str, Any]] = {}
+
+
+def _get_frontend_url() -> str:
+    url = os.getenv("FRONTEND_URL", "").rstrip("/")
+    if url:
+        return url
+    if is_self_hosted():
+        return get_email_config().get("frontend_url", "").rstrip("/")
+    return ""
+
+
+def get_redirect_uri() -> str:
+    frontend_url = _get_frontend_url()
+    if frontend_url:
+        return f"{frontend_url}/api/connections/databricks/oauth/callback"
+    return "byaan://databricks/callback"
+
+
+def _normalize_host(server_hostname: str) -> str:
+    host = server_hostname.strip()
+    if host.startswith("http://") or host.startswith("https://"):
+        host = host.split("://", 1)[1]
+    return host.rstrip("/")
+
+
+def _authorize_url(host: str) -> str:
+    return f"https://{host}/oidc/v1/authorize"
+
+
+def _token_url(host: str) -> str:
+    return f"https://{host}/oidc/v1/token"
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    code_verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return code_verifier, code_challenge
+
+
+async def get_oauth_credentials(session: AsyncSession | None = None) -> tuple[str, str]:
+    """Return (client_id, client_secret). Settings-backed in self-hosted, env-backed otherwise."""
+    if not is_self_hosted():
+        return DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
+
+    if not session:
+        return "", ""
+
+    from server.services.crypto_service import CryptoService
+    from server.services.settings import SettingsService
+
+    client_id_setting = await SettingsService.get_setting_by_key(session, DATABRICKS_OAUTH_CLIENT_ID_KEY)
+    if not client_id_setting:
+        return "", ""
+
+    client_id = client_id_setting.setting_value
+    secret_setting = await SettingsService.get_setting_by_key(session, DATABRICKS_OAUTH_CLIENT_SECRET_KEY)
+    if not secret_setting:
+        return client_id, ""
+
+    try:
+        decrypted = await CryptoService.decrypt_config(secret_setting.setting_value, session)
+        client_secret = decrypted.get("value", "")
+    except Exception:
+        logger.error("[DATABRICKS OAUTH] Failed to decrypt client secret")
+        return client_id, ""
+
+    return client_id, client_secret
+
+
+async def is_oauth_configured(session: AsyncSession | None = None) -> bool:
+    client_id, client_secret = await get_oauth_credentials(session)
+    return bool(client_id and client_secret)
+
+
+async def create_auth_url(
+    server_hostname: str,
+    client_id: str,
+    tenant_id: UUID | None = None,
+    user_id: UUID | None = None,
+    redirect_uri: str | None = None,
+) -> tuple[str, str]:
+    host = _normalize_host(server_hostname)
+    redirect_uri = redirect_uri or get_redirect_uri()
+    code_verifier, code_challenge = generate_pkce_pair()
+    state = secrets.token_urlsafe(32)
+
+    _oauth_state_store[state] = {
+        "code_verifier": code_verifier,
+        "server_hostname": host,
+        "redirect_uri": redirect_uri,
+        "tenant_id": str(tenant_id) if tenant_id else None,
+        "user_id": str(user_id) if user_id else None,
+        "created_at": time.time(),
+    }
+    logger.info(f"[DATABRICKS OAUTH] Created auth URL for host={host} state={state[:16]}...")
+
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "scope": DATABRICKS_SCOPES,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{_authorize_url(host)}?{urlencode(params)}", state
+
+
+def pop_state(state: str) -> dict[str, Any] | None:
+    return _oauth_state_store.pop(state, None)
+
+
+def peek_state(state: str) -> dict[str, Any] | None:
+    return _oauth_state_store.get(state)
+
+
+async def exchange_code(
+    code: str,
+    state: str,
+    client_id: str,
+    client_secret: str,
+) -> dict[str, Any]:
+    """Exchange auth code for tokens. Pops the state entry on success.
+
+    Returns the raw Databricks token response augmented with `expires_at` (epoch s)
+    and `server_hostname` (so the connector can refresh later without needing the
+    workspace URL re-supplied).
+    """
+    stored = _oauth_state_store.pop(state, None)
+    if not stored:
+        raise ValueError("Invalid or expired state parameter. Please restart the authentication flow.")
+
+    host = stored["server_hostname"]
+    redirect_uri = stored["redirect_uri"]
+    code_verifier = stored["code_verifier"]
+
+    logger.info(f"[DATABRICKS OAUTH] Exchanging code for tokens at {host}")
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            _token_url(host),
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "code_verifier": code_verifier,
+            },
+            auth=(client_id, client_secret) if client_secret else None,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    if response.status_code != 200:
+        logger.error(f"[DATABRICKS OAUTH] Token exchange failed: {response.status_code} - {response.text}")
+        raise ValueError(f"Token exchange failed: {response.text}")
+
+    tokens = response.json()
+    tokens["server_hostname"] = host
+    tokens["expires_at"] = int(time.time()) + int(tokens.get("expires_in", 3600))
+    return tokens
+
+
+def store_result(state: str, tokens: dict[str, Any], stored_state: dict[str, Any] | None = None) -> None:
+    _oauth_result_store[state] = {
+        "tokens": tokens,
+        "stored_at": time.time(),
+        "context": stored_state or {},
+    }
+    _gc_results()
+
+
+def pop_result(state: str) -> dict[str, Any] | None:
+    _gc_results()
+    return _oauth_result_store.pop(state, None)
+
+
+def _gc_results() -> None:
+    now = time.time()
+    expired = [s for s, v in _oauth_result_store.items() if now - v["stored_at"] > RESULT_TTL_SECONDS]
+    for s in expired:
+        _oauth_result_store.pop(s, None)
+
+
+def is_oauth_block_expired(oauth_block: dict[str, Any]) -> bool:
+    expires_at = oauth_block.get("expires_at", 0)
+    return time.time() >= (expires_at - REFRESH_SKEW_SECONDS)
+
+
+async def refresh_databricks_token(
+    oauth_block: dict[str, Any],
+    client_id: str,
+    client_secret: str,
+) -> dict[str, Any]:
+    """Refresh using the stored refresh_token. Returns updated oauth block
+    (caller is responsible for persisting it back to the connection row)."""
+    host = oauth_block.get("server_hostname")
+    refresh_token = oauth_block.get("refresh_token")
+    if not host or not refresh_token:
+        raise ValueError("Cannot refresh Databricks token: missing server_hostname or refresh_token")
+
+    logger.info(f"[DATABRICKS OAUTH] Refreshing token for {host}")
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            _token_url(host),
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+            },
+            auth=(client_id, client_secret) if client_secret else None,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    if response.status_code != 200:
+        logger.error(f"[DATABRICKS OAUTH] Refresh failed: {response.status_code} - {response.text}")
+        raise ValueError(f"Token refresh failed: {response.text}")
+
+    new_tokens = response.json()
+    return {
+        "access_token": new_tokens["access_token"],
+        "refresh_token": new_tokens.get("refresh_token", refresh_token),
+        "expires_at": int(time.time()) + int(new_tokens.get("expires_in", 3600)),
+        "scope": new_tokens.get("scope", oauth_block.get("scope")),
+        "server_hostname": host,
+    }
+
+
+async def list_warehouses(server_hostname: str, access_token: str) -> list[dict[str, Any]]:
+    """Hit /api/2.0/sql/warehouses and return a normalized list for the picker UI."""
+    host = _normalize_host(server_hostname)
+    url = f"https://{host}/api/2.0/sql/warehouses"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(url, headers={"Authorization": f"Bearer {access_token}"})
+
+    if response.status_code != 200:
+        logger.error(f"[DATABRICKS OAUTH] list_warehouses failed: {response.status_code} - {response.text}")
+        raise ValueError(f"Could not list warehouses: {response.text}")
+
+    payload = response.json()
+    warehouses = payload.get("warehouses", []) or []
+    return [
+        {
+            "id": w.get("id"),
+            "name": w.get("name"),
+            "state": w.get("state"),
+            "size": w.get("cluster_size"),
+            "http_path": f"/sql/1.0/warehouses/{w.get('id')}",
+        }
+        for w in warehouses
+        if w.get("id")
+    ]

--- a/server/services/databricks_oauth_service.py
+++ b/server/services/databricks_oauth_service.py
@@ -259,8 +259,8 @@ async def _start_loopback_listener(state: str, client_id: str) -> None:
             try:
                 writer.close()
                 await writer.wait_closed()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"[DATABRICKS OAUTH] Ignoring loopback writer close error: {e}", exc_info=True)
             if terminate:
                 done.set()
 
@@ -274,7 +274,9 @@ async def _start_loopback_listener(state: str, client_id: str) -> None:
         ) from e
 
     _active_loopback_servers[state] = server
-    logger.info(f"[DATABRICKS OAUTH] Loopback listener bound on 127.0.0.1:{DATABRICKS_LOOPBACK_PORT} state={state[:16]}...")
+    logger.info(
+        f"[DATABRICKS OAUTH] Loopback listener bound on 127.0.0.1:{DATABRICKS_LOOPBACK_PORT} state={state[:16]}..."
+    )
 
     async def _serve_until_done() -> None:
         try:

--- a/server/tests/test_databricks_connector.py
+++ b/server/tests/test_databricks_connector.py
@@ -12,9 +12,14 @@ def conn_obj():
     return {
         "server_hostname": "adb-1234.azuredatabricks.net",
         "http_path": "/sql/1.0/warehouses/abc123",
-        "access_token": "dapi-fake-token",
         "catalog": "main",
         "schema": "default",
+        "oauth": {
+            "access_token": "dapi-oauth-fake",
+            "refresh_token": "rt-fake",
+            "expires_at": 2**31 - 1,
+            "server_hostname": "adb-1234.azuredatabricks.net",
+        },
     }
 
 
@@ -39,6 +44,13 @@ def _fake_connection(cursor):
 async def test_connect_validates_required_fields():
     connector = AsyncDatabricksConnector({"server_hostname": "x"})
     with pytest.raises(ValueError, match="http_path"):
+        await connector.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_requires_oauth_access_token():
+    connector = AsyncDatabricksConnector({"server_hostname": "x", "http_path": "/y"})
+    with pytest.raises(ValueError, match="OAuth access_token"):
         await connector.connect()
 
 
@@ -136,8 +148,13 @@ async def test_get_schema_with_catalog_only_iterates_schemas():
     obj = {
         "server_hostname": "x",
         "http_path": "/y",
-        "access_token": "z",
         "catalog": "samples",
+        "oauth": {
+            "access_token": "z",
+            "refresh_token": "rt",
+            "expires_at": 2**31 - 1,
+            "server_hostname": "x",
+        },
     }
     schemas_cursor = _fake_cursor(
         rows=[("tpch",), ("information_schema",)],
@@ -176,7 +193,16 @@ async def test_get_schema_with_catalog_only_iterates_schemas():
 
 @pytest.mark.asyncio
 async def test_list_catalog_tree_returns_tree_excluding_system():
-    obj = {"server_hostname": "x", "http_path": "/y", "access_token": "z"}
+    obj = {
+        "server_hostname": "x",
+        "http_path": "/y",
+        "oauth": {
+            "access_token": "z",
+            "refresh_token": "rt",
+            "expires_at": 2**31 - 1,
+            "server_hostname": "x",
+        },
+    }
 
     catalogs_cursor = _fake_cursor(
         rows=[("main",), ("analytics",), ("system",)],
@@ -207,6 +233,53 @@ async def test_list_catalog_tree_returns_tree_excluding_system():
     assert "default" in main["schemas"]
     assert "gold" in main["schemas"]
     assert "information_schema" not in main["schemas"]
+
+
+@pytest.mark.asyncio
+async def test_expired_oauth_triggers_refresh_and_callback(conn_obj):
+    """When access_token is near expiry, connector calls the OAuth refresh helper
+    and invokes the on_token_refresh callback with the new oauth block."""
+    conn_obj["oauth"]["expires_at"] = 0  # forces refresh
+
+    cursor = _fake_cursor(rows=[(1,)], description=[("c", "INT", None, None, None, None, None)])
+    fake_conn = _fake_connection(cursor)
+
+    captured: dict = {}
+
+    async def cb(new_oauth):
+        captured.update(new_oauth)
+
+    refreshed = {
+        "access_token": "fresh-token",
+        "refresh_token": "rotated-rt",
+        "expires_at": 2**31 - 1,
+        "scope": "sql offline_access",
+        "server_hostname": conn_obj["server_hostname"],
+    }
+
+    from unittest.mock import AsyncMock
+
+    connector = AsyncDatabricksConnector(conn_obj, on_token_refresh=cb)
+
+    with (
+        patch("server.services.databricks_connector.sql.connect", return_value=fake_conn),
+        patch(
+            "server.services.databricks_oauth_service.refresh_databricks_token",
+            new=AsyncMock(return_value=refreshed),
+        ),
+        patch(
+            "server.services.databricks_oauth_service.get_oauth_credentials",
+            new=AsyncMock(return_value=("client-id", "client-secret")),
+        ),
+        patch("server.db.session.AsyncSessionFactory") as factory_mock,
+    ):
+        factory_mock.return_value.__aenter__.return_value = MagicMock()
+        factory_mock.return_value.__aexit__.return_value = False
+        await connector.connect()
+
+    assert captured["access_token"] == "fresh-token"
+    assert captured["refresh_token"] == "rotated-rt"
+    assert connector.connection_obj["oauth"]["access_token"] == "fresh-token"
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_databricks_oauth_service.py
+++ b/server/tests/test_databricks_oauth_service.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from server.services import databricks_oauth_service as svc
+
+
+def test_generate_pkce_pair_shape():
+    verifier, challenge = svc.generate_pkce_pair()
+    assert len(verifier) >= 43
+    assert len(challenge) >= 43
+    assert "=" not in challenge
+
+
+def test_normalize_host_strips_scheme_and_trailing_slash():
+    assert svc._normalize_host("https://adb-1.azuredatabricks.net/") == "adb-1.azuredatabricks.net"
+    assert svc._normalize_host("adb-2.azuredatabricks.net") == "adb-2.azuredatabricks.net"
+
+
+@pytest.mark.asyncio
+async def test_create_auth_url_stores_state():
+    url, state = await svc.create_auth_url(
+        server_hostname="adb-x.azuredatabricks.net",
+        client_id="cid",
+        redirect_uri="http://localhost:17433/cb",
+    )
+    assert "oidc/v1/authorize" in url
+    assert "code_challenge=" in url
+    assert "scope=sql+offline_access+all-apis" in url
+    stored = svc.peek_state(state)
+    assert stored is not None
+    assert stored["server_hostname"] == "adb-x.azuredatabricks.net"
+    svc.pop_state(state)
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_invalid_state_raises():
+    with pytest.raises(ValueError, match="Invalid or expired state"):
+        await svc.exchange_code("code", "missing-state", "cid", "secret")
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_success():
+    _, state = await svc.create_auth_url(
+        server_hostname="adb-x.azuredatabricks.net",
+        client_id="cid",
+        redirect_uri="http://localhost/cb",
+    )
+
+    response = httpx.Response(
+        200,
+        json={
+            "access_token": "AT",
+            "refresh_token": "RT",
+            "expires_in": 3600,
+            "scope": "sql offline_access all-apis",
+            "token_type": "Bearer",
+        },
+    )
+
+    async def _post(*a, **k):
+        return response
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(side_effect=_post)):
+        tokens = await svc.exchange_code("code-xyz", state, "cid", "secret")
+
+    assert tokens["access_token"] == "AT"
+    assert tokens["refresh_token"] == "RT"
+    assert tokens["server_hostname"] == "adb-x.azuredatabricks.net"
+    assert tokens["expires_at"] > time.time()
+
+
+@pytest.mark.asyncio
+async def test_refresh_databricks_token_rotates_and_recomputes_expiry():
+    response = httpx.Response(
+        200,
+        json={"access_token": "new-AT", "refresh_token": "new-RT", "expires_in": 1800, "scope": "sql"},
+    )
+
+    async def _post(*a, **k):
+        return response
+
+    oauth = {
+        "access_token": "old-AT",
+        "refresh_token": "old-RT",
+        "expires_at": 0,
+        "server_hostname": "adb-x.azuredatabricks.net",
+    }
+    with patch("httpx.AsyncClient.post", new=AsyncMock(side_effect=_post)):
+        out = await svc.refresh_databricks_token(oauth, "cid", "secret")
+
+    assert out["access_token"] == "new-AT"
+    assert out["refresh_token"] == "new-RT"
+    assert out["expires_at"] > time.time()
+
+
+def test_is_oauth_block_expired_within_skew():
+    assert svc.is_oauth_block_expired({"expires_at": int(time.time()) + 100}) is True
+    assert svc.is_oauth_block_expired({"expires_at": int(time.time()) + 3600}) is False
+
+
+def test_result_store_roundtrip_and_pop():
+    svc.store_result("st-1", {"access_token": "a", "expires_at": 1, "server_hostname": "h"})
+    entry = svc.pop_result("st-1")
+    assert entry is not None
+    assert entry["tokens"]["access_token"] == "a"
+    assert svc.pop_result("st-1") is None
+
+
+@pytest.mark.asyncio
+async def test_list_warehouses_normalizes_response():
+    response = httpx.Response(
+        200,
+        json={
+            "warehouses": [
+                {"id": "w1", "name": "Big", "state": "RUNNING", "cluster_size": "XL"},
+                {"id": "w2", "name": "Small", "state": "STOPPED", "cluster_size": "S"},
+            ]
+        },
+    )
+
+    async def _get(*a, **k):
+        return response
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=_get)):
+        out = await svc.list_warehouses("adb-x.azuredatabricks.net", "AT")
+
+    assert [w["id"] for w in out] == ["w1", "w2"]
+    assert out[0]["http_path"] == "/sql/1.0/warehouses/w1"

--- a/server/utils/config_loader.py
+++ b/server/utils/config_loader.py
@@ -223,35 +223,6 @@ def get_github_oauth_config() -> dict[str, str | None]:
         }
 
 
-def get_databricks_oauth_config() -> dict[str, str | None]:
-    try:
-        import os
-
-        config = load_config()
-        databricks_config = config.get("databricks", {})
-        client_id = databricks_config.get("client_id")
-        client_secret = databricks_config.get("client_secret")
-
-        if not client_id:
-            client_id = os.getenv("DATABRICKS_OAUTH_CLIENT_ID")
-        if not client_secret:
-            client_secret = os.getenv("DATABRICKS_OAUTH_CLIENT_SECRET")
-
-        return {"client_id": client_id, "client_secret": client_secret}
-    except Exception as e:
-        import os
-
-        logger.error(
-            f"Failed to get Databricks OAuth config: {str(e)}",
-            exc_info=True,
-            posthog_context={"function": "get_databricks_oauth_config"},
-        )
-        return {
-            "client_id": os.getenv("DATABRICKS_OAUTH_CLIENT_ID"),
-            "client_secret": os.getenv("DATABRICKS_OAUTH_CLIENT_SECRET"),
-        }
-
-
 def get_deployment_config() -> dict[str, Any]:
     """
     Get deployment configuration from config.json.

--- a/server/utils/config_loader.py
+++ b/server/utils/config_loader.py
@@ -223,6 +223,35 @@ def get_github_oauth_config() -> dict[str, str | None]:
         }
 
 
+def get_databricks_oauth_config() -> dict[str, str | None]:
+    try:
+        import os
+
+        config = load_config()
+        databricks_config = config.get("databricks", {})
+        client_id = databricks_config.get("client_id")
+        client_secret = databricks_config.get("client_secret")
+
+        if not client_id:
+            client_id = os.getenv("DATABRICKS_OAUTH_CLIENT_ID")
+        if not client_secret:
+            client_secret = os.getenv("DATABRICKS_OAUTH_CLIENT_SECRET")
+
+        return {"client_id": client_id, "client_secret": client_secret}
+    except Exception as e:
+        import os
+
+        logger.error(
+            f"Failed to get Databricks OAuth config: {str(e)}",
+            exc_info=True,
+            posthog_context={"function": "get_databricks_oauth_config"},
+        )
+        return {
+            "client_id": os.getenv("DATABRICKS_OAUTH_CLIENT_ID"),
+            "client_secret": os.getenv("DATABRICKS_OAUTH_CLIENT_SECRET"),
+        }
+
+
 def get_deployment_config() -> dict[str, Any]:
     """
     Get deployment configuration from config.json.

--- a/server/utils/deployment.py
+++ b/server/utils/deployment.py
@@ -19,11 +19,12 @@ if TYPE_CHECKING:
 
 
 def get_feature_flags() -> dict[str, bool]:
-    from server.utils.config_loader import should_hide_email_auth
+    from server.utils.config_loader import get_google_oauth_config, should_hide_email_auth
 
     self_hosted = is_self_hosted()
+    google_configured = bool(get_google_oauth_config().get("client_id"))
 
-    email_auth_enabled = not self_hosted
+    email_auth_enabled = (not self_hosted) or (not google_configured)
     if should_hide_email_auth():
         email_auth_enabled = False
 
@@ -33,7 +34,7 @@ def get_feature_flags() -> dict[str, bool]:
         "public_registration_enabled": False,  # Removed with SaaS
         "local_auth_enabled": email_auth_enabled,
         "invitation_only": self_hosted,
-        "google_oauth_enabled": self_hosted,
+        "google_oauth_enabled": self_hosted and google_configured,
         "team_sharing_enabled": self_hosted,
         "enterprise_licensed": self_hosted,
     }


### PR DESCRIPTION
## Summary

Add Databricks connector using OAuth User-to-Machine (U2M) flow instead of Personal Access Tokens. Admin-side OAuth client config, loopback callback server, and a setup guide make the flow usable on both web and the Tauri desktop app.

- Replace PAT auth with OAuth U2M; add admin OAuth config UI/storage
- Expose loopback port and gate auth flags on Google config; auto-close OAuth tab after success
- Open OAuth URL via Tauri shell so the Mac app launches the system browser
- Docs link directly to the Databricks App integrations page in the OAuth setup guide
  
## Testing

- [x] Backend tests run, or not applicable
- [x] Frontend build/lint run, or not applicable
- [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
- [x] Docs updated, or not applicable

## Security And Data Access

- [x] This change does not weaken read-only database guardrails
- [x] This change does not expose secrets, credentials, private schemas, or sensitive data — OAuth tokens stored same as other connector creds; no PAT persisted
- [x] This change does not add a privileged workflow path for untrusted pull request code
- [x] New database/MCP/auth behavior is documented — OAuth setup guide included

## Notes

- Users must register an OAuth app in Databricks Account Console (App integrations) before connecting; redirect URI is the loopback port exposed by the backend.
- Desktop app requires Tauri shell permission for opening external URLs.
- Follow-up: surface clearer error when admin OAuth config missing.
