### PR TITLE
fix: cancellable Databricks OAuth, hostname normalization, and resili…

### DIFF
--- a/client/src/components/DatabaseConnectionDialog.tsx
+++ b/client/src/components/DatabaseConnectionDialog.tsx
@@ -139,6 +139,8 @@ export function DatabaseConnectionDialog({
   const [showManageDatabricksOAuth, setShowManageDatabricksOAuth] = useState<boolean>(false)
   const [oauthTokens, setOauthTokens] = useState<DatabricksOAuthTokens | null>(null)
   const [, setOauthState] = useState<string | null>(null)
+  const oauthStateRef = useRef<string | null>(null)
+  const oauthAbortRef = useRef<AbortController | null>(null)
   const [oauthSigningIn, setOauthSigningIn] = useState(false)
   const [oauthError, setOauthError] = useState<string | null>(null)
   const [warehouses, setWarehouses] = useState<DatabricksWarehouse[] | null>(null)
@@ -161,6 +163,20 @@ export function DatabaseConnectionDialog({
     if (open) refreshDatabricksAuthStatus()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
+
+  useEffect(() => {
+    return () => {
+      if (oauthAbortRef.current) {
+        oauthAbortRef.current.abort()
+        oauthAbortRef.current = null
+      }
+      const pendingState = oauthStateRef.current
+      if (pendingState) {
+        ApiService.cancelDatabricksOAuth(pendingState).catch(() => {})
+        oauthStateRef.current = null
+      }
+    }
+  }, [])
 
   const databricksTileVisible = !isSelfHosted || databricksOAuthConfigured || databricksOAuthCanConfigure
 
@@ -253,6 +269,15 @@ export function DatabaseConnectionDialog({
   }, [selectedType, connectionConfig, uploadFileType, uploadFiles, uploadURLs, databricksStep, selectedPairs, oauthTokens, selectedWarehouseId])
 
   const resetDatabricksWizard = () => {
+    if (oauthAbortRef.current) {
+      oauthAbortRef.current.abort()
+      oauthAbortRef.current = null
+    }
+    const pendingState = oauthStateRef.current
+    if (pendingState) {
+      ApiService.cancelDatabricksOAuth(pendingState).catch(() => {})
+    }
+    oauthStateRef.current = null
     setDatabricksStep(1)
     setOauthTokens(null)
     setOauthState(null)
@@ -395,38 +420,96 @@ export function DatabaseConnectionDialog({
   const isPairSelected = (pair: DatabricksPair) =>
     selectedPairs.some(p => pairKey(p) === pairKey(pair))
 
+  const handleCancelDatabricksSignIn = () => {
+    const pendingState = oauthStateRef.current
+    if (oauthAbortRef.current) {
+      oauthAbortRef.current.abort()
+      oauthAbortRef.current = null
+    }
+    if (pendingState) {
+      ApiService.cancelDatabricksOAuth(pendingState).catch(() => {})
+    }
+    oauthStateRef.current = null
+    setOauthState(null)
+    setOauthSigningIn(false)
+    setOauthError(null)
+  }
+
+  const normalizeDatabricksHost = (raw: string): string => {
+    let h = raw.trim()
+    const schemeIdx = h.indexOf('://')
+    if (schemeIdx !== -1) h = h.slice(schemeIdx + 3)
+    h = h.split('/')[0].split('?')[0]
+    return h.trim().replace(/\.+$/, '')
+  }
+
   const handleDatabricksSignIn = async () => {
-    if (!connectionConfig.serverHostname.trim()) {
+    const normalizedHost = normalizeDatabricksHost(connectionConfig.serverHostname)
+    if (!normalizedHost) {
       setOauthError('Enter your Databricks workspace URL first')
       return
     }
+    if (normalizedHost !== connectionConfig.serverHostname) {
+      setConnectionConfig(prev => ({ ...prev, serverHostname: normalizedHost }))
+    }
+    if (oauthAbortRef.current) {
+      oauthAbortRef.current.abort()
+    }
+    const controller = new AbortController()
+    oauthAbortRef.current = controller
+    const { signal } = controller
     setOauthError(null)
     setOauthSigningIn(true)
     try {
-      const { auth_url, state } = await ApiService.startDatabricksOAuth(connectionConfig.serverHostname.trim())
+      const { auth_url, state } = await ApiService.startDatabricksOAuth(normalizedHost)
+      if (signal.aborted) return
+      oauthStateRef.current = state
       setOauthState(state)
       await openExternalUrl(auth_url)
+      if (signal.aborted) return
+
+      const sleep = (ms: number) => new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          signal.removeEventListener('abort', onAbort)
+          resolve()
+        }, ms)
+        const onAbort = () => {
+          clearTimeout(timer)
+          reject(new DOMException('aborted', 'AbortError'))
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+      })
 
       const deadline = Date.now() + 5 * 60 * 1000
       while (Date.now() < deadline) {
-        await new Promise(r => setTimeout(r, 2000))
+        await sleep(2000)
+        if (signal.aborted) return
         try {
           const res = await ApiService.pollDatabricksOAuthResult(state)
+          if (signal.aborted) return
           if (res.status === 'success' && res.tokens) {
+            oauthStateRef.current = null
             setOauthTokens(res.tokens)
             setConnectionConfig(prev => ({ ...prev, serverHostname: res.tokens!.server_hostname }))
             await loadWarehouses(res.tokens.server_hostname, res.tokens.access_token)
             return
           }
         } catch (err: any) {
+          if (signal.aborted) return
           console.warn('OAuth poll failed:', err?.message)
         }
       }
-      setOauthError('Sign-in timed out. Please try again.')
+      if (!signal.aborted) setOauthError('Sign-in timed out. Please try again.')
     } catch (err: any) {
+      if (err?.name === 'AbortError' || signal.aborted) return
       setOauthError(err?.message || 'Failed to start Databricks sign-in')
     } finally {
-      setOauthSigningIn(false)
+      if (!signal.aborted) {
+        setOauthSigningIn(false)
+      }
+      if (oauthAbortRef.current === controller) {
+        oauthAbortRef.current = null
+      }
     }
   }
 
@@ -1217,21 +1300,37 @@ export function DatabaseConnectionDialog({
                           disabled={isLoading || oauthSigningIn || !!oauthTokens}
                           className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
                         />
-                        <p className="text-xs text-gray-400 mt-1">No scheme — just the host, e.g. <code>adb-1234.azuredatabricks.net</code>.</p>
+                        <p className="text-xs text-gray-400 mt-1">
+                          Enter the <strong>Server hostname</strong> only — no <code>https://</code>, no path. Example: <code>adb-1234.azuredatabricks.net</code>.
+                        </p>
                       </div>
 
                       {!oauthTokens ? (
-                        <Button
-                          onClick={handleDatabricksSignIn}
-                          disabled={isLoading || oauthSigningIn || !connectionConfig.serverHostname.trim()}
-                          className="w-full bg-brand-orange hover:bg-brand-orange/90"
-                        >
-                          {oauthSigningIn ? (
-                            <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Waiting for sign-in…</>
-                          ) : (
-                            <>Sign in with Databricks</>
-                          )}
-                        </Button>
+                        oauthSigningIn ? (
+                          <div className="flex gap-2">
+                            <Button
+                              disabled
+                              className="flex-1 bg-brand-orange/70 hover:bg-brand-orange/70 cursor-default"
+                            >
+                              <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Waiting for sign-in…
+                            </Button>
+                            <Button
+                              type="button"
+                              onClick={handleCancelDatabricksSignIn}
+                              className="bg-[#2a2a2a] hover:bg-[#3a3a3a] border border-[#555555] text-white"
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            onClick={handleDatabricksSignIn}
+                            disabled={isLoading || !connectionConfig.serverHostname.trim()}
+                            className="w-full bg-brand-orange hover:bg-brand-orange/90"
+                          >
+                            Sign in with Databricks
+                          </Button>
+                        )
                       ) : (
                         <div className="flex items-start gap-2 bg-green-900/20 border border-green-700/50 rounded-md p-3 text-sm text-green-200">
                           <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -96,6 +96,8 @@ export default function DatabasesPage() {
   const [databricksOAuthCanConfigure, setDatabricksOAuthCanConfigure] = useState<boolean>(false)
   const [showManageDatabricksOAuth, setShowManageDatabricksOAuth] = useState<boolean>(false)
   const [oauthTokens, setOauthTokens] = useState<DatabricksOAuthTokens | null>(null)
+  const oauthStateRef = useRef<string | null>(null)
+  const oauthAbortRef = useRef<AbortController | null>(null)
   const [oauthSigningIn, setOauthSigningIn] = useState(false)
   const [oauthError, setOauthError] = useState<string | null>(null)
   const [warehouses, setWarehouses] = useState<DatabricksWarehouse[] | null>(null)
@@ -231,6 +233,15 @@ export default function DatabasesPage() {
   }, [selectedType, connectionConfig, databricksStep, selectedPairs, oauthTokens, selectedWarehouseId])
 
   const resetDatabricksWizard = () => {
+    if (oauthAbortRef.current) {
+      oauthAbortRef.current.abort()
+      oauthAbortRef.current = null
+    }
+    const pendingState = oauthStateRef.current
+    if (pendingState) {
+      ApiService.cancelDatabricksOAuth(pendingState).catch(() => {})
+    }
+    oauthStateRef.current = null
     setDatabricksStep(1)
     setDiscoveredCatalogs(null)
     setDiscovering(false)
@@ -248,6 +259,20 @@ export default function DatabasesPage() {
     setLoadingWarehouses(false)
   }
 
+  useEffect(() => {
+    return () => {
+      if (oauthAbortRef.current) {
+        oauthAbortRef.current.abort()
+        oauthAbortRef.current = null
+      }
+      const pendingState = oauthStateRef.current
+      if (pendingState) {
+        ApiService.cancelDatabricksOAuth(pendingState).catch(() => {})
+        oauthStateRef.current = null
+      }
+    }
+  }, [])
+
   const loadWarehouses = async (host: string, token: string) => {
     setLoadingWarehouses(true)
     try {
@@ -261,36 +286,94 @@ export default function DatabasesPage() {
     }
   }
 
+  const normalizeDatabricksHost = (raw: string): string => {
+    let h = raw.trim()
+    const schemeIdx = h.indexOf('://')
+    if (schemeIdx !== -1) h = h.slice(schemeIdx + 3)
+    h = h.split('/')[0].split('?')[0]
+    return h.trim().replace(/\.+$/, '')
+  }
+
+  const handleCancelDatabricksSignIn = () => {
+    const pendingState = oauthStateRef.current
+    if (oauthAbortRef.current) {
+      oauthAbortRef.current.abort()
+      oauthAbortRef.current = null
+    }
+    if (pendingState) {
+      ApiService.cancelDatabricksOAuth(pendingState).catch(() => {})
+    }
+    oauthStateRef.current = null
+    setOauthSigningIn(false)
+    setOauthError(null)
+  }
+
   const handleDatabricksSignIn = async () => {
-    if (!connectionConfig.serverHostname.trim()) {
+    const normalizedHost = normalizeDatabricksHost(connectionConfig.serverHostname)
+    if (!normalizedHost) {
       setOauthError('Enter your Databricks workspace URL first')
       return
     }
+    if (normalizedHost !== connectionConfig.serverHostname) {
+      setConnectionConfig(prev => ({ ...prev, serverHostname: normalizedHost }))
+    }
+    if (oauthAbortRef.current) {
+      oauthAbortRef.current.abort()
+    }
+    const controller = new AbortController()
+    oauthAbortRef.current = controller
+    const { signal } = controller
     setOauthError(null)
     setOauthSigningIn(true)
     try {
-      const { auth_url, state } = await ApiService.startDatabricksOAuth(connectionConfig.serverHostname.trim())
+      const { auth_url, state } = await ApiService.startDatabricksOAuth(normalizedHost)
+      if (signal.aborted) return
+      oauthStateRef.current = state
       await openExternalUrl(auth_url)
+      if (signal.aborted) return
+
+      const sleep = (ms: number) => new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          signal.removeEventListener('abort', onAbort)
+          resolve()
+        }, ms)
+        const onAbort = () => {
+          clearTimeout(timer)
+          reject(new DOMException('aborted', 'AbortError'))
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+      })
+
       const deadline = Date.now() + 5 * 60 * 1000
       while (Date.now() < deadline) {
-        await new Promise(r => setTimeout(r, 2000))
+        await sleep(2000)
+        if (signal.aborted) return
         try {
           const res = await ApiService.pollDatabricksOAuthResult(state)
+          if (signal.aborted) return
           if (res.status === 'success' && res.tokens) {
+            oauthStateRef.current = null
             setOauthTokens(res.tokens)
             setConnectionConfig(prev => ({ ...prev, serverHostname: res.tokens!.server_hostname }))
             await loadWarehouses(res.tokens.server_hostname, res.tokens.access_token)
             return
           }
         } catch (err: any) {
+          if (signal.aborted) return
           console.warn('OAuth poll failed:', err?.message)
         }
       }
-      setOauthError('Sign-in timed out. Please try again.')
+      if (!signal.aborted) setOauthError('Sign-in timed out. Please try again.')
     } catch (err: any) {
+      if (err?.name === 'AbortError' || signal.aborted) return
       setOauthError(err?.message || 'Failed to start Databricks sign-in')
     } finally {
-      setOauthSigningIn(false)
+      if (!signal.aborted) {
+        setOauthSigningIn(false)
+      }
+      if (oauthAbortRef.current === controller) {
+        oauthAbortRef.current = null
+      }
     }
   }
 
@@ -1626,21 +1709,37 @@ export default function DatabasesPage() {
                             disabled={oauthSigningIn || !!oauthTokens}
                             className="mt-1 bg-[#1a1a1a] border-[#555555] text-white font-mono text-sm"
                           />
-                          <p className="text-xs text-gray-400 mt-1">No scheme — just the host, e.g. <code>adb-1234.azuredatabricks.net</code>.</p>
+                          <p className="text-xs text-gray-400 mt-1">
+                            Enter the <strong>Server hostname</strong> only — no <code>https://</code>, no path. Example: <code>adb-1234.azuredatabricks.net</code>.
+                          </p>
                         </div>
 
                         {!oauthTokens ? (
-                          <Button
-                            onClick={handleDatabricksSignIn}
-                            disabled={oauthSigningIn || !connectionConfig.serverHostname.trim()}
-                            className="w-full bg-brand-orange hover:bg-brand-orange/90"
-                          >
-                            {oauthSigningIn ? (
-                              <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Waiting for sign-in…</>
-                            ) : (
-                              <>Sign in with Databricks</>
-                            )}
-                          </Button>
+                          oauthSigningIn ? (
+                            <div className="flex gap-2">
+                              <Button
+                                disabled
+                                className="flex-1 bg-brand-orange/70 hover:bg-brand-orange/70 cursor-default"
+                              >
+                                <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Waiting for sign-in…
+                              </Button>
+                              <Button
+                                type="button"
+                                onClick={handleCancelDatabricksSignIn}
+                                className="bg-[#2a2a2a] hover:bg-[#3a3a3a] border border-[#555555] text-white"
+                              >
+                                Cancel
+                              </Button>
+                            </div>
+                          ) : (
+                            <Button
+                              onClick={handleDatabricksSignIn}
+                              disabled={!connectionConfig.serverHostname.trim()}
+                              className="w-full bg-brand-orange hover:bg-brand-orange/90"
+                            >
+                              Sign in with Databricks
+                            </Button>
+                          )
                         ) : (
                           <div className="flex items-start gap-2 bg-green-900/20 border border-green-700/50 rounded-md p-3 text-sm text-green-200">
                             <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1476,6 +1476,14 @@ export class ApiService {
     return extractData<DatabricksOAuthResultResponse>(data)
   }
 
+  static async cancelDatabricksOAuth(state: string): Promise<void> {
+    await apiFetch(`${API_BASE_URL}/connections/databricks/oauth/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state }),
+    })
+  }
+
   static async listDatabricksWarehouses(server_hostname: string, access_token: string): Promise<DatabricksWarehouse[]> {
     const response = await apiFetch(`${API_BASE_URL}/connections/databricks/oauth/warehouses`, {
       method: 'POST',

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -48,6 +48,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Node.js (for Claude Code CLI) and the CLI itself so the SDK can spawn it.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=ghcr.io/astral-sh/uv:0.11.3 /uv /usr/local/bin/uv
 
 COPY --from=deps /app/.venv /app/.venv

--- a/server/routers/databricks_oauth.py
+++ b/server/routers/databricks_oauth.py
@@ -11,6 +11,7 @@ from server.auth.scopes import Scope
 from server.auth.tenant_context import set_tenant_id
 from server.db.session import get_async_session
 from server.schemas.connections import (
+    DatabricksOAuthCancelRequest,
     DatabricksOAuthResultResponse,
     DatabricksOAuthSettingsRequest,
     DatabricksOAuthSettingsResponse,
@@ -144,6 +145,18 @@ async def databricks_oauth_result(
             ),
         ).model_dump(),
         message="Databricks tokens retrieved",
+    )
+
+
+@router.post("/connections/databricks/oauth/cancel")
+async def databricks_oauth_cancel(
+    body: DatabricksOAuthCancelRequest,
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
+):
+    cancelled = databricks_oauth_service.cancel_flow(body.state)
+    return success_response(
+        data={"cancelled": cancelled},
+        message="Databricks OAuth flow cancelled" if cancelled else "No active flow found",
     )
 
 

--- a/server/schemas/connections.py
+++ b/server/schemas/connections.py
@@ -93,6 +93,10 @@ class DatabricksOAuthStartResponse(BaseModel):
     redirect_uri: str
 
 
+class DatabricksOAuthCancelRequest(BaseModel):
+    state: str
+
+
 class DatabricksOAuthTokens(BaseModel):
     access_token: str
     refresh_token: str | None = None

--- a/server/services/databricks_oauth_service.py
+++ b/server/services/databricks_oauth_service.py
@@ -77,9 +77,11 @@ def get_redirect_uri() -> str:
 
 def _normalize_host(server_hostname: str) -> str:
     host = server_hostname.strip()
-    if host.startswith("http://") or host.startswith("https://"):
+    if "://" in host:
         host = host.split("://", 1)[1]
-    return host.rstrip("/")
+    host = host.split("/", 1)[0]
+    host = host.split("?", 1)[0]
+    return host.strip().rstrip(".")
 
 
 def _authorize_url(host: str) -> str:
@@ -297,6 +299,26 @@ async def _start_loopback_listener(state: str, client_id: str) -> None:
             _oauth_state_store.pop(state, None)
 
     asyncio.create_task(_serve_until_done())
+
+
+def cancel_flow(state: str) -> bool:
+    """Abort an in-progress OAuth flow: close its loopback listener and drop
+    any state/result entries. Returns True if anything was found to cancel."""
+    found = False
+    server = _active_loopback_servers.pop(state, None)
+    if server is not None:
+        found = True
+        try:
+            server.close()
+        except Exception as e:
+            logger.debug(f"[DATABRICKS OAUTH] Ignoring cancel close error: {e}")
+    if _oauth_state_store.pop(state, None) is not None:
+        found = True
+    if _oauth_result_store.pop(state, None) is not None:
+        found = True
+    if found:
+        logger.info(f"[DATABRICKS OAUTH] Cancelled flow state={state[:16]}...")
+    return found
 
 
 def pop_state(state: str) -> dict[str, Any] | None:

--- a/server/services/title_generation.py
+++ b/server/services/title_generation.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import re
+from typing import Any
 
 from litellm import acompletion
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.services.claude_mcp_service import stream_claude_with_mcp_tools
 from server.services.llm_service import ModelService
+from server.tools.agentic import search_datasets
 from server.utils.custom_logger import get_logger
 
 logger = get_logger(__name__)
@@ -111,40 +113,49 @@ async def _generate_title_claude_sdk(
 
     async def _protected():
         generated_title = ""
+        sdk_error: str | None = None
         async for event in stream_claude_with_mcp_tools(
             prompt=prompt,
-            tools=None,
+            tools=[search_datasets],
             model=model,
             instructions=TITLE_SYSTEM_PROMPT,
-            context=None,
-            max_turns=1,
-            disallowed_tools_override=[
-                "WebSearch",
-                "WebFetch",
-                "Read",
-                "Write",
-                "Edit",
-                "Bash",
-                "Glob",
-                "Grep",
-                "Task",
-                "NotebookEdit",
-                "AskUserQuestion",
-                "TodoWrite",
-                "ToolSearch",
-                "Agent",
-                "LSP",
-            ],
+            context={},
         ):
-            if event.get("type") == "content":
+            etype = event.get("type")
+            if etype == "content":
                 generated_title += event.get("text", "")
-            elif event.get("type") == "done":
+            elif etype == "error":
+                sdk_error = event.get("error") or "Unknown Claude SDK error"
+            elif etype == "done":
                 break
-        return generated_title
+        return generated_title, sdk_error
 
-    generated_title = await asyncio.shield(_protected())
-    logger.info(f"Generated title via Claude SDK: {generated_title}")
+    generated_title, sdk_error = await asyncio.shield(_protected())
+    if sdk_error and not generated_title.strip():
+        logger.warning(f"[TITLE GEN] Claude SDK error, using fallback: {sdk_error}")
+        return _fallback_title(user_message)
+    logger.info(f"Generated title via Claude SDK: {generated_title!r}")
     return _clean_title(generated_title, user_message)
+
+
+def _extract_content_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                btype = block.get("type")
+                if btype in ("text", "output_text") or btype is None:
+                    text = block.get("text") or block.get("content") or ""
+                    if isinstance(text, str):
+                        parts.append(text)
+        return "".join(parts)
+    return str(content)
 
 
 async def _generate_title_litellm(
@@ -163,11 +174,27 @@ async def _generate_title_litellm(
         model=model_instance.model,
         messages=messages,
         temperature=0.7,
-        max_tokens=20,
+        max_tokens=2048,
     )
 
-    title = response.choices[0].message.content.strip() if response.choices[0].message.content else ""
-    logger.info(f"Generated title via LiteLLM: {title}")
+    message = response.choices[0].message
+    raw_content = getattr(message, "content", None)
+    content = _extract_content_text(raw_content).strip()
+    if not content:
+        reasoning = (getattr(message, "reasoning_content", None) or "").strip()
+        if reasoning:
+            lines = [line.strip() for line in reasoning.splitlines() if line.strip()]
+            content = lines[-1] if lines else ""
+
+    if not content:
+        logger.warning(
+            f"[TITLE GEN] LiteLLM returned empty content. model={model_instance.model} "
+            f"finish_reason={getattr(response.choices[0], 'finish_reason', None)} "
+            f"raw_content_type={type(raw_content).__name__} raw={repr(raw_content)[:500]}"
+        )
+
+    title = content.strip()
+    logger.info(f"Generated title via LiteLLM: {title!r}")
     return _clean_title(title, user_message)
 
 


### PR DESCRIPTION
## Summary

Fix Databricks OAuth UX gaps and notebook title generation.

This change adds a cancel button to unfreeze the **"Waiting for sign-in…"** state. It ties an `AbortController` and state refs to the polling loop so closing the dialog, switching connector type, or resetting the wizard cleanly tears down both the client-side poll and the server-side loopback listener through a new:

`POST /connections/databricks/oauth/cancel`

It also normalizes the Databricks Server hostname on both client and backend so users can paste either a bare host or a full URL. Helper text was updated to clearly mention the `no https://` rule.

The same OAuth UX fixes were applied to the duplicate flow in:

`client/src/pages/Databases.tsx`

Notebook title generation now matches the chat agent SDK call shape:

`tools=[search_datasets], context={}`

This prevents the Claude Agent SDK from crashing on `None` params.

The runtime Docker image now includes Node and `@anthropic-ai/claude-code` so `find_claude_cli_path` succeeds and the SDK can spawn the CLI.

LiteLLM title generation `max_tokens` was increased to `2048`, with a `reasoning_content` fallback for thinking-model responses.

## Testing

* [x] Backend tests run, or not applicable — manual smoke test completed for the cancel endpoint through the UI
* [x] Frontend build/lint run, or not applicable — `tsc -p tsconfig.json --noEmit` is clean for touched files
* [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
* [x] Docs updated, or not applicable — N/A

## Security And Data Access

* [x] This change does not weaken read-only database guardrails
* [x] This change does not expose secrets, credentials, private schemas, or sensitive data
* [x] This change does not add a privileged workflow path for untrusted pull request code
* [x] New database/MCP/auth behavior is documented — cancel endpoint reuses existing `Scope.CONNECTION_CREATE` guard

## Notes

No migration required.

Follow-up: none.
