### PR TITLE
fix: stop PostHog exception spam from expected 4xx errors and fronten…

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -140,6 +140,23 @@ function AppWithConfig() {
     api_host: config?.host || "https://us.i.posthog.com",
     autocapture: true, // Explicitly enable autocapture for Tauri
     persistence: "localStorage", // Use localStorage for persistence in desktop app
+    capture_exceptions: {
+      capture_unhandled_errors: true,
+      capture_unhandled_rejections: true,
+      capture_console_errors: false,
+    },
+    before_send: (event: any) => {
+      if (event?.event === "$exception") {
+        const values = (event.properties?.$exception_list ?? [])
+          .map((e: any) => String(e?.value ?? ""))
+          .join(" ");
+        // Drop network noise: backend still booting or machine offline
+        if (/Load failed|Failed to fetch|NetworkError|Could not connect|status: 404/i.test(values)) {
+          return null;
+        }
+      }
+      return event;
+    },
     loaded: (posthog: any) => {
       console.log("PostHog loaded successfully", {
         api_host: posthog.config.api_host,

--- a/server/main.py
+++ b/server/main.py
@@ -443,16 +443,21 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     is_auth_error = "ErrorCode." in detail_str or detail_str in AUTH_ERROR_MESSAGES
     readable_message = get_auth_error_message(detail_str) if is_auth_error else detail_str
 
-    logger.error(
-        f"HTTP {exc.status_code}: {request.method} {request.url.path} - {exc.detail}",
-        posthog_context={
-            "path": request.url.path,
-            "method": request.method,
-            "status_code": exc.status_code,
-            "user_agent": request.headers.get("user-agent"),
-            "detail": detail_str,
-        },
-    )
+    log_message = f"HTTP {exc.status_code}: {request.method} {request.url.path} - {exc.detail}"
+    if exc.status_code >= 500:
+        logger.error(
+            log_message,
+            posthog_context={
+                "path": request.url.path,
+                "method": request.method,
+                "status_code": exc.status_code,
+                "user_agent": request.headers.get("user-agent"),
+                "detail": detail_str,
+            },
+        )
+    else:
+        # 4xx are expected client errors (stale notebooks, missing datasources, auth) — don't report to PostHog
+        logger.warning(log_message)
 
     # Check if this is an HTML endpoint - these should return HTML errors, not JSON
     if request.url.path.endswith("/html"):
@@ -496,16 +501,8 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    logger.error(
-        f"Validation error: {request.method} {request.url.path}",
-        posthog_context={
-            "path": request.url.path,
-            "method": request.method,
-            "status_code": 422,
-            "user_agent": request.headers.get("user-agent"),
-            "errors": exc.errors(),
-        },
-    )
+    # 422 is an expected client error (malformed request) — log as warning, don't report to PostHog
+    logger.warning(f"Validation error: {request.method} {request.url.path} - {exc.errors()}")
 
     if request.url.path.startswith("/api/"):
         return JSONResponse(


### PR DESCRIPTION
…d network noise

## Summary

Stops a flood of low-value `$exception` events from being reported to PostHog by both the backend and the desktop client.

**Backend (`server/main.py`):** The global HTTP exception handlers previously reported *every* handled error to PostHog via `posthog_context`, so routine client errors (stale-notebook 404s, missing datasources, auth failures, malformed-request 422s) were fabricated into empty-message `$exception` events that buried real errors. Now:
- `http_exception_handler` reports only 5xx server errors to PostHog; 4xx client errors log as warnings with no PostHog context.
- `validation_exception_handler` (422) logs as a warning instead of reporting to PostHog (422 is an expected client error). The `exc.errors()` detail is preserved in the log line, and all HTTP response bodies are unchanged.
- `global_exception_handler` (500) is unchanged — genuine unhandled server errors are still reported.

**Client (`client/src/main.tsx`):** Explicitly configures posthog-js to disable console-error capture and adds a `before_send` filter that drops expected network noise — backend-still-booting connection failures and 404s (`Load failed`, `Failed to fetch`, `NetworkError`, `Could not connect`, `status: 404`). `Load failed` is included specifically because that's the WKWebView (Tauri-on-macOS) fetch-failure message.

## Testing

- [ ] Backend tests run, or not applicable — *not run: local env cannot build the `litellm` Rust bridge. `ruff check` passes on the changed file. Change is logging-only and does not alter response behavior.*
- [x] Frontend build/lint run, or not applicable — `tsc --noEmit` passes with no errors in `main.tsx`.
- [x] GitHub Actions PR checks are expected to pass, or the failing check is explained below
- [x] Docs updated, or not applicable — logging/telemetry behavior only, no user-facing docs affected.

## Security And Data Access

- [x] This change does not weaken read-only database guardrails
- [x] This change does not expose secrets, credentials, private schemas, or sensitive data — reduces data sent to PostHog; error detail stays in local logs only.
- [x] This change does not add a privileged workflow path for untrusted pull request code
- [x] New database/MCP/auth behavior is documented — n/a, no such behavior added.

## Notes

- No migrations, no schema changes, no API contract changes — HTTP status codes and JSON/HTML response bodies are identical to before.
- **Trade-off:** the client `before_send` regex is intentionally broad — it drops *all* fetch failures and any exception whose message contains `status: 404`, so a genuine connectivity bug or 404-surfaced frontend bug would also be suppressed from PostHog. Backend 4xx/5xx logs remain fully intact for diagnosis. Can be narrowed later to only failures against the local backend host if needed.
- Follow-up idea: consider a shared helper for the "4xx → warning, 5xx → report" decision so the two backend handlers stay consistent if more are added.