### PR TITLE
Slack and Claude code bugs fixes

### DIFF
--- a/server/constants/models.py
+++ b/server/constants/models.py
@@ -10,9 +10,9 @@ ANTHROPIC_MODELS = [
 ]
 
 CLAUDE_CODE_MODELS = [
-    "claude_code/claude-opus-4.8",
-    "claude_code/claude-opus-4.7",
-    "claude_code/claude-sonnet-4.6",
+    "claude_code/claude-opus-4-8",
+    "claude_code/claude-opus-4-7",
+    "claude_code/claude-sonnet-4-6",
 ]
 
 OPENROUTER_SPECIFIC_MODELS = [

--- a/server/services/claude_mcp_service.py
+++ b/server/services/claude_mcp_service.py
@@ -139,8 +139,8 @@ async def stream_claude_with_mcp_tools(
 
         # Step 3: Configure Claude options
         # Tool names are prefixed with mcp__<server_name>__<tool_name>
-        mcp_servers_dict = None
-        allowed_tools_list = None
+        mcp_servers_dict: dict = {}
+        allowed_tools_list: list[str] = []
 
         if mcp_server:
             mcp_servers_dict = {"byaan_tools": mcp_server}
@@ -186,6 +186,11 @@ async def stream_claude_with_mcp_tools(
             "stderr": stderr_callback,
             "env": cli_env,
         }
+
+        if model:
+            sdk_model = model.split("/", 1)[1] if model.startswith("claude_code/") else model
+            options_kwargs["model"] = sdk_model
+            logger.info(f"[CLAUDE MCP] Passing model to SDK: {sdk_model}")
 
         # Auto-detect CLI path using the same expanded PATH so discovery and launch agree
         cli_path = find_claude_cli_path(search_path=expanded_path)
@@ -384,6 +389,10 @@ async def stream_claude_with_mcp_tools(
 
                     logger.info(f"[CLAUDE MCP] API Source: {api_source}")
                     logger.info(f"[CLAUDE MCP] MCP Servers: {len(mcp_servers_info)}")
+
+                    actual_model = message.data.get("model")
+                    if actual_model:
+                        logger.info(f"[CLAUDE MCP] Active model (from SDK init): {actual_model}")
 
             elif message_type == "StreamEvent":
                 if hasattr(message, "event"):

--- a/server/services/completion_service.py
+++ b/server/services/completion_service.py
@@ -10,11 +10,12 @@ from server.services.claude_mcp_service import DISALLOWED_BUILTIN_TOOLS, stream_
 from server.services.llm_service import ModelService
 from server.services.unified_agent import is_using_claude_code_auth
 from server.utils.custom_logger import get_logger
+from server.utils.litellm_utils import supports_custom_temperature
 
 logger = get_logger(__name__)
 
 ALL_BUILTIN_TOOLS = [*DISALLOWED_BUILTIN_TOOLS, "Read", "ToolSearch"]
-_TOOL_CALL_RE = re.compile(r"\[\[TOOL_CALL:[^\]]*\]\]")
+_TOOL_CALL_RE = re.compile(r"\[\[TOOL_CALL:.*?\]\](?=\[\[TOOL_CALL|[^\[\]]|$)", re.DOTALL)
 
 
 class CompletionService:
@@ -27,6 +28,7 @@ class CompletionService:
         session: AsyncSession,
         system_prompt: str | None = None,
         use_claude_sdk: bool | None = None,
+        model: str | None = None,
     ) -> str | None:
         """
         Get a completion from the appropriate LLM based on connection type.
@@ -37,6 +39,7 @@ class CompletionService:
             session: Database session
             system_prompt: Optional system instructions
             use_claude_sdk: If provided, skip the DB auth check and use this value directly
+            model: Optional model identifier to pass to the underlying provider
 
         Returns:
             The completion text, or None if failed
@@ -51,12 +54,14 @@ class CompletionService:
                 return await CompletionService._complete_with_claude_sdk(
                     prompt=prompt,
                     system_prompt=system_prompt,
+                    model=model,
                 )
             else:
                 return await CompletionService._complete_with_litellm(
                     prompt=prompt,
                     llm_connection_id=llm_id,
                     system_prompt=system_prompt,
+                    model=model,
                 )
         except Exception as e:
             logger.error(f"Completion failed: {e}", exc_info=True)
@@ -66,13 +71,14 @@ class CompletionService:
     async def _complete_with_claude_sdk(
         prompt: str,
         system_prompt: str | None = None,
+        model: str | None = None,
     ) -> str | None:
         """Complete using Claude Code SDK with all builtin tools disabled."""
         result = ""
         gen = stream_claude_with_mcp_tools(
             prompt=prompt,
             tools=None,
-            model=None,
+            model=model,
             instructions=system_prompt,
             context=None,
             disallowed_tools_override=ALL_BUILTIN_TOOLS,
@@ -101,9 +107,10 @@ class CompletionService:
         prompt: str,
         llm_connection_id: str,
         system_prompt: str | None = None,
+        model: str | None = None,
     ) -> str | None:
         """Complete using LiteLLM."""
-        model_instance = await ModelService.get_litellm_model_instance(llm_connection_id)
+        model_instance = await ModelService.get_litellm_model_instance(llm_connection_id, model=model)
         if not model_instance:
             logger.error(f"Could not create model instance for LLM connection {llm_connection_id}")
             return None
@@ -113,10 +120,13 @@ class CompletionService:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": prompt})
 
-        response = await acompletion(
-            model=model_instance.model,
-            messages=messages,
-            temperature=0,
-        )
+        completion_kwargs: dict = {
+            "model": model_instance.model,
+            "messages": messages,
+        }
+        if supports_custom_temperature(model_instance.model):
+            completion_kwargs["temperature"] = 0
+
+        response = await acompletion(**completion_kwargs)
         content = response.choices[0].message.content  # type: ignore[union-attr]
         return content.strip() if content else None

--- a/server/services/conversation_state.py
+++ b/server/services/conversation_state.py
@@ -3,6 +3,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from server.utils.conversation_items import conversation_items_to_messages
 from server.utils.custom_logger import get_logger
+from server.utils.litellm_utils import supports_custom_temperature
 
 logger = get_logger(__name__)
 
@@ -447,13 +448,15 @@ class ConversationStateSession:
             if not model_instance:
                 return "[Handoff summary: Failed to create model instance. Session was reset but context was not summarized.]"
 
-            # Call litellm directly for summarization
-            response = await acompletion(
-                model=model,
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=1000,
-                temperature=0.3,
-            )
+            completion_kwargs: dict = {
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": 1000,
+            }
+            if supports_custom_temperature(model):
+                completion_kwargs["temperature"] = 0.3
+
+            response = await acompletion(**completion_kwargs)
 
             # Extract summary from response (handle different response formats)
             try:

--- a/server/services/llm_service.py
+++ b/server/services/llm_service.py
@@ -91,18 +91,14 @@ async def build_litellm_params(conn: LLMConnection, session=None, model: str = N
             logger.debug(f"Removed 'codex/' prefix from model name: {model_name}")
 
     if not model_name:
-        if conn.type == "openai":
-            model_name = "gpt-5.4"
-        elif conn.type == "anthropic":
-            model_name = "claude-sonnet-4-5"
-        elif conn.type == "codex":
-            model_name = "gpt-5.4"
-        elif conn.type == "claude_code":
-            model_name = "claude-opus-4.6"
-        elif conn.type == "openrouter":
-            model_name = "anthropic/claude-sonnet-4.5"
-        elif conn.type == "groq":
-            model_name = "moonshotai/kimi-k2-instruct-0905"
+        provider_models = MODELS_BY_PROVIDER.get(conn.type, [])
+        if provider_models:
+            default_with_prefix = provider_models[0]
+            own_prefix = f"{conn.type}/"
+            if default_with_prefix.startswith(own_prefix):
+                model_name = default_with_prefix[len(own_prefix) :]
+            else:
+                model_name = default_with_prefix
         elif conn.type == "azure":
             raise ValueError("Azure deployment name must be provided in the configuration.")
         elif conn.type == "bedrock":

--- a/server/services/schedule_service.py
+++ b/server/services/schedule_service.py
@@ -36,7 +36,7 @@ logger = get_logger(__name__)
 
 executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="schedule_")
 
-_TOOL_CALL_RE = re.compile(r"\[\[TOOL_CALL:[^\]]*\]\]")
+_TOOL_CALL_RE = re.compile(r"\[\[TOOL_CALL:.*?\]\](?=\[\[TOOL_CALL|[^\[\]]|$)", re.DOTALL)
 
 
 def _clean_tool_markers(text: str) -> str:

--- a/server/services/slack_agent_service.py
+++ b/server/services/slack_agent_service.py
@@ -13,10 +13,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 litellm.drop_params = True
 
+from server.constants.models import MODELS_BY_PROVIDER
 from server.models.slack_conversation import SlackConversation
 from server.models.slack_event_log import SlackEventLog
 from server.models.slack_workspace import SlackWorkspace
 from server.repositories.custom_skill import CustomSkillRepository
+from server.repositories.llm_connections import LLMConnectionRepository
 from server.schemas.agent import AgentRequest
 from server.services.completion_service import CompletionService
 from server.services.crypto_service import CryptoService
@@ -38,6 +40,33 @@ class SlackAgentService:
 
     CONFIRMATION_MESSAGE = "Hey, I'm working on your request. I'll let you know once it's ready."
     SLACK_MENTION_HINT = "\n\n_@Byaan to continue the conversation_"
+
+    @staticmethod
+    async def _resolve_model_for_connection(
+        llm_connection_id: UUID,
+        session: AsyncSession,
+    ) -> str | None:
+        """Resolve the model string for a Slack LLM connection.
+
+        Order of preference:
+        1. Model stored in connection.config["model"] (user-selected at connection creation)
+        2. First entry in MODELS_BY_PROVIDER for the connection type (latest model)
+        """
+        connection = await LLMConnectionRepository(session).get(llm_connection_id)
+        if not connection:
+            return None
+
+        try:
+            cfg = await CryptoService.decrypt_config(connection.config, session) if connection.config else {}
+        except Exception:
+            cfg = {}
+
+        stored_model = cfg.get("model") if isinstance(cfg, dict) else None
+        if stored_model:
+            return stored_model
+
+        provider_models = MODELS_BY_PROVIDER.get(connection.type, [])
+        return provider_models[0] if provider_models else None
 
     @staticmethod
     async def process_mention(
@@ -91,6 +120,9 @@ class SlackAgentService:
             if not llm_connection_id:
                 raise ValueError("No LLM connection configured for Slack workspace")
 
+            resolved_model = await SlackAgentService._resolve_model_for_connection(llm_connection_id, session)
+            logger.info(f"[SLACK] Using model for connection {llm_connection_id}: {resolved_model}")
+
             slack_prompt = await SlackAgentService._build_slack_prompt(
                 question=question,
                 tenant_id=workspace.tenant_id,
@@ -102,6 +134,7 @@ class SlackAgentService:
                 notebook_id=conversation.notebook_id,
                 llm_connection_id=llm_connection_id,
                 create_notebook=conversation.notebook_id is None,
+                model=resolved_model,
             )
 
             raw_response, new_notebook_id, dashboard_generated, query_executed = await SlackAgentService._run_agent(
@@ -119,6 +152,7 @@ class SlackAgentService:
                 llm_connection_id=llm_connection_id,
                 tenant_id=workspace.tenant_id,
                 session=session,
+                model=resolved_model,
             )
 
             response_msg = await slack_client.post_message(
@@ -347,6 +381,7 @@ class SlackAgentService:
         llm_connection_id: UUID,
         tenant_id: UUID,
         session: AsyncSession,
+        model: str | None = None,
     ) -> tuple[list[dict], str]:
         """Clean agent response and convert to Slack Block Kit format."""
         try:
@@ -386,12 +421,18 @@ Output only the cleaned message in Markdown, nothing else."""
                 llm_connection_id=llm_connection_id,
                 session=session,
                 system_prompt="You are a message cleaner. Output only the cleaned message in Markdown.",
+                model=model,
             )
 
             cleaned = result if result else raw_response
 
             # Fallback: regex cleanup in case LLM didn't remove tool calls
-            cleaned = re.sub(r"\[\[TOOL_CALL:[^\]]+\]\]", "", cleaned)
+            cleaned = re.sub(
+                r"\[\[TOOL_CALL:.*?\]\](?=\[\[TOOL_CALL|[^\[\]]|$)",
+                "",
+                cleaned,
+                flags=re.DOTALL,
+            )
             cleaned = re.sub(r"Tool executed successfully", "", cleaned)
             cleaned = cleaned.strip()
 

--- a/server/services/title_generation.py
+++ b/server/services/title_generation.py
@@ -11,6 +11,7 @@ from server.services.claude_mcp_service import stream_claude_with_mcp_tools
 from server.services.llm_service import ModelService
 from server.tools.agentic import search_datasets
 from server.utils.custom_logger import get_logger
+from server.utils.litellm_utils import supports_custom_temperature
 
 logger = get_logger(__name__)
 
@@ -51,7 +52,12 @@ def _fallback_title(user_message: str) -> str:
 
 
 def _clean_title(title: str, user_message: str) -> str:
-    title = re.sub(r"\[\[TOOL_CALL:[^\]]*\]\]", "", title)
+    title = re.sub(
+        r"\[\[TOOL_CALL:.*?\]\](?=\[\[TOOL_CALL|[^\[\]]|$)",
+        "",
+        title,
+        flags=re.DOTALL,
+    )
     title = re.sub(r"Tool executed successfully\s*", "", title)
     title = title.strip().strip('"').strip("'")
     if len(title) > 100:
@@ -170,12 +176,15 @@ async def _generate_title_litellm(
 
     messages = _build_title_messages(user_message, assistant_response)
 
-    response = await acompletion(
-        model=model_instance.model,
-        messages=messages,
-        temperature=0.7,
-        max_tokens=2048,
-    )
+    completion_kwargs: dict = {
+        "model": model_instance.model,
+        "messages": messages,
+        "max_tokens": 2048,
+    }
+    if supports_custom_temperature(model_instance.model):
+        completion_kwargs["temperature"] = 0.7
+
+    response = await acompletion(**completion_kwargs)
 
     message = response.choices[0].message
     raw_content = getattr(message, "content", None)

--- a/server/utils/litellm_utils.py
+++ b/server/utils/litellm_utils.py
@@ -8,6 +8,21 @@ from server.utils.custom_logger import get_logger
 
 logger = get_logger(__name__)
 
+# OpenAI reasoning families that reject non-default temperature. Extend as new families ship.
+_RESTRICTED_TEMPERATURE_FAMILIES = ("gpt-5", "o1", "o3", "o4")
+
+
+def supports_custom_temperature(model: str | None) -> bool:
+    """Return False for OpenAI reasoning families (gpt-5.x, o1/o3/o4) that only accept the default temperature.
+
+    LiteLLM's drop_params does not strip temperature for these models, so callers must omit it explicitly.
+    """
+    if not model:
+        return True
+
+    model_lower = model.lower()
+    return not any(family in model_lower for family in _RESTRICTED_TEMPERATURE_FAMILIES)
+
 
 def supports_parallel_tool_calls(model: str | None) -> bool:
     """


### PR DESCRIPTION

## Summary

Slack showed tool call markers in it's responses and the default models used for slack were older obsolete models.

## Testing

- [x] Backend tests run, or not applicable
- [x] Frontend build/lint run, or not applicable
- [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
- [x] Docs updated, or not applicable

## Security And Data Access

- [x] This change does not weaken read-only database guardrails
- [x] This change does not expose secrets, credentials, private schemas, or sensitive data
- [x] This change does not add a privileged workflow path for untrusted pull request code
- [x] New database/MCP/auth behavior is documented

