### PR TITLE
feat(github): add fine-grained PAT auth method with setup guidance an…

### DIFF
--- a/client/src/components/github/GitHubOAuthDialog.tsx
+++ b/client/src/components/github/GitHubOAuthDialog.tsx
@@ -19,7 +19,9 @@ export function GitHubOAuthDialog({ open, onOpenChange, onSuccess, oauthAvailabl
   const [step, setStep] = useState<OAuthStep>('idle')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
-  const [authMethod, setAuthMethod] = useState<'oauth' | 'pat'>(oauthAvailable ? 'oauth' : 'pat')
+  const [authMethod, setAuthMethod] = useState<'oauth' | 'pat_classic' | 'pat_fine_grained'>(
+    oauthAvailable ? 'oauth' : 'pat_classic',
+  )
   const [patToken, setPatToken] = useState('')
   const [patLoading, setPatLoading] = useState(false)
   const [userCode, setUserCode] = useState('')
@@ -28,7 +30,7 @@ export function GitHubOAuthDialog({ open, onOpenChange, onSuccess, oauthAvailabl
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
-    setAuthMethod(oauthAvailable ? 'oauth' : 'pat')
+    setAuthMethod(oauthAvailable ? 'oauth' : 'pat_classic')
   }, [oauthAvailable])
 
   useEffect(() => {
@@ -42,7 +44,7 @@ export function GitHubOAuthDialog({ open, onOpenChange, onSuccess, oauthAvailabl
     setUserCode('')
     setCopied(false)
     setPatToken('')
-    setAuthMethod(oauthAvailable ? 'oauth' : 'pat')
+    setAuthMethod(oauthAvailable ? 'oauth' : 'pat_classic')
   }
 
   const handleClose = (newOpen: boolean) => {
@@ -144,8 +146,8 @@ export function GitHubOAuthDialog({ open, onOpenChange, onSuccess, oauthAvailabl
                 Connect your GitHub account to analyze repositories and build codebase skills.
               </p>
 
-              {oauthAvailable && (
-                <div className="flex gap-1 bg-[#1a1a1a] rounded-lg p-1">
+              <div className="flex gap-1 bg-[#1a1a1a] rounded-lg p-1">
+                {oauthAvailable && (
                   <button
                     onClick={() => setAuthMethod('oauth')}
                     className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm transition-colors ${
@@ -157,19 +159,30 @@ export function GitHubOAuthDialog({ open, onOpenChange, onSuccess, oauthAvailabl
                     <Github className="w-4 h-4" />
                     OAuth
                   </button>
-                  <button
-                    onClick={() => setAuthMethod('pat')}
-                    className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm transition-colors ${
-                      authMethod === 'pat'
-                        ? 'bg-[#3a3a3a] text-white'
-                        : 'text-gray-400 hover:text-gray-300'
-                    }`}
-                  >
-                    <KeyRound className="w-4 h-4" />
-                    Access Token
-                  </button>
-                </div>
-              )}
+                )}
+                <button
+                  onClick={() => setAuthMethod('pat_classic')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm transition-colors ${
+                    authMethod === 'pat_classic'
+                      ? 'bg-[#3a3a3a] text-white'
+                      : 'text-gray-400 hover:text-gray-300'
+                  }`}
+                >
+                  <KeyRound className="w-4 h-4" />
+                  Classic PAT
+                </button>
+                <button
+                  onClick={() => setAuthMethod('pat_fine_grained')}
+                  className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm transition-colors ${
+                    authMethod === 'pat_fine_grained'
+                      ? 'bg-[#3a3a3a] text-white'
+                      : 'text-gray-400 hover:text-gray-300'
+                  }`}
+                >
+                  <KeyRound className="w-4 h-4" />
+                  Fine-grained
+                </button>
+              </div>
 
               {authMethod === 'oauth' && oauthAvailable ? (
                 <>
@@ -200,28 +213,72 @@ export function GitHubOAuthDialog({ open, onOpenChange, onSuccess, oauthAvailabl
                     type="password"
                     value={patToken}
                     onChange={(e) => setPatToken(e.target.value)}
-                    placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+                    placeholder={
+                      authMethod === 'pat_fine_grained'
+                        ? 'github_pat_11ABCDEFG0xxxxxxxxxxxx'
+                        : 'ghp_xxxxxxxxxxxxxxxxxxxx'
+                    }
                     className="bg-[#1a1a1a] border-gray-700 text-white font-mono text-sm"
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' && patToken.trim()) connectWithPAT()
                     }}
                   />
-                  <p className="text-xs text-gray-500">
-                    Create a token at{' '}
-                    <a
-                      href="https://github.com/settings/tokens"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-brand-orange hover:underline"
-                    >
-                      github.com/settings/tokens
-                    </a>
-                    {' '}with these scopes:
-                  </p>
-                  <ul className="text-xs text-gray-500 space-y-1 mt-1 ml-3">
-                    <li><span className="text-gray-400 font-mono">repo</span> — Full access to public and private repositories <span className="text-gray-600">(required)</span></li>
-                    <li><span className="text-gray-400 font-mono">read:user</span> — Read your GitHub profile info <span className="text-gray-600">(optional)</span></li>
-                  </ul>
+                  {authMethod === 'pat_fine_grained' ? (
+                    <>
+                      <p className="text-xs text-gray-500">
+                        Create a token at{' '}
+                        <a
+                          href="https://github.com/settings/personal-access-tokens"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-brand-orange hover:underline"
+                        >
+                          github.com/settings/personal-access-tokens
+                        </a>
+                        {' '}with these Repository permissions:
+                      </p>
+                      <ul className="text-xs text-gray-500 space-y-1 mt-1 ml-3">
+                        <li><span className="text-gray-400 font-mono">Contents</span> — Read-only <span className="text-gray-600">(required)</span></li>
+                        <li><span className="text-gray-400 font-mono">Metadata</span> — Read-only <span className="text-gray-600">(required, auto-selected)</span></li>
+                      </ul>
+                      <div className="bg-[#1a1a1a] border border-gray-800 rounded-lg p-3 space-y-2">
+                        <p className="text-xs text-gray-400 font-medium">Setup checklist</p>
+                        <ul className="text-xs text-gray-500 space-y-1.5 list-disc ml-4">
+                          <li>
+                            <span className="text-gray-400">Resource owner</span> — choose your personal account for personal repos, or the organization for org repos.
+                          </li>
+                          <li>
+                            <span className="text-gray-400">Repository access</span> — pick &quot;Only select repositories&quot; (or &quot;All repositories&quot;) and tick the repos you want Byaan to see. Only those will appear in the repo list.
+                          </li>
+                          <li>
+                            <span className="text-gray-400">Repository permissions</span> — you must explicitly tick <span className="font-mono text-gray-400">Contents</span> Read-only. If the token page later shows &quot;does not have any repository permissions,&quot; nothing was selected — edit the token and try again.
+                          </li>
+                          <li>
+                            <span className="text-gray-400">Org tokens need approval</span> — when the resource owner is an organization, the token is <span className="text-brand-orange">pending</span> until an org admin approves it under <span className="font-mono text-gray-400">Settings → Third-party Access → Personal access tokens → Pending requests</span>. Until then it has zero access. The org must also have fine-grained PATs allowed in its policy.
+                          </li>
+                        </ul>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-xs text-gray-500">
+                        Create a token at{' '}
+                        <a
+                          href="https://github.com/settings/tokens"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-brand-orange hover:underline"
+                        >
+                          github.com/settings/tokens
+                        </a>
+                        {' '}with these scopes:
+                      </p>
+                      <ul className="text-xs text-gray-500 space-y-1 mt-1 ml-3">
+                        <li><span className="text-gray-400 font-mono">repo</span> — Full access to public and private repositories <span className="text-gray-600">(required)</span></li>
+                        <li><span className="text-gray-400 font-mono">read:user</span> — Read your GitHub profile info <span className="text-gray-600">(optional)</span></li>
+                      </ul>
+                    </>
+                  )}
                   <div className="flex justify-end gap-2 pt-1">
                     <Button variant="outline" onClick={() => handleClose(false)} className="border-[#555555] text-white hover:bg-[#3a3a3a]">
                       Cancel

--- a/client/src/pages/GitHubIntegrations.tsx
+++ b/client/src/pages/GitHubIntegrations.tsx
@@ -32,6 +32,7 @@ export default function GitHubIntegrations() {
   const {
     githubConnected,
     githubUsername,
+    githubAuthMethod,
     setGitHubConnected,
     connectedRepos,
     setConnectedRepos,
@@ -132,7 +133,7 @@ export default function GitHubIntegrations() {
   const loadStatus = useCallback(async () => {
     try {
       const status = await GitHubService.getStatus()
-      setGitHubConnected(status.connected, status.username)
+      setGitHubConnected(status.connected, status.username, status.auth_method)
     } catch {
       setGitHubConnected(false)
     }
@@ -457,8 +458,18 @@ export default function GitHubIntegrations() {
               <div className="flex items-center gap-4">
                 <div className={`w-3 h-3 rounded-full ${githubConnected ? 'bg-green-400' : 'bg-gray-600'}`} />
                 <div>
-                  <h3 className="text-white font-medium">
+                  <h3 className="text-white font-medium flex items-center gap-2">
                     {githubConnected ? `Connected as ${githubUsername}` : 'Not connected'}
+                    {githubConnected && githubAuthMethod === 'pat_fine_grained' && (
+                      <span className="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded bg-brand-orange/15 text-brand-orange border border-brand-orange/30">
+                        Fine-grained PAT
+                      </span>
+                    )}
+                    {githubConnected && githubAuthMethod === 'pat_classic' && (
+                      <span className="text-[10px] uppercase tracking-wide px-2 py-0.5 rounded bg-gray-500/15 text-gray-300 border border-gray-500/30">
+                        Classic PAT
+                      </span>
+                    )}
                   </h3>
                   <p className="text-sm text-gray-500">
                     {githubConnected

--- a/client/src/services/github.ts
+++ b/client/src/services/github.ts
@@ -123,7 +123,12 @@ export const GitHubService = {
 
   async getStatus() {
     const res = await apiFetch('/oauth/status')
-    return res.data as { connected: boolean; username: string | null; scopes: string[] | null }
+    return res.data as {
+      connected: boolean
+      username: string | null
+      scopes: string[] | null
+      auth_method: 'oauth' | 'pat_classic' | 'pat_fine_grained' | null
+    }
   },
 
   async disconnect() {

--- a/client/src/stores/slices/githubSlice.ts
+++ b/client/src/stores/slices/githubSlice.ts
@@ -2,13 +2,16 @@ import type { StateCreator } from 'zustand'
 import type { StoreState } from '../useStore'
 import type { ConnectedRepo } from '../../services/github'
 
+export type GitHubAuthMethod = 'oauth' | 'pat_classic' | 'pat_fine_grained' | null
+
 export interface GitHubSlice {
   githubConnected: boolean
   githubUsername: string | null
+  githubAuthMethod: GitHubAuthMethod
   connectedRepos: ConnectedRepo[]
   selectedRepo: ConnectedRepo | null
 
-  setGitHubConnected: (connected: boolean, username?: string | null) => void
+  setGitHubConnected: (connected: boolean, username?: string | null, authMethod?: GitHubAuthMethod) => void
   setConnectedRepos: (repos: ConnectedRepo[]) => void
   addConnectedRepo: (repo: ConnectedRepo) => void
   updateRepoStatus: (repoId: string, status: string, error?: string | null) => void
@@ -24,13 +27,15 @@ export const createGitHubSlice: StateCreator<
 > = (set) => ({
   githubConnected: false,
   githubUsername: null,
+  githubAuthMethod: null,
   connectedRepos: [],
   selectedRepo: null,
 
-  setGitHubConnected: (connected, username = null) =>
+  setGitHubConnected: (connected, username = null, authMethod = null) =>
     set(() => ({
       githubConnected: connected,
       githubUsername: username,
+      githubAuthMethod: authMethod,
     })),
 
   setConnectedRepos: (repos) =>

--- a/server/routers/github.py
+++ b/server/routers/github.py
@@ -141,11 +141,18 @@ async def oauth_status(
 
     try:
         user_info = await github_service.get_authenticated_user(token)
+        auth_method = await github_service.get_stored_auth_method(auth.tenant_id, auth.user_id, session)
+        scopes = (
+            None
+            if auth_method == github_service.AUTH_METHOD_PAT_FINE_GRAINED
+            else github_service.GITHUB_SCOPES.split(" ")
+        )
         return success_response(
             data=GitHubOAuthStatusResponse(
                 connected=True,
                 username=user_info["login"],
-                scopes=github_service.GITHUB_SCOPES.split(" "),
+                scopes=scopes,
+                auth_method=auth_method,
             ).model_dump()
         )
     except Exception:

--- a/server/schemas/github.py
+++ b/server/schemas/github.py
@@ -20,6 +20,7 @@ class GitHubOAuthStatusResponse(BaseModel):
     connected: bool
     username: str | None = None
     scopes: list[str] | None = None
+    auth_method: str | None = None  # "oauth" | "pat_classic" | "pat_fine_grained"
 
 
 class GitHubRepoConnect(BaseModel):

--- a/server/services/github_service.py
+++ b/server/services/github_service.py
@@ -28,6 +28,13 @@ GITHUB_API_BASE = "https://api.github.com"
 GITHUB_SCOPES = "repo read:user"
 REQUIRED_SCOPES = {"repo"}
 
+CLASSIC_PAT_PREFIX = "ghp_"
+FINE_GRAINED_PAT_PREFIX = "github_pat_"
+
+AUTH_METHOD_OAUTH = "oauth"
+AUTH_METHOD_PAT_CLASSIC = "pat_classic"
+AUTH_METHOD_PAT_FINE_GRAINED = "pat_fine_grained"
+
 _device_code_store: dict[str, dict] = {}  # device_code → {tenant_id, user_id}
 
 
@@ -166,6 +173,28 @@ async def get_github_token(tenant_id: UUID, user_id: UUID, session: AsyncSession
     return decrypted.get("access_token")
 
 
+async def get_stored_auth_method(tenant_id: UUID, user_id: UUID, session: AsyncSession) -> str | None:
+    repo = SkillCredentialRepository(session)
+    cred = await repo.get_by_skill("github", tenant_id, user_id, scope="user")
+    if not cred:
+        return None
+    decrypted = await repo.get_decrypted_credentials(cred)
+    if not decrypted:
+        return None
+    token_type = (decrypted.get("token_type") or "").lower()
+    if token_type == AUTH_METHOD_PAT_FINE_GRAINED:
+        return AUTH_METHOD_PAT_FINE_GRAINED
+    if token_type in (AUTH_METHOD_PAT_CLASSIC, "pat"):
+        return AUTH_METHOD_PAT_CLASSIC
+    return AUTH_METHOD_OAUTH
+
+
+def detect_pat_type(token: str) -> str:
+    if token.startswith(FINE_GRAINED_PAT_PREFIX):
+        return AUTH_METHOD_PAT_FINE_GRAINED
+    return AUTH_METHOD_PAT_CLASSIC
+
+
 async def delete_github_token(tenant_id: UUID, user_id: UUID, session: AsyncSession) -> bool:
     repo = SkillCredentialRepository(session)
     return await repo.delete_by_skill("github", tenant_id, user_id, scope="user")
@@ -220,7 +249,7 @@ async def list_user_repos(token: str, page: int = 1, per_page: int = 30, search:
         response = await client.get(
             f"{GITHUB_API_BASE}/user/repos",
             params={
-                "affiliation": "owner,collaborator",
+                "affiliation": "owner,collaborator,organization_member",
                 "sort": "updated",
                 "per_page": per_page,
                 "page": page,
@@ -359,15 +388,41 @@ async def poll_device_token(device_code: str, client_id: str) -> dict:
         return {"status": "success", "token_data": data, "context": context}
 
 
-async def validate_and_save_pat(token: str, tenant_id: UUID, user_id: UUID, session: AsyncSession) -> dict:
-    missing = await validate_token_scopes(token)
-    if missing:
-        raise ValueError(
-            f"Token is missing required scope(s): {', '.join(missing)}. "
-            "Create a new token with these scopes at github.com/settings/tokens"
-        )
+async def _validate_fine_grained_pat(token: str) -> dict:
     user_info = await get_authenticated_user(token)
-    token_data = {"access_token": token, "token_type": "pat"}
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.get(
+            f"{GITHUB_API_BASE}/user/repos",
+            params={"per_page": 1},
+            headers={**GITHUB_HEADERS, "Authorization": f"Bearer {token}"},
+        )
+        if response.status_code == 403:
+            raise ValueError(
+                "Fine-grained token lacks repository access. Grant 'Contents: Read-only' "
+                "and 'Metadata: Read-only' permissions and select at least one repository."
+            )
+        response.raise_for_status()
+        if not response.json():
+            raise ValueError(
+                "Fine-grained token has no accessible repositories. "
+                "Select at least one repository when creating the token."
+            )
+    return user_info
+
+
+async def validate_and_save_pat(token: str, tenant_id: UUID, user_id: UUID, session: AsyncSession) -> dict:
+    pat_type = detect_pat_type(token)
+    if pat_type == AUTH_METHOD_PAT_FINE_GRAINED:
+        user_info = await _validate_fine_grained_pat(token)
+    else:
+        missing = await validate_token_scopes(token)
+        if missing:
+            raise ValueError(
+                f"Token is missing required scope(s): {', '.join(missing)}. "
+                "Create a new token with these scopes at github.com/settings/tokens"
+            )
+        user_info = await get_authenticated_user(token)
+    token_data = {"access_token": token, "token_type": pat_type}
     await save_github_token(tenant_id, user_id, token_data, session)
     return user_info
 


### PR DESCRIPTION
…d org-repo listing fix

## Summary

Adds GitHub Fine-grained Personal Access Token as a third connection method alongside OAuth and Classic PAT. Fine-grained tokens use GitHub's permissions model instead of classic scopes, so the existing repo-scope check rejected them outright — this PR routes them through a separate validator that confirms /user + at least one accessible repo, persists token_type in the encrypted credential blob, and surfaces auth_method in GET /github/oauth/status so the UI can show which method the user connected with.

Also fixes a latent bug in list_user_repos(): the affiliation=owner,collaborator filter excluded organization-member repos, so users connecting via any method (OAuth, Classic PAT, Fine-grained PAT) couldn't see org repos they only had member access to. Filter now includes organization_member.

UI changes: the connect dialog now has three tabs (OAuth | Classic PAT | Fine-grained), each with method-specific help text. The Fine-grained tab includes a setup checklist covering resource-owner selection, repository-access selection, the required Contents + Metadata Read-only permissions, and the organization-approval gotcha. The integrations page shows a small badge next to "Connected as …" reflecting the auth method.

Testing

- Backend tests run, or not applicable — 606 passed, 0 failures
- Frontend build/lint run, or not applicable — ESLint 0 errors (pre-existing warnings only)
- GitHub Actions PR checks are expected to pass, or the failing check is explained below
- Docs updated, or not applicable — no user-facing docs touched; in-product help text in the modal covers the setup steps

Security And Data Access

- This change does not weaken read-only database guardrails
- This change does not expose secrets, credentials, private schemas, or sensitive data — tokens continue to be stored encrypted via SkillCredentialRepository / CryptoService; only the auth-method label (not the token) is returned by the status endpoint
- This change does not add a privileged workflow path for untrusted pull request code
- New database/MCP/auth behavior is documented — in-modal checklist + auth_method field documented in GitHubOAuthStatusResponse

Notes

- No DB migration: token_type is stored inside the existing opaque credentials_encrypted JSON blob; existing rows without it default to oauth via get_stored_auth_method().
- Fine-grained PAT quirk to be aware of when testing: GitHub fine-grained tokens always grant read access to public repos regardless of the "Repository access" selection. So the repo list will include the granted private/org
  repos plus every public repo the user owns or collaborates on. This is GitHub behavior, not a Byaan bug.
- Org tokens targeting an organization may require admin approval before becoming active (per org policy). The dialog's setup checklist calls this out.
- Follow-up: the repo search box uses GitHub's search API with user:{login} and won't surface org repos by search. Main listing now does. Extending search to also query org: is a small follow-up if desired.
