### PR TITLE
fix(mcp): pass DATABASE_URL and APP_MODE to exec sessions from persis…

### DIFF
--- a/docs/self-hosted/README.md
+++ b/docs/self-hosted/README.md
@@ -189,7 +189,7 @@ To register from your laptop over SSH instead of on the server itself:
 claude mcp add-json byaan '{
   "type": "stdio",
   "command": "ssh",
-  "args": ["your-server", "byaan-mcp", "youeamil@org.com"]
+  "args": ["your-server", "byaan-mcp", "you@org.com"]
 }' --scope user
 ```
 

--- a/docs/self-hosted/byaan-mcp
+++ b/docs/self-hosted/byaan-mcp
@@ -29,9 +29,20 @@ if [ -z "$CONTAINER" ]; then
     exit 1
 fi
 
-exec docker exec -i \
-    -w /app/server \
-    -e BYAAN_MCP_USER="$EMAIL" \
-    ${TENANT:+-e BYAAN_MCP_TENANT="$TENANT"} \
-    "$CONTAINER" \
+EXEC_ARGS=(-i -w /app/server -e BYAAN_MCP_USER="$EMAIL")
+[ -n "$TENANT" ] && EXEC_ARGS+=(-e BYAAN_MCP_TENANT="$TENANT")
+
+# The self-hosted entrypoint exports DATABASE_URL and APP_MODE at runtime, so
+# exec sessions don't inherit them; rebuild them from the persisted credentials
+# and run as the byaan user so created files stay writable by the backend.
+if CREDS=$(docker exec "$CONTAINER" cat /data/.db_credentials 2>/dev/null) && [ -n "$CREDS" ]; then
+    DB_NAME=$(docker exec "$CONTAINER" printenv POSTGRES_DB 2>/dev/null || true)
+    EXEC_ARGS+=(
+        -u byaan
+        -e DATABASE_URL="postgresql+asyncpg://${CREDS%%:*}:${CREDS#*:}@localhost:5432/${DB_NAME:-byaan}"
+        -e APP_MODE=self-hosted
+    )
+fi
+
+exec docker exec "${EXEC_ARGS[@]}" "$CONTAINER" \
     uv run --frozen --no-sync python -m server.mcp.stdio_server


### PR DESCRIPTION
…ted credentials and run as byaan user

## Summary

MCP-over-SSH sessions on `start.sh` deployments failed with `no such table: tenants` even though the container was detected correctly. Root cause: the self-hosted entrypoint exports `DATABASE_URL` and `APP_MODE` at runtime, so `docker exec` sessions never inherit them — the MCP stdio server silently fell back to an empty SQLite database and local-mode identity resolution.

The `byaan-mcp` wrapper now:

- Rebuilds `DATABASE_URL` inside the container from the credentials the entrypoint persists at `/data/.db_credentials` (the same source the entrypoint treats as authoritative on restarts) and sets `APP_MODE=self-hosted`
- Runs the MCP process as the `byaan` user — matching the backend under supervisord — so files created by MCP sessions (DuckDB catalogs, datasets) stay writable by the backend instead of becoming root-owned
- Skips all of this on non-self-hosted containers (dev compose), where the credentials file doesn't exist and the compose environment already provides `DATABASE_URL`
- Guards against an empty credentials file

Also fixes a typo in the README's SSH registration example (`youeamil@org.com` → `you@org.com`).

## Testing

- [x] Backend tests run, or not applicable
- [x] Frontend build/lint run, or not applicable
- [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
- [x] Docs updated, or not applicable

## Security And Data Access

- [x] This change does not weaken read-only database guardrails
- [x] This change does not expose secrets, credentials, private schemas, or sensitive data
- [x] This change does not add a privileged workflow path for untrusted pull request code
- [x] New database/MCP/auth behavior is documented

## Notes

- Verified end-to-end: full MCP initialize handshake against a production-style `start.sh` container, and regression-tested against the dev compose stack (credentials file absent → fall-through path).
- The reconstructed `DATABASE_URL` is passed via `docker exec -e`, visible to anyone who can inspect execs — consistent with the wrapper's existing trust model (Docker access already implies database access; documented in the script header).
- The wrapper must be re-copied to `/usr/local/bin/` on each self-hosted host to take effect.
- Follow-up option: have the entrypoint persist its runtime env (or let `stdio_server` read the credentials file itself) so exec-based tooling no longer reconstructs it.