### PR TITLE
[codex] Land Data Studio commercial backend foundations

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "build:check": "tsc -b && vite build",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install chromium",
     "lint": "eslint .",
     "preview": "vite preview",
     "tauri": "tauri",
@@ -60,6 +62,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@eslint/js": "^9.30.1",
     "@tauri-apps/cli": "^2.8.4",
     "@types/node": "^24.2.0",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium-desktop-1440x900',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
+    },
+    {
+      name: 'chromium-mobile-390x844',
+      use: { ...devices['Pixel 7'], viewport: { width: 390, height: 844 } },
+    },
+  ],
+  webServer: {
+    command: 'pnpm run build && pnpm exec vite preview --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@eslint/js':
         specifier: ^9.30.1
         version: 9.37.0
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.62.1
       '@tauri-apps/cli':
         specifier: ^2.8.4
         version: 2.8.4
@@ -762,6 +765,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@posthog/core@1.3.0':
     resolution: {integrity: sha512-hxLL8kZNHH098geedcxCz8y6xojkNYbmJEW+1vFXsmPcExyCXIUUJ/34X6xa9GcprKxd0Wsx3vfJQLQX4iVPhw==}
@@ -1847,6 +1855,11 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2389,6 +2402,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3415,6 +3438,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@posthog/core@1.3.0': {}
 
@@ -4461,6 +4488,9 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5156,6 +5186,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.25):
     dependencies:

--- a/client/src/components/CodeHighlight.tsx
+++ b/client/src/components/CodeHighlight.tsx
@@ -3,7 +3,7 @@ import { Highlight, themes } from 'prism-react-renderer'
 
 interface CodeHighlightProps {
   code: string
-  language: 'html' | 'sql' | 'javascript' | 'typescript' | 'json'
+  language: 'html' | 'sql' | 'javascript' | 'typescript' | 'json' | 'graphql'
   showLineNumbers?: boolean
   customStyle?: React.CSSProperties
   className?: string

--- a/client/src/components/DashboardFilterBar.tsx
+++ b/client/src/components/DashboardFilterBar.tsx
@@ -246,7 +246,7 @@ const getFilterTypeLabel = (filterType: DashboardFilterDefinition["filter_type"]
 const useDismissableDropdown = (
   isOpen: boolean,
   onClose: () => void,
-): React.RefObject<HTMLDivElement> => {
+): React.RefObject<HTMLDivElement | null> => {
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {

--- a/client/src/components/DashboardPreviewPanel.tsx
+++ b/client/src/components/DashboardPreviewPanel.tsx
@@ -48,7 +48,7 @@ interface DashboardPreviewPanelProps {
   iframeErrors?: unknown[]
   activeTab?: TabKey
   onActiveTabChange?: (tab: TabKey) => void
-  iframeRef?: React.RefObject<HTMLIFrameElement>
+  iframeRef?: React.RefObject<HTMLIFrameElement | null>
   htmlEditTimeline?: HtmlEditTimelineEntry[]
   liveCodeOverride?: string | null
   isLiveStreamEnabled?: boolean

--- a/client/src/components/ErrorLogModal.tsx
+++ b/client/src/components/ErrorLogModal.tsx
@@ -63,8 +63,6 @@ export const ErrorLogModal: React.FC<ErrorLogModalProps> = ({ errors, onClearErr
         return 'JS Error'
       case 'unhandledRejection':
         return 'Promise'
-      case 'console':
-        return 'Console'
       default:
         return 'Unknown'
     }

--- a/client/src/components/MCPKeysModal.tsx
+++ b/client/src/components/MCPKeysModal.tsx
@@ -51,7 +51,7 @@ export function MCPKeysModal({ open, onClose }: MCPKeysModalProps) {
     localStorage.setItem('byaan_mcp_setup_dismissed', 'true')
     navigator.clipboard.writeText(text).catch(() => {})
     setCopiedSnippet(id)
-    showToast('Copied to clipboard', 'success')
+    showToast.success('Copied to clipboard')
     setTimeout(() => setCopiedSnippet(null), 2000)
   }
 
@@ -71,7 +71,7 @@ export function MCPKeysModal({ open, onClose }: MCPKeysModalProps) {
 
   const handleCreateKey = async () => {
     if (!newKeyName.trim()) {
-      showToast('Please enter a key name', 'error')
+      showToast.error('Please enter a key name')
       return
     }
 
@@ -88,7 +88,7 @@ export function MCPKeysModal({ open, onClose }: MCPKeysModalProps) {
       setShowCreatedKeyDialog(true)
       refetch()
     } catch (error: any) {
-      showToast(error?.response?.data?.detail || 'Failed to create API key', 'error')
+      showToast.error(error?.response?.data?.detail || 'Failed to create API key')
     } finally {
       setIsCreating(false)
     }
@@ -108,9 +108,9 @@ export function MCPKeysModal({ open, onClose }: MCPKeysModalProps) {
       setShowDeleteConfirm(false)
       setKeyToDelete(null)
       refetch()
-      showToast('API key deleted successfully', 'success')
+      showToast.success('API key deleted successfully')
     } catch (error: any) {
-      showToast(error?.response?.data?.detail || 'Failed to delete API key', 'error')
+      showToast.error(error?.response?.data?.detail || 'Failed to delete API key')
     } finally {
       setDeletingKeyId(null)
     }
@@ -124,7 +124,7 @@ export function MCPKeysModal({ open, onClose }: MCPKeysModalProps) {
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text)
     setIsCopied(true)
-    showToast('Copied to clipboard', 'success')
+    showToast.success('Copied to clipboard')
     setTimeout(() => setIsCopied(false), 2000)
   }
 

--- a/client/src/components/MarkdownRenderer.tsx
+++ b/client/src/components/MarkdownRenderer.tsx
@@ -72,6 +72,10 @@ const BLOCK_ELEMENTS = new Set([
   "img",
 ])
 
+const hasReactChildProps = (props: unknown): props is { children?: ReactNode; className?: string } => {
+  return typeof props === "object" && props !== null
+}
+
 const SQL_CLAUSE_PATTERNS: RegExp[] = [
   /([^\n])\s*(FROM)\b/gi,
   /([^\n])\s*(WHERE)\b/gi,
@@ -486,13 +490,13 @@ export default function MarkdownRenderer({ content, onCodeInject }: MarkdownRend
           }
 
           // Check for code blocks (which render as div)
-          if (typeof childType === "function" && child.props?.className?.includes("language-")) {
+          if (typeof childType === "function" && hasReactChildProps(child.props) && child.props.className?.includes("language-")) {
             return true
           }
 
           // Check if child has nested block elements (div, pre, etc.)
           const childProps = child.props
-          if (childProps && typeof childProps === "object") {
+          if (hasReactChildProps(childProps)) {
             const nestedChildren = childProps.children
             if (nestedChildren) {
               const checkNested = (node: any): boolean => {
@@ -503,7 +507,7 @@ export default function MarkdownRenderer({ content, onCodeInject }: MarkdownRend
                   if (typeof nodeType === "string" && BLOCK_ELEMENTS.has(nodeType)) {
                     return true
                   }
-                  if (node.props?.children) {
+                  if (hasReactChildProps(node.props) && node.props.children) {
                     return checkNested(node.props.children)
                   }
                 }

--- a/client/src/components/NotebookQueryPanel.tsx
+++ b/client/src/components/NotebookQueryPanel.tsx
@@ -46,6 +46,7 @@ interface ConnectionConfig {
   password: string
   connectionString: string
   file_path?: string
+  dataset_type?: string
 }
 
 interface QueryResult {
@@ -80,7 +81,7 @@ export function NotebookQueryPanel({ notebookId, initialQuery, initialQueryVersi
   const querySavedTrigger = useStore(state => state.querySavedTrigger)
   const notebookDatasourcesChangedTrigger = useStore(state => state.notebookDatasourcesChangedTrigger)
   const selectedConnectionIdRef = useRef<string | null>(null)
-  const previousNotebookIdRef = useRef<string | undefined>()
+  const previousNotebookIdRef = useRef<string | undefined>(undefined)
   const injectedRetryKeyRef = useRef<string | null>(null)
 
   const [allNotebookConnections, setAllNotebookConnections] = useState<any[]>([])
@@ -403,7 +404,7 @@ export function NotebookQueryPanel({ notebookId, initialQuery, initialQueryVersi
         )
       )
 
-      setNotebookConnection(prev => {
+      setNotebookConnection((prev: any) => {
         if (prev?.id === selectedConnectionId) {
           return {
             ...prev,

--- a/client/src/components/SchemaViewer.tsx
+++ b/client/src/components/SchemaViewer.tsx
@@ -5,7 +5,7 @@ import { Button } from "./ui/button"
 import { Card } from "./ui/card"
 import { Table, Database, AlertCircle, Loader2, RefreshCw, ChevronDown, ChevronRight } from "lucide-react"
 import { Switch } from './ui/switch'
-import { type DatabaseTable, type MongoCollection, type DatabaseColumn } from "../services/api"
+import { type DatabaseTable, type MongoCollection, type DatabaseColumn, isMultiDatabaseSchema } from "../services/api"
 import { useStore } from "../stores/useStore"
 import { showToast } from "../utils/toast"
 import { toast } from "react-toastify"
@@ -134,6 +134,10 @@ export function SchemaViewer({ connection, onQueryChange, notebookId, onRefreshS
   const isCollection = (item: DatabaseTable | MongoCollection): item is MongoCollection => {
     return 'sample_fields' in item
   }
+
+  const singleSchema = schema && !isMultiDatabaseSchema(schema) ? schema : null
+  const schemaEntries = singleSchema ? Object.entries(singleSchema.schema) : []
+
   return (
     <div className="m-0 p-4 bg-[#1a1a1a] h-full overflow-auto">
       <div className="space-y-6">
@@ -164,7 +168,7 @@ export function SchemaViewer({ connection, onQueryChange, notebookId, onRefreshS
           <div>
             <h3 className="font-medium text-white text-lg">Database Schema</h3>
             <p className="text-sm text-[#888888]">
-              {schema ? `${schema.datasource_name || 'Database'} (${(schema.datasource_type || connection?.type || 'UNKNOWN').toUpperCase()})` : 'Explore your database structure'}
+              {singleSchema ? `${singleSchema.datasource_name || 'Database'} (${(singleSchema.datasource_type || connection?.type || 'UNKNOWN').toUpperCase()})` : 'Explore your database structure'}
             </p>
           </div>
           {connection && (
@@ -218,9 +222,9 @@ export function SchemaViewer({ connection, onQueryChange, notebookId, onRefreshS
               Try Again
             </Button>
           </div>
-        ) : schema?.schema && Object.keys(schema.schema).length > 0 ? (
+        ) : schemaEntries.length > 0 ? (
           <div className="space-y-4 max-h-full overflow-y-auto custom-scrollbar">
-            {Object.entries(schema.schema).map(([tableName, tableData]) => {
+            {schemaEntries.map(([tableName, tableData]) => {
               const table = tableData as DatabaseTable;
               const isExpanded = expandedTables.has(tableName);
 
@@ -252,9 +256,9 @@ export function SchemaViewer({ connection, onQueryChange, notebookId, onRefreshS
                     {/* Additional info when collapsed */}
                     {!isExpanded && (
                       <p className="text-xs text-[#888888] ml-6">
-                        {(schema.datasource_type === 'csv' || schema.datasource_type === 'excel' || schema.datasource_type === 'parquet' || schema.datasource_type === 'json') && isTable(tableData) && tableData.filename
-                          ? `${schema.datasource_type.toUpperCase()} File: ${tableData.filename}`
-                          : schema.datasource_type === 'mongo'
+                        {(singleSchema?.datasource_type === 'csv' || singleSchema?.datasource_type === 'excel' || singleSchema?.datasource_type === 'parquet' || singleSchema?.datasource_type === 'json') && isTable(tableData) && tableData.filename
+                          ? `${singleSchema.datasource_type.toUpperCase()} File: ${tableData.filename}`
+                          : singleSchema?.datasource_type === 'mongo'
                           ? 'MongoDB Collection'
                           : 'Database Table'}
                         {table.row_count !== undefined && ` • ${table.row_count} rows`}

--- a/client/src/components/TableMentionInput.tsx
+++ b/client/src/components/TableMentionInput.tsx
@@ -584,7 +584,7 @@ export const TableMentionInput = forwardRef<HTMLTextAreaElement, TableMentionInp
                               onClick={(e) => {
                                 e.preventDefault()
                                 e.stopPropagation()
-                                handleColumnSelect(column.name, hoveredTable)
+                                handleColumnSelect(column.name, hoveredTable || undefined)
                               }}
                               onMouseEnter={() => isColumnMode && setSelectedColumnIndex(index)}
                             >

--- a/client/src/components/ToolCallCard.tsx
+++ b/client/src/components/ToolCallCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { ChevronDown, Copy, Play, Database, Leaf, Save, Search, Sparkles } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
 import { Button } from "./ui/button"
 import { CodeHighlight } from "./CodeHighlight"
 import { Tooltip } from "./ui/tooltip"
@@ -128,7 +129,16 @@ interface SkillMetadata {
   is_graphql?: boolean
 }
 
-const getToolConfig = (toolName: string, skillMetadata?: SkillMetadata) => {
+interface ToolConfig {
+  icon: LucideIcon
+  label: string
+  color: string
+  borderColor: string
+  bgColor: string
+  emoji?: string
+}
+
+const getToolConfig = (toolName: string, skillMetadata?: SkillMetadata): ToolConfig => {
   if (toolName === 'execute_skill_api' && skillMetadata?.skill_name) {
     const apiType = skillMetadata.is_graphql ? 'GraphQL' : 'REST'
     return {
@@ -151,10 +161,10 @@ const getToolConfig = (toolName: string, skillMetadata?: SkillMetadata) => {
 
 export function ToolCallCard({ tool_name, description, arguments: args, onCodeInject }: ToolCallCardProps) {
   const hasDescription = description && description.trim().length > 0
-  const hasArguments = args && (
+  const hasArguments = Boolean(args && (
     typeof args === 'string' ? args.trim().length > 0 :
     typeof args === 'object' ? Object.keys(args).length > 0 : false
-  )
+  ))
 
   const isSkillApi = tool_name === 'execute_skill_api'
   const isQueryTool = ['execute_sql_query', 'execute_mongo_query', 'execute_duckdb_query', 'save_query'].includes(tool_name)
@@ -209,7 +219,7 @@ export function ToolCallCard({ tool_name, description, arguments: args, onCodeIn
     ? String(parsedArgs.connection_id || parsedArgs.dataset_id)
     : undefined
 
-  let queryLanguage = 'sql'
+  let queryLanguage: 'sql' | 'javascript' = 'sql'
   if (tool_name === 'execute_sql_query' || tool_name === 'execute_duckdb_query') {
     queryLanguage = 'sql'
   } else if (tool_name === 'execute_mongo_query') {
@@ -254,9 +264,9 @@ export function ToolCallCard({ tool_name, description, arguments: args, onCodeIn
       >
         <div className="flex items-center gap-2 min-w-0 flex-1">
           {'emoji' in toolConfig && toolConfig.emoji ? (
-            <span className="w-3 h-3 flex-shrink-0 text-xs leading-none">{toolConfig.emoji}</span>
+            <span className="w-3 h-3 flex-shrink-0 text-xs leading-none">{String(toolConfig.emoji)}</span>
           ) : (
-            <IconComponent className={`w-3 h-3 flex-shrink-0 ${toolConfig.color}`} />
+            <IconComponent className={`w-3 h-3 flex-shrink-0 ${String(toolConfig.color)}`} />
           )}
 
           <span className={`

--- a/client/src/components/context/DatabaseUnderstandingSection.tsx
+++ b/client/src/components/context/DatabaseUnderstandingSection.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/select';
 import { useDatasources } from '@/hooks/useDBConnections';
 import { useScopes } from '@/hooks/useScopes';
-import { ApiService, type DatabaseSchemaResponse, type DatabaseTable, type DatabaseColumn, type MongoCollection } from '@/services/api';
+import { ApiService, type DatabaseSchemaResponse, type DatabaseTable, type DatabaseColumn, type MongoCollection, isMultiDatabaseSchema } from '@/services/api';
 import { showToast } from '@/utils/toast';
 import { useAppConfig } from '@/hooks/useAppConfig';
 import { isTauriApp } from '@/lib/tauri-api';
@@ -102,19 +102,20 @@ export const DatabaseUnderstandingSection: React.FC<DatabaseUnderstandingSection
   const schema = selectedDatasourceId ? datasourceSchemas[selectedDatasourceId] : null;
 
   const effectiveSchema = propsSchema || schema;
-  const effectiveType = propsType || selectedDatasource?.database_type;
+  const singleEffectiveSchema = effectiveSchema && !isMultiDatabaseSchema(effectiveSchema) ? effectiveSchema : null;
+  const effectiveType = propsType || selectedDatasource?.database_type || selectedDatasource?.db_type || selectedDatasource?.type;
 
   const filteredTables = useMemo(() => {
-    if (!effectiveSchema?.schema) return [];
+    if (!singleEffectiveSchema?.schema) return [];
 
-    const entries = Object.entries(effectiveSchema.schema);
+    const entries = Object.entries(singleEffectiveSchema.schema);
     if (!searchQuery.trim()) return entries;
 
     const query = searchQuery.toLowerCase();
     return entries.filter(([tableName]) =>
       tableName.toLowerCase().includes(query)
     );
-  }, [effectiveSchema, searchQuery]);
+  }, [singleEffectiveSchema, searchQuery]);
 
   useEffect(() => {
     if (enableSelector && datasources.length > 0 && !selectedDatasourceId && !propsSchema) {
@@ -640,11 +641,12 @@ export const DatabaseUnderstandingSection: React.FC<DatabaseUnderstandingSection
       )}
 
       {/* Tables */}
-      {effectiveSchema && !loadingSchema && (
+      {singleEffectiveSchema && !loadingSchema && (
         <div className={compact ? "max-h-96 overflow-y-auto space-y-3" : "space-y-3"}>
           {filteredTables.length > 0 ? (
             filteredTables.map(([tableName, tableData]) => {
-              const table = tableData as DatabaseTable;
+              const typedTableData = tableData as DatabaseTable | MongoCollection;
+              const table = typedTableData as DatabaseTable;
               const userAnnotation = getUserAnnotations(tableName);
               const tableDescription = userAnnotation?.semanticDescription || '';
               const isExpanded = expandedTables.has(tableName);
@@ -664,8 +666,8 @@ export const DatabaseUnderstandingSection: React.FC<DatabaseUnderstandingSection
                   )}
                   <h4 className="text-sm font-mono font-semibold text-white">{tableName}</h4>
                   <span className="text-xs text-gray-500">
-                    {isMongoCollection(tableData)
-                      ? `${tableData.sample_fields?.length || 0} fields`
+                    {isMongoCollection(typedTableData)
+                      ? `${typedTableData.sample_fields?.length || 0} fields`
                       : `${table.columns?.length || 0} columns`}
                   </span>
                 </button>
@@ -737,17 +739,17 @@ export const DatabaseUnderstandingSection: React.FC<DatabaseUnderstandingSection
             {/* Columns / Fields */}
             {isExpanded && (
             <div className={`space-y-1.5 ${userAnnotation?.redacted ? 'opacity-40' : ''}`}>
-              {isMongoCollection(tableData) ? (
+              {isMongoCollection(typedTableData) ? (
                 <>
                   <div className="flex items-center gap-2 mb-2">
                     <div className="h-px flex-1 bg-gray-800" />
                     <span className="text-[10px] text-gray-500 uppercase tracking-wider">
-                      {tableData.sample_fields.length} fields
+                      {typedTableData.sample_fields.length} fields
                     </span>
                     <div className="h-px flex-1 bg-gray-800" />
                   </div>
 
-                  {tableData.sample_fields.map((fieldName: string) => {
+                  {typedTableData.sample_fields.map((fieldName: string) => {
                     const userColumnAnnotation = userAnnotation?.columns.find(c => c.name === fieldName);
                     const annotation = userColumnAnnotation?.annotation || '';
                     const isRedacted = userColumnAnnotation?.redacted || false;

--- a/client/src/components/home/SharedDashboardsSection.tsx
+++ b/client/src/components/home/SharedDashboardsSection.tsx
@@ -615,9 +615,14 @@ export default function SharedDashboardsSection({ onLoadingChange, onError, deep
   }
 
   const handleSaveTitle = async () => {
-    const notebookId = dashboardToEdit?.notebook_id || selectedDashboard?.notebook_id
+    const editingDashboard = dashboardToEdit
+    const notebookId = editingDashboard?.notebook_id || selectedDashboard?.notebook_id
     if (!notebookId) {
       showToast.error('Missing notebook information')
+      return
+    }
+    if (!editingDashboard) {
+      showToast.error('Missing dashboard information')
       return
     }
     if (!editingTitleValue.trim()) return
@@ -631,12 +636,12 @@ export default function SharedDashboardsSection({ onLoadingChange, onError, deep
           folders: prev.folders.map(folder => ({
             ...folder,
             dashboards: folder.dashboards.map(db =>
-              db.id === dashboardToEdit.id ? { ...db, notebook_name: editingTitleValue.trim() } : db
+              db.id === editingDashboard.id ? { ...db, notebook_name: editingTitleValue.trim() } : db
             )
           }))
         }
       })
-      setClickedDashboardInfo(prev => prev?.id === dashboardToEdit.id ? { ...prev, notebook_name: editingTitleValue.trim() } : prev)
+      setClickedDashboardInfo(prev => prev?.id === editingDashboard.id ? { ...prev, notebook_name: editingTitleValue.trim() } : prev)
       setIsEditingTitle(false)
       setDashboardToEdit(null)
       showToast.success('Title updated')

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -11,7 +11,7 @@ interface TooltipProps {
 export function Tooltip({ children, content, side = "top", align = "center", delayDuration = 200 }: TooltipProps) {
   const [isVisible, setIsVisible] = React.useState(false)
   const [isMounted, setIsMounted] = React.useState(false)
-  const timeoutRef = React.useRef<NodeJS.Timeout>()
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleMouseEnter = () => {
     timeoutRef.current = setTimeout(() => {
@@ -63,7 +63,7 @@ export function Tooltip({ children, content, side = "top", align = "center", del
 
   return (
     <div className="relative inline-flex">
-      {React.cloneElement(children, {
+      {React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
         onMouseEnter: handleMouseEnter,
         onMouseLeave: handleMouseLeave,
       })}

--- a/client/src/hooks/useNotebooks.ts
+++ b/client/src/hooks/useNotebooks.ts
@@ -77,18 +77,11 @@ export const useDeleteNotebook = () => {
 }
 
 export const useNotebookThreads = (notebookId: string | null) => {
-  const setThreads = useStore(state => state.setThreads)
-  
   return useQuery({
     queryKey: ['threads', notebookId],
     queryFn: async () => {
       if (!notebookId) return []
       const threads = await ApiService.getNotebookThreads(notebookId)
-      setThreads(threads.map(thread => ({
-        ...thread,
-        messages: [],
-        title: thread.thread_title || 'Untitled Thread'
-      })))
       return threads
     },
     enabled: !!notebookId,

--- a/client/src/hooks/useTableMentions.ts
+++ b/client/src/hooks/useTableMentions.ts
@@ -1079,7 +1079,7 @@ export function useTableMentions({
             if (columnsForHoveredTable[selectedColumnIndex]) {
               e.preventDefault()
               e.stopPropagation()
-              handleColumnSelect(columnsForHoveredTable[selectedColumnIndex].name, hoveredTable)
+              handleColumnSelect(columnsForHoveredTable[selectedColumnIndex].name, hoveredTable || undefined)
               return
             }
             break

--- a/client/src/lib/tauri-api.ts
+++ b/client/src/lib/tauri-api.ts
@@ -3,6 +3,7 @@
 declare global {
   interface Window {
     __TAURI__?: any;
+    __TAURI_INTERNALS__?: unknown;
   }
 }
 
@@ -18,7 +19,7 @@ export const getBackendPort = async (): Promise<number> => {
   }
 
   try {
-    const invokeFn = window.__TAURI__?.core?.invoke
+    const invokeFn: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T> = window.__TAURI__?.core?.invoke
       ? window.__TAURI__.core.invoke
       : (await import("@tauri-apps/api/core")).invoke;
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { PostHogProvider, usePostHog } from "posthog-js/react";
-import posthog from "posthog-js";
+import posthog, { type PostHogConfig } from "posthog-js";
 import { queryClient } from "./lib/queryClient";
 import { getPostHogConfig } from "./lib/config";
 import { isAnalyticsOptedOut } from "./lib/analyticsPreference";
@@ -90,8 +90,7 @@ function PostHogFlushHandler({ children }: { children: React.ReactNode }) {
       if (posthog) {
         console.log("Flushing PostHog events before window close");
         posthog.capture("app_close");
-        // PostHog's shutdown method flushes pending events
-        posthog.shutdown();
+        posthog.capture("$pageleave");
       }
     };
 
@@ -136,7 +135,7 @@ function AppWithConfig() {
     );
   }
 
-  const options = {
+  const options: Partial<PostHogConfig> = {
     api_host: config?.host || "https://us.i.posthog.com",
     autocapture: true, // Explicitly enable autocapture for Tauri
     persistence: "localStorage", // Use localStorage for persistence in desktop app

--- a/client/src/pages/ChatPreview.tsx
+++ b/client/src/pages/ChatPreview.tsx
@@ -53,6 +53,7 @@ import { ResizableSplitPanel } from '../components/ResizableSplitPanel'
 type ScheduleFrequency = 'daily' | 'weekly' | 'custom'
 const CHAT_PREFLIGHT_DEBUG_STORAGE_KEY = 'chat_preview_filter_preflight_debug'
 const ACTIVE_PREVIEW_NOTEBOOK_KEY = 'byaan:active-preview-notebook-id'
+type SchemaDataset = { id: string; name: string; tables: Record<string, any> }
 
 function parseCronToScheduleConfig(cron: string): {
   frequency: ScheduleFrequency
@@ -1268,7 +1269,7 @@ Please modify this element to: `
   }, [isNotebookStreaming, isHtmlBeingEdited, loadDashboardFilters])
 
   // Get datasources from schema (supports both single and multiple databases)
-  const schemaDatasets = useMemo(() => {
+  const schemaDatasets = useMemo<SchemaDataset[]>(() => {
     if (isNewNotebook && pendingDatasourceIds.length > 0 && Object.keys(pendingDatasourceSchemas).length > 0) {
       const result = pendingDatasourceIds
         .map(datasourceId => {
@@ -1304,7 +1305,7 @@ Please modify this element to: `
     }
 
     if (allNotebookConnections && allNotebookConnections.length > 1) {
-      const result = allNotebookConnections.map((conn: any) => {
+      const result = allNotebookConnections.map((conn: any): SchemaDataset => {
         let tables = {}
 
         if (conn.database_schema && typeof conn.database_schema === 'object') {
@@ -1337,7 +1338,7 @@ Please modify this element to: `
     if (isMultiDB) {
       // Multiple databases - create structured datasources array
       const multiSchema = schema as any
-      const result = multiSchema.databases.map((db: any) => ({
+      const result = multiSchema.databases.map((db: any): SchemaDataset => ({
         id: db.connection_id || db.connection_name,
         name: db.connection_name,
         tables: db.schema || {}
@@ -2779,7 +2780,7 @@ Please modify this element to: `
   }, [isEditingName])
 
   // Handle model selection change from ModelSelector - shared by both instances
-  const handleModelSelectionChange = useCallback(async (selection: { provider: LLMProvider; model: string; connectionId: string } | null) => {
+  const handleModelSelectionChange = useCallback(async (selection: { provider: LLMProvider; model: string; connectionId: string } | undefined) => {
     if (selection) {
       setSelectedProvider(selection.provider)
       setSelectedModel(selection.model)

--- a/client/src/pages/Databases.tsx
+++ b/client/src/pages/Databases.tsx
@@ -854,6 +854,10 @@ export default function DatabasesPage() {
         alert('Please select at least one file')
         return
       }
+      if (!uploadFileType) {
+        alert('Unable to detect file type. Supported: CSV, Excel, Parquet, JSON')
+        return
+      }
 
       uploadMultipleFilesMutation.mutate(
         { files: uploadFiles, name: uploadConnectionName, aliases: uploadFileAliases, fileType: uploadFileType },
@@ -898,6 +902,10 @@ export default function DatabasesPage() {
       // File upload mode
       if (uploadFiles.length === 0) {
         alert('Please select at least one file')
+        return
+      }
+      if (!uploadFileType) {
+        alert('Unable to detect file type. Supported: CSV, Excel, Parquet, JSON')
         return
       }
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -476,7 +476,7 @@ export interface ExecuteSavedQueryResponse {
 }
 
 // Connections - Only database connections now, files are handled by datasets
-export type ConnectionType = 'pg' | 'mongo' | 'mysql' | 'sqlite' | 'mssql' | 'dynamodb' | 'databricks'
+export type ConnectionType = 'pg' | 'mongo' | 'mysql' | 'sqlite' | 'mssql' | 'dynamodb' | 'databricks' | 'upload' | 'url'
 export type FileType = 'csv' | 'excel' | 'parquet' | 'json'
 export type DatasourceType = ConnectionType | FileType | 'duckdb'
 
@@ -691,6 +691,9 @@ export interface MultiDatabaseSchema {
   notebook_id: string
   total_databases: number
   databases: DatabaseInfo[]
+  schema?: never
+  datasource_type?: never
+  datasource_name?: never
 }
 
 // Union type for schema response (supports both single and multiple databases)
@@ -751,6 +754,7 @@ export interface Datasource {
   name: string
   type: DatasourceType
   db_type?: string
+  database_type?: DatasourceType
   source_type: 'connection' | 'dataset'
   connection_id?: string  // Only for connection-type datasources
   files_count?: number  // Only for datasets
@@ -3370,9 +3374,25 @@ export class ApiService {
     description: string
     is_configured: boolean
     required_credentials: string[]
+    credential_fields?: Array<{
+      key: string
+      label: string
+      placeholder: string
+      help: string
+      optional?: boolean
+      type?: string
+      options?: { value: string; label: string }[]
+      default?: string
+      depends_on?: { key: string; value: string }
+    }>
+    emoji?: string
+    homepage?: string
+    domain?: string
     scopes_configured: Array<'user' | 'org'>
     user_scope_created_by: string | null
     org_scope_created_by: string | null
+    org_scope_created_by_name?: string | null
+    domain_active?: boolean
   }>>> {
     try {
       const response = await apiFetch(`${API_BASE_URL}/skills`)
@@ -3482,13 +3502,23 @@ export class ApiService {
     name: string
     description: string
     scope: 'user' | 'org'
-    skill_type: 'general' | 'slack_inbound' | 'slack_outbound'
+    skill_type: 'general' | 'slack_inbound' | 'slack_outbound' | 'github_analysis'
     is_active: boolean
     created_by: string
     created_by_name: string
     created_at: string
     updated_at: string
     can_execute_api: boolean
+    instructions?: string
+    api_base_url?: string | null
+    api_type?: string | null
+    api_auth_type?: string | null
+    api_domain?: string | null
+    domain_active?: boolean
+    has_credentials?: boolean
+    github_repo_id?: string | null
+    github_analysis_type?: string | null
+    github_repo_name?: string | null
   }>>> {
     try {
       const response = await apiFetch(`${API_BASE_URL}/custom-skills`)
@@ -3511,13 +3541,22 @@ export class ApiService {
     description: string
     instructions: string
     scope: 'user' | 'org'
-    skill_type: 'general' | 'slack_inbound' | 'slack_outbound'
+    skill_type: 'general' | 'slack_inbound' | 'slack_outbound' | 'github_analysis'
     is_active: boolean
     created_by: string
     created_by_name: string
     created_at: string
     updated_at: string
     can_execute_api: boolean
+    api_base_url?: string | null
+    api_type?: string | null
+    api_auth_type?: string | null
+    api_domain?: string | null
+    domain_active?: boolean
+    has_credentials?: boolean
+    github_repo_id?: string | null
+    github_analysis_type?: string | null
+    github_repo_name?: string | null
   }>> {
     try {
       const response = await apiFetch(`${API_BASE_URL}/custom-skills/${id}`)
@@ -3539,7 +3578,7 @@ export class ApiService {
     description: string
     instructions: string
     scope?: 'user' | 'org'
-    skill_type?: 'general' | 'slack_inbound' | 'slack_outbound'
+    skill_type?: 'general' | 'slack_inbound' | 'slack_outbound' | 'github_analysis'
     api_config?: {
       api_base_url: string
       api_type: 'rest' | 'graphql'
@@ -3553,13 +3592,22 @@ export class ApiService {
     description: string
     instructions: string
     scope: 'user' | 'org'
-    skill_type: 'general' | 'slack_inbound' | 'slack_outbound'
+    skill_type: 'general' | 'slack_inbound' | 'slack_outbound' | 'github_analysis'
     is_active: boolean
     created_by: string
     created_by_name: string
     created_at: string
     updated_at: string
     can_execute_api: boolean
+    api_base_url?: string | null
+    api_type?: string | null
+    api_auth_type?: string | null
+    api_domain?: string | null
+    domain_active?: boolean
+    has_credentials?: boolean
+    github_repo_id?: string | null
+    github_analysis_type?: string | null
+    github_repo_name?: string | null
   }>> {
     try {
       const response = await apiFetch(`${API_BASE_URL}/custom-skills`, {
@@ -3599,13 +3647,22 @@ export class ApiService {
     description: string
     instructions: string
     scope: 'user' | 'org'
-    skill_type: 'general' | 'slack_inbound' | 'slack_outbound'
+    skill_type: 'general' | 'slack_inbound' | 'slack_outbound' | 'github_analysis'
     is_active: boolean
     created_by: string
     created_by_name: string
     created_at: string
     updated_at: string
     can_execute_api: boolean
+    api_base_url?: string | null
+    api_type?: string | null
+    api_auth_type?: string | null
+    api_domain?: string | null
+    domain_active?: boolean
+    has_credentials?: boolean
+    github_repo_id?: string | null
+    github_analysis_type?: string | null
+    github_repo_name?: string | null
   }>> {
     try {
       const response = await apiFetch(`${API_BASE_URL}/custom-skills/${id}`, {

--- a/client/src/services/pdfGenerator.ts
+++ b/client/src/services/pdfGenerator.ts
@@ -5,6 +5,12 @@ import { showToast } from '../utils/toast';
 import { injectErrorCaptureScript } from '../utils/iframeErrorCapture';
 import { getAccessToken } from './tokenStore';
 
+declare global {
+  interface Window {
+    pdfDataReady?: boolean;
+  }
+}
+
 interface PdfGenerationOptions {
   notebookId: string;
   version?: number | null;

--- a/client/src/stores/slices/contextSlice.ts
+++ b/client/src/stores/slices/contextSlice.ts
@@ -1,5 +1,9 @@
 import type { StateCreator } from 'zustand'
 import { ApiService } from '@/services/api'
+import type { StoreState } from '../useStore'
+
+const defaultInstructions = ''
+const defaultStyleGuidelines = ''
 
 export type SkillScope = 'user' | 'org'
 
@@ -75,6 +79,30 @@ export interface CreateCustomSkillData {
   api_config?: ApiConfig
   remove_api_config?: boolean
 }
+
+const normalizeSkillStatus = (skill: SkillStatus | Omit<SkillStatus, 'credential_fields' | 'emoji' | 'homepage' | 'domain' | 'org_scope_created_by_name' | 'domain_active'> & Partial<SkillStatus>): SkillStatus => ({
+  ...skill,
+  credential_fields: skill.credential_fields || [],
+  emoji: skill.emoji || '',
+  homepage: skill.homepage || '',
+  domain: skill.domain || '',
+  org_scope_created_by_name: skill.org_scope_created_by_name || null,
+  domain_active: skill.domain_active ?? true,
+})
+
+const normalizeCustomSkill = (skill: CustomSkill | Omit<CustomSkill, 'instructions' | 'api_base_url' | 'api_type' | 'api_auth_type' | 'api_domain' | 'domain_active' | 'has_credentials' | 'github_repo_id' | 'github_analysis_type' | 'github_repo_name'> & Partial<CustomSkill>): CustomSkill => ({
+  ...skill,
+  instructions: skill.instructions || '',
+  api_base_url: skill.api_base_url ?? null,
+  api_type: skill.api_type ?? null,
+  api_auth_type: skill.api_auth_type ?? null,
+  api_domain: skill.api_domain ?? null,
+  domain_active: skill.domain_active ?? true,
+  has_credentials: skill.has_credentials ?? false,
+  github_repo_id: skill.github_repo_id ?? null,
+  github_analysis_type: skill.github_analysis_type ?? null,
+  github_repo_name: skill.github_repo_name ?? null,
+})
 
 export interface LearningRecord {
   id: string
@@ -256,7 +284,7 @@ const dummyDatabaseContext: DatabaseContext[] = [
   },
 ];
 
-export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
+export const createContextSlice: StateCreator<StoreState, [], [], ContextSlice> = (set, get) => ({
   isSidebarOpen: false,
   activeSection: 'instructions',
   selectedDatasourceId: null,
@@ -613,10 +641,10 @@ export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
 
   // Load default preferences from backend on app startup
   loadPreferencesFromBackend: async () => {
-    const { isAuthenticated } = get()
+    const { user } = get()
 
     // Only load preferences if authenticated
-    if (!isAuthenticated) {
+    if (!user) {
       return
     }
 
@@ -666,7 +694,7 @@ export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
   resetInstructionsToDefault: async () => {
     try {
       const response = await ApiService.resetPreferenceToDefault('instructions')
-      set({ globalInstructions: response.data?.content || dummyInstructions })
+      set({ globalInstructions: response.data?.content || defaultInstructions })
     } catch (error) {
       console.error('Failed to reset instructions to default:', error)
       throw error
@@ -676,7 +704,7 @@ export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
   resetStyleGuidelinesToDefault: async () => {
     try {
       const response = await ApiService.resetPreferenceToDefault('style_guidelines')
-      set({ styleGuidelines: response.data?.content || dummyStyleGuidelines })
+      set({ styleGuidelines: response.data?.content || defaultStyleGuidelines })
     } catch (error) {
       console.error('Failed to reset style guidelines to default:', error)
       throw error
@@ -723,7 +751,7 @@ export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
     set({ isLoadingSkills: true })
     try {
       const response = await ApiService.getSkills()
-      set({ skills: response.data || [], isLoadingSkills: false })
+      set({ skills: (response.data || []).map(normalizeSkillStatus), isLoadingSkills: false })
     } catch (error) {
       console.error('Failed to load skills:', error)
       set({ isLoadingSkills: false })
@@ -781,7 +809,7 @@ export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
     set({ isLoadingCustomSkills: true })
     try {
       const response = await ApiService.getCustomSkills()
-      set({ customSkills: response.data || [], isLoadingCustomSkills: false })
+      set({ customSkills: (response.data || []).map(normalizeCustomSkill), isLoadingCustomSkills: false })
     } catch (error) {
       console.error('Failed to load custom skills:', error)
       set({ isLoadingCustomSkills: false })
@@ -792,7 +820,10 @@ export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
     try {
       const response = await ApiService.createCustomSkill(data)
       await get().loadCustomSkills()
-      return response.data
+      if (!response.data) {
+        throw new Error('Custom skill creation returned no data')
+      }
+      return normalizeCustomSkill(response.data)
     } catch (error) {
       console.error('Failed to create custom skill:', error)
       throw error
@@ -803,7 +834,10 @@ export const createContextSlice: StateCreator<ContextSlice> = (set, get) => ({
     try {
       const response = await ApiService.updateCustomSkill(id, data)
       await get().loadCustomSkills()
-      return response.data
+      if (!response.data) {
+        throw new Error('Custom skill update returned no data')
+      }
+      return normalizeCustomSkill(response.data)
     } catch (error) {
       console.error('Failed to update custom skill:', error)
       throw error

--- a/client/src/types/folder.ts
+++ b/client/src/types/folder.ts
@@ -191,6 +191,7 @@ export interface ViewerDashboardDetail {
   html_content: string
   version: number
   notebook_id: string
+  notebook_name?: string | null
   created_at: string | null
 }
 

--- a/client/src/utils/toast.ts
+++ b/client/src/utils/toast.ts
@@ -1,6 +1,10 @@
 import { toast, type ToastOptions } from 'react-toastify'
 
-const defaultOptions: ToastOptions = {
+type ByaanToastOptions = ToastOptions & {
+  progressStyle?: React.CSSProperties
+}
+
+const defaultOptions: ByaanToastOptions = {
   position: 'bottom-right',
   autoClose: 3000,
   hideProgressBar: false,
@@ -21,7 +25,7 @@ const defaultOptions: ToastOptions = {
 }
 
 export const showToast = {
-  success: (message: string, options?: ToastOptions) => {
+  success: (message: string, options?: ByaanToastOptions) => {
     toast.success(message, {
       ...defaultOptions,
       style: {
@@ -37,7 +41,7 @@ export const showToast = {
     })
   },
 
-  error: (message: string, options?: ToastOptions) => {
+  error: (message: string, options?: ByaanToastOptions) => {
     toast.error(message, {
       ...defaultOptions,
       style: {
@@ -53,7 +57,7 @@ export const showToast = {
     })
   },
 
-  warning: (message: string, options?: ToastOptions) => {
+  warning: (message: string, options?: ByaanToastOptions) => {
     toast.warning(message, {
       ...defaultOptions,
       style: {
@@ -69,7 +73,7 @@ export const showToast = {
     })
   },
 
-  info: (message: string, options?: ToastOptions) => {
+  info: (message: string, options?: ByaanToastOptions) => {
     toast.info(message, {
       ...defaultOptions,
       style: {
@@ -85,7 +89,7 @@ export const showToast = {
     })
   },
 
-  loading: (message: string, options?: ToastOptions) => {
+  loading: (message: string, options?: ByaanToastOptions) => {
     return toast.loading(message, {
       ...defaultOptions,
       style: {

--- a/client/tests/e2e/home-responsive.spec.ts
+++ b/client/tests/e2e/home-responsive.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test } from '@playwright/test'
+
+const tenantId = '00000000-0000-4000-8000-000000000001'
+const userId = '00000000-0000-4000-8000-000000000002'
+
+const ownerScopes = [
+  'notebook.create',
+  'notebook.read_own',
+  'notebook.update_own',
+  'notebook.delete_own',
+  'connection.create',
+  'connection.read',
+  'connection.update',
+  'connection.delete',
+  'dataset.create',
+  'dataset.read',
+  'dataset.update',
+  'dataset.delete',
+  'query.create',
+  'query.read',
+  'query.update',
+  'query.delete',
+  'query.execute',
+  'llm_connection.create',
+  'llm_connection.read',
+  'llm_connection.update',
+  'llm_connection.delete',
+  'dashboard.read',
+  'dashboard.export',
+  'dashboard.share',
+  'sharing.read',
+  'folder.create',
+  'folder.read',
+  'folder.update',
+  'folder.delete',
+  'folder.manage_members',
+  'folder.share_notebook',
+]
+
+async function mockApi(page: import('@playwright/test').Page) {
+  await page.addInitScript(({ tenantId: activeTenantId }) => {
+    window.localStorage.setItem('byaan_active_tenant', activeTenantId)
+    window.localStorage.setItem('byaan_mcp_setup_dismissed', 'true')
+  }, { tenantId })
+
+  await page.route('**/api/**', async route => {
+    const url = new URL(route.request().url())
+    const path = url.pathname
+
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      })
+
+    if (path === '/api/app/config') {
+      return json({
+        success: true,
+        data: {
+          features: {
+            worker_features_enabled: false,
+            external_sharing_enabled: false,
+            notebook_import_enabled: false,
+            public_registration_enabled: false,
+            local_auth_enabled: true,
+            invitation_only: false,
+            google_oauth_enabled: false,
+            enterprise_licensed: false,
+            team_sharing_enabled: false,
+          },
+          community_bootstrap: {
+            user_id: userId,
+            email: 'owner@example.test',
+            full_name: 'Owner Example',
+            tenant_id: tenantId,
+          },
+        },
+      })
+    }
+
+    if (path === '/api/scopes/all') {
+      return json({
+        success: true,
+        data: {
+          tenants: [
+            {
+              tenant_id: tenantId,
+              tenant_name: 'Responsive Smoke Tenant',
+              role: 'owner',
+              scopes: ownerScopes,
+              features: {
+                worker_features_enabled: false,
+                external_sharing_enabled: false,
+                notebook_import_enabled: false,
+                public_registration_enabled: false,
+                local_auth_enabled: true,
+                invitation_only: false,
+                google_oauth_enabled: false,
+                team_sharing_enabled: false,
+              },
+            },
+          ],
+        },
+      })
+    }
+
+    if (path === '/api/preferences/instructions' || path === '/api/preferences/style_guidelines') {
+      return json({ success: true, data: { content: '' } })
+    }
+
+    if (path === '/api/llm-connections') {
+      return json({ success: true, data: { items: [], total: 0 } })
+    }
+
+    if (path === '/api/datasources') {
+      return json({ success: true, data: { items: [], total: 0 } })
+    }
+
+    if (path === '/api/github/oauth/status') {
+      return json({ success: true, data: { connected: true, username: 'octocat', scopes: [], auth_method: 'oauth' } })
+    }
+
+    if (path === '/api/mcp/keys') {
+      return json({ data: [{ id: 'key-1', name: 'Smoke key', key_prefix: 'byaan_', is_active: true, last_used_at: null, created_at: '2026-08-17T00:00:00Z' }] })
+    }
+
+    if (path === '/api/schedules') {
+      return json({ data: [] })
+    }
+
+    if (path === '/api/notebooks') {
+      return json({
+        success: true,
+        data: {
+          items: [
+            {
+              id: 'notebook-1',
+              notebook_name: 'Responsive smoke notebook',
+              description: 'Viewport smoke validation',
+              created_by: userId,
+              created_at: '2026-08-17T00:00:00Z',
+              updated_at: '2026-08-17T00:00:00Z',
+            },
+          ],
+          total: 1,
+        },
+      })
+    }
+
+    return json({ success: true, data: { items: [], total: 0 } })
+  })
+}
+
+test.describe('home responsive smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockApi(page)
+  })
+
+  test('renders the authenticated community home page at required viewport', async ({ page }, testInfo) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /new notebook/i }).first()).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'My Notebooks' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Responsive smoke notebook' })).toBeVisible()
+    await expect(page.getByText('Something went wrong')).toHaveCount(0)
+    await expect(page.getByText('Booting Byaan')).toHaveCount(0)
+
+    expect(page.viewportSize()).toEqual(testInfo.project.name.includes('390x844')
+      ? { width: 390, height: 844 }
+      : { width: 1440, height: 900 })
+  })
+})

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -6,6 +6,10 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -17,8 +21,8 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true

--- a/docs/product/data-studio-commercial-official-landing-manifest.md
+++ b/docs/product/data-studio-commercial-official-landing-manifest.md
@@ -1,0 +1,278 @@
+# Data Studio Commercial Official Landing Manifest
+
+This manifest defines the selective migration from the staging branch
+`veadk-data-studio/integration/data-studio-commercial-p0` at
+`082f209c476b26c4d5c891849532a7018a42a1f4` into the official repository history.
+The staging branch is evidence-only input. It is not a base branch, merge source,
+or tree to copy wholesale.
+
+## Baseline and safety constraints
+
+- Official target repository: `byaan-ai/byaan`
+- Official fork used for publication: `marchpure/byaan`
+- Official landing branch: `integration/data-studio-commercial-official-p0`
+- Official base at landing start: `1e3410fd29c09eb2dd01f88d31650120dd1aeb84`
+- Staging final SHA: `082f209c476b26c4d5c891849532a7018a42a1f4`
+- Staging connector/modeling input `54c1f299800e0c3957b31f482e11fed21b75024f`
+  is an ancestor of staging final.
+- Staging dashboard/evaluation/sharing input
+  `acd2749869626b66b146b88a03fe96fd75f44cc7` is an ancestor of staging final.
+- Staging and official `origin/main` have unrelated histories; this landing must
+  not use `--allow-unrelated-histories`.
+- The branch `official-fork/integration/data-studio-commercial-p0` is a known
+  wrong staging-tree push and must not be used as a base, merge source, PR head,
+  or continued push target. It is intentionally left for later cleanup.
+
+## Landing method
+
+Each domain must be ported in small, reviewable batches after reading the
+official implementation it touches. Changes should be behavior- and
+contract-oriented, using path-scoped patches or manual reconciliation. The
+landing must preserve official workflows and avoid copying the staging tree.
+
+## Connector and modeling
+
+Contracts to migrate:
+
+- Governed source connection/resource model for local files, public web URLs,
+  Feishu/Lark, Volcengine TOS, SQL databases, MongoDB, DynamoDB, and Databricks.
+- Connector catalog with honest availability states. Connector/modeling readiness
+  remains `PARTIAL`, not production-ready: `0 ready / 14 beta / 26 planned /
+  0 blocked / 40 total`.
+- Source resource snapshots with raw locators, parser metadata, lineage, sync
+  status, retry/error state, and tombstone/delete behavior.
+- Tabular projection review for CSV, Excel, JSON/JSONL, Parquet, Feishu
+  Sheet/Base, and TOS objects, with projected dataset handoff.
+- Source understanding run, evidence fragments, relationship/candidate review,
+  semantic draft creation, immutable publish, reload, and MCP `query_metric`
+  contracts.
+- NoSQL guardrails: MongoDB and DynamoDB profile evidence may exist, but semantic
+  candidates remain blocked until reviewed tabular projection is proven.
+- OpenHuman-style provenance gate for semi-structured context extraction remains
+  unverified; context rows stay beta until runtime metadata proves algorithm,
+  config digest, source revision, confidence, evidence locator, provenance, and
+  warnings.
+
+Expected file areas:
+
+- `server/models/source_connections.py`
+- `server/models/source_resources.py`
+- `server/models/source_snapshots.py`
+- `server/models/source_understanding.py`
+- `server/models/knowledge_resources.py`
+- `server/models/semantic_models.py`
+- `server/schemas/source_connections.py`
+- `server/schemas/source_resources.py`
+- `server/schemas/source_overview.py`
+- `server/schemas/source_understanding.py`
+- `server/routers/source_connections.py`
+- `server/routers/source_resources.py`
+- `server/routers/semantic_models.py`
+- `server/services/connector_catalog.py`
+- `server/services/analysis_artifacts.py`
+- `server/services/assets.py`
+- `server/services/connections.py`
+- `server/services/database_operations.py`
+- `server/services/folder_service.py`
+- `server/mcp/tools.py`
+- `server/mcp/tool_wrappers.py`
+- `client/src/features/data-modeling/**`
+- `client/src/pages/SourceDetailPage.tsx`
+- `client/src/components/SourceConnectorImportPanel.tsx`
+- `client/src/services/api.ts`
+- Connector/modeling tests under `server/tests/` and browser/API smoke scripts
+  under `client/scripts/`.
+
+## Dashboard
+
+Contracts to migrate:
+
+- Structured dashboard assets for saved queries, semantic metrics, and context
+  search.
+- Explicit legacy dashboard handling so legacy HTML assets do not fall through to
+  generic app errors.
+- Lifecycle/status states for stale, partial, blocked, permission-denied,
+  malformed, policy-blocked, and legacy assets.
+- Safe review/notebook preview actions and legacy structured-action gating.
+- Dashboard REST, service, repository, MCP, persistence, migration, security, and
+  UI coverage.
+
+Expected file areas:
+
+- `server/models/dashboard.py`
+- `server/repositories/dashboard.py`
+- `server/routers/dashboard.py`
+- `server/schemas/dashboard.py`
+- `server/services/dashboard.py`
+- `server/services/dashboard_cache_service.py`
+- `server/services/dashboard_refresh_service.py`
+- `client/src/features/dashboard/**`
+- `client/src/components/DashboardFilterBar.tsx`
+- `client/src/components/DashboardPreviewPanel.tsx`
+- `client/src/components/home/SharedDashboardsSection.tsx`
+- `client/src/services/dashboard.ts`
+- `client/src/types/dashboard.ts`
+- Dashboard-focused tests and smoke scripts.
+
+## Evaluation
+
+Contracts to migrate:
+
+- Evaluation suite/case/version/run authoritative model.
+- REST APIs for suite creation, case import/listing, draft version creation,
+  publish, runner claim/heartbeat/complete/failure, comparison, feedback advisor,
+  and promotion decision.
+- MCP parity for evaluation workflows.
+- Actionable empty-state and explicit demo fixture loading in the UI.
+- Tenant isolation, scope protection, idempotency, resumability, redaction, and
+  promotion blocking behavior.
+
+Expected file areas:
+
+- `server/models/evaluation.py`
+- `server/repositories/evaluation.py`
+- `server/routers/evaluation.py`
+- `server/schemas/evaluation.py`
+- `server/serializers/evaluation.py`
+- `server/services/evaluation.py`
+- `server/scripts/evaluation_mcp_parity_smoke.py`
+- `server/scripts/evaluation_release_gate_8080.py`
+- `server/scripts/seed_evaluation_smoke.py`
+- `client/src/features/evaluation/**`
+- `client/src/services/evaluation.ts`
+- `client/src/types/evaluation.ts`
+- Evaluation-focused tests and smoke scripts.
+
+## Sharing
+
+Contracts to migrate:
+
+- Canonical sharing grants for notebooks, dashboards, folders, and compatible
+  worker-backed sharing surfaces.
+- Folder notebook and folder dashboard share/revoke evidence.
+- Object authorization checks before read or grant operations.
+- Self-hosted external sharing policy: worker-backed external sharing returns an
+  explicit unavailable response in self-hosted mode.
+- Redaction of secret, token, password, and verifier values in APIs, logs, audit
+  events, and release gates.
+
+Expected file areas:
+
+- `server/auth/object_authorizer.py`
+- `server/models/sharing.py`
+- `server/routers/sharing.py`
+- `server/serializers/sharing.py`
+- `server/services/sharing.py`
+- `server/routers/folders.py`
+- `server/routers/exports.py`
+- `server/services/folder_service.py`
+- `client/src/components/ShareModal.tsx`
+- `client/src/types/folder.ts`
+- Sharing-focused tests and release gate scripts.
+
+## Shared auth, tenant, MCP, and API wiring
+
+Contracts to migrate:
+
+- Scope constants and dependencies required by the new Data Studio routes.
+- Tenant isolation across source resources, dashboards, evaluation, and sharing.
+- MCP tool registration/wrappers for semantic model, dashboard, evaluation, and
+  sharing read surfaces.
+- App route registration in `server/main.py`.
+- Client route/sidebar/API service integration.
+
+Expected file areas:
+
+- `server/auth/dependencies.py`
+- `server/auth/scopes.py`
+- `server/main.py`
+- `server/models/__init__.py`
+- `server/mcp/tools.py`
+- `server/mcp/tool_wrappers.py`
+- `client/src/App.tsx`
+- `client/src/components/CollapsibleSidebar.tsx`
+- `client/src/constants/scopes.ts`
+- `client/src/services/api.ts`
+- `client/src/stores/**`
+
+## Migration plan
+
+Official migrations must be rebuilt on top of the official Alembic chain, not
+copied as a staging migration chain. The final chain must have one head and must
+upgrade cleanly on fresh and existing SQLite and PostgreSQL databases.
+
+Expected migration content:
+
+- Source connections/resources/snapshots/knowledge/evidence/source-understanding
+  tables and related indexes.
+- Semantic model/version lineage tables.
+- Governed dashboard asset/version/share/backfill tables or columns.
+- Evaluation suite/case/version/run/artifact/advisor/promotion tables.
+- Canonical sharing grant/evidence tables.
+- Any compatibility bridge required by existing official tables.
+
+Validation commands:
+
+- `cd server && PYTHONPATH=..:tests uv run alembic heads`
+- Fresh SQLite upgrade.
+- Existing SQLite upgrade from the official base schema.
+- Disposable PostgreSQL upgrade when a local PostgreSQL target is available.
+- Migration-focused pytest coverage.
+
+## Docker, package, and dependency policy
+
+Dependencies must be merged at dependency level only:
+
+- Add backend packages only when required by landed runtime/test behavior.
+- Add frontend packages/scripts only when required by landed UI/smoke behavior.
+- Do not replace `uv.lock` or `client/pnpm-lock.yaml` wholesale from staging.
+- Preserve official Docker and self-hosted startup behavior while adding only
+  necessary route/static/runtime support.
+
+Expected file areas:
+
+- `pyproject.toml`
+- `uv.lock`
+- `client/package.json`
+- `client/pnpm-lock.yaml`
+- `Dockerfile.self-hosted`
+- `docker-compose.yml`
+- `server/Dockerfile`
+- `docker/self-hosted/**`
+
+## Tests and validation gates
+
+Each domain batch should include scoped tests before commit where practical.
+Before handoff, rerun:
+
+- Connector/modeling pytest gates.
+- Dashboard pytest gates.
+- Evaluation pytest gates.
+- Sharing pytest gates.
+- REST/MCP parity checks.
+- Tenant isolation and permission tests.
+- Alembic single-head and fresh/existing migration checks.
+- Frontend typecheck/build and relevant lint.
+- Browser/API smokes at 1440x900 and 390x844 for Connector/Modeling,
+  Dashboard, Evaluation, and Sharing where scripts exist.
+- `git diff --check`.
+- Secret scan of the outgoing diff.
+
+Staging test history is not evidence for the official branch.
+
+## Explicit exclusions
+
+The official landing must exclude:
+
+- Any deletion or replacement of official `.github/workflows/**`.
+- `client/tmp-data-modeling-screens*/` and other temporary screenshot folders.
+- `docs/product/dashboard-browser-smoke/*.png` and other historical smoke images.
+- Machine-produced artifacts not required for source review.
+- Unrelated product/UX/docs churn from staging.
+- Wholesale lockfile replacement.
+- Direct pushes to `origin`.
+- Force pushes.
+- Staging branch pushes to `origin` or `official-fork`.
+- Claims that Connector/Modeling is fully ready without real credentials and
+  verified OpenHuman-compatible provenance.
+- Claims that the work has entered official `main` before maintainer merge.

--- a/server/auth/object_authorizer.py
+++ b/server/auth/object_authorizer.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext
+from server.auth.scopes import Scope
+from server.models.notebooks import Notebook
+
+
+class NotebookAction(str, Enum):
+    EXPORT = "export"
+    SHARE_MANAGE = "share_manage"
+
+
+NOTEBOOK_ACTION_SCOPES: dict[NotebookAction, Scope] = {
+    NotebookAction.EXPORT: Scope.DASHBOARD_EXPORT,
+    NotebookAction.SHARE_MANAGE: Scope.DASHBOARD_SHARE,
+}
+
+
+async def authorize_notebook_action(
+    *,
+    session: AsyncSession,
+    auth: AuthContext,
+    notebook_id: str,
+    action: NotebookAction,
+) -> Notebook:
+    required_scope = NOTEBOOK_ACTION_SCOPES[action]
+    if not auth.has_scope(required_scope):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied. Required scope: {required_scope.value}",
+        )
+
+    notebook = await session.scalar(
+        select(Notebook).where(
+            Notebook.id == notebook_id,
+            Notebook.tenant_id == auth.tenant_id,
+        )
+    )
+    if notebook is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+
+    if notebook.created_by is None or str(notebook.created_by) != str(auth.user_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only share or export notebooks you created",
+        )
+
+    return notebook

--- a/server/auth/scopes.py
+++ b/server/auth/scopes.py
@@ -61,6 +61,9 @@ class Scope(str, Enum):
     DASHBOARD_EXPORT = "dashboard.export"
     DASHBOARD_SHARE = "dashboard.share"
 
+    # Sharing scopes
+    SHARING_READ = "sharing.read"
+
     # Annotation scopes
     ANNOTATION_CREATE = "annotation.create"
     ANNOTATION_READ = "annotation.read"
@@ -135,6 +138,8 @@ OWNER_SCOPES: list[str] = [
     Scope.DASHBOARD_READ.value,
     Scope.DASHBOARD_EXPORT.value,
     Scope.DASHBOARD_SHARE.value,
+    # Sharing
+    Scope.SHARING_READ.value,
     # Annotation
     Scope.ANNOTATION_CREATE.value,
     Scope.ANNOTATION_READ.value,
@@ -198,6 +203,8 @@ ADMIN_SCOPES: list[str] = [
     Scope.DASHBOARD_READ.value,
     Scope.DASHBOARD_EXPORT.value,
     Scope.DASHBOARD_SHARE.value,
+    # Sharing
+    Scope.SHARING_READ.value,
     # Annotation
     Scope.ANNOTATION_CREATE.value,
     Scope.ANNOTATION_READ.value,
@@ -258,6 +265,8 @@ MEMBER_SCOPES: list[str] = [
     # Dashboard
     Scope.DASHBOARD_READ.value,
     Scope.DASHBOARD_EXPORT.value,
+    # Sharing
+    Scope.SHARING_READ.value,
     # Annotation (read-only)
     Scope.ANNOTATION_READ.value,
     # Tenant (read-only)

--- a/server/main.py
+++ b/server/main.py
@@ -52,6 +52,7 @@ from server.routers import claude_oauth as claude_oauth_router
 from server.routers import codex_oauth as codex_oauth_router
 from server.routers import connections as connections_router
 from server.routers import custom_skills as custom_skills_router
+from server.routers import dashboard as dashboard_router
 from server.routers import databricks_oauth as databricks_oauth_router
 from server.routers import datasets as datasets_router  # Dataset management
 from server.routers import (
@@ -584,6 +585,7 @@ app.include_router(codex_oauth_router.router, tags=["codex-oauth"])
 app.include_router(exports_router.router, prefix="/api", tags=["exports"])
 
 app.include_router(imports_router.router, prefix="/api", tags=["imports"])
+app.include_router(dashboard_router.router, prefix="/api", tags=["dashboard"])
 app.include_router(evaluation_router.router, prefix="/api", tags=["evaluation"])
 
 app.include_router(user_preferences_router.router, prefix="/api", tags=["user-preferences"])

--- a/server/main.py
+++ b/server/main.py
@@ -81,6 +81,8 @@ from server.routers import skill_loop as skill_loop_router
 from server.routers import skill_suggestions as skill_suggestions_router
 from server.routers import skills as skills_router
 from server.routers import slack as slack_router
+from server.routers import source_connections as source_connections_router
+from server.routers import source_resources as source_resources_router
 from server.routers import tenant as tenant_router
 from server.routers import user_preferences as user_preferences_router
 from server.routers import users as users_router
@@ -587,6 +589,8 @@ app.include_router(exports_router.router, prefix="/api", tags=["exports"])
 app.include_router(imports_router.router, prefix="/api", tags=["imports"])
 app.include_router(dashboard_router.router, prefix="/api", tags=["dashboard"])
 app.include_router(evaluation_router.router, prefix="/api", tags=["evaluation"])
+app.include_router(source_connections_router.router, prefix="/api", tags=["source-connections"])
+app.include_router(source_resources_router.router, prefix="/api", tags=["source-resources"])
 
 app.include_router(user_preferences_router.router, prefix="/api", tags=["user-preferences"])
 app.include_router(learnings_router.router, prefix="/api", tags=["learnings"])

--- a/server/main.py
+++ b/server/main.py
@@ -57,6 +57,7 @@ from server.routers import datasets as datasets_router  # Dataset management
 from server.routers import (
     datasources as datasources_router,
 )  # Unified datasources (connections + datasets)
+from server.routers import evaluation as evaluation_router
 from server.routers import exports as exports_router
 from server.routers import (
     file_upload as file_upload_router,
@@ -583,6 +584,7 @@ app.include_router(codex_oauth_router.router, tags=["codex-oauth"])
 app.include_router(exports_router.router, prefix="/api", tags=["exports"])
 
 app.include_router(imports_router.router, prefix="/api", tags=["imports"])
+app.include_router(evaluation_router.router, prefix="/api", tags=["evaluation"])
 
 app.include_router(user_preferences_router.router, prefix="/api", tags=["user-preferences"])
 app.include_router(learnings_router.router, prefix="/api", tags=["learnings"])

--- a/server/main.py
+++ b/server/main.py
@@ -74,6 +74,7 @@ from server.routers import raw_query as raw_query_router
 from server.routers import schedules as schedules_router
 from server.routers import scopes as scopes_router
 from server.routers import settings as settings_router
+from server.routers import sharing as sharing_router
 from server.routers import skill_loop as skill_loop_router
 from server.routers import skill_suggestions as skill_suggestions_router
 from server.routers import skills as skills_router
@@ -615,6 +616,7 @@ app.include_router(settings_router.router, prefix="/api", tags=["settings"])
 app.include_router(tenant_router.router, prefix="/api", tags=["tenants"])
 
 app.include_router(folders_router.router, prefix="/api", tags=["folders"])
+app.include_router(sharing_router.router, prefix="/api", tags=["sharing"])
 
 app.include_router(github_router.router, prefix="/api", tags=["github"])
 app.include_router(databricks_oauth_router.router, prefix="/api", tags=["databricks-oauth"])

--- a/server/main.py
+++ b/server/main.py
@@ -75,6 +75,7 @@ from server.routers import queries as queries_router
 from server.routers import raw_query as raw_query_router
 from server.routers import schedules as schedules_router
 from server.routers import scopes as scopes_router
+from server.routers import semantic_models as semantic_models_router
 from server.routers import settings as settings_router
 from server.routers import sharing as sharing_router
 from server.routers import skill_loop as skill_loop_router
@@ -591,6 +592,7 @@ app.include_router(dashboard_router.router, prefix="/api", tags=["dashboard"])
 app.include_router(evaluation_router.router, prefix="/api", tags=["evaluation"])
 app.include_router(source_connections_router.router, prefix="/api", tags=["source-connections"])
 app.include_router(source_resources_router.router, prefix="/api", tags=["source-resources"])
+app.include_router(semantic_models_router.router, prefix="/api", tags=["semantic-models"])
 
 app.include_router(user_preferences_router.router, prefix="/api", tags=["user-preferences"])
 app.include_router(learnings_router.router, prefix="/api", tags=["learnings"])

--- a/server/mcp/tool_wrappers.py
+++ b/server/mcp/tool_wrappers.py
@@ -5,6 +5,7 @@ These wrappers adapt Byaan's internal tools (which use RunContextWrapper)
 to work with FastMCP's tool protocol.
 """
 
+import hashlib
 import json
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -14,6 +15,7 @@ from agents.run_context import RunContextWrapper
 from server.auth.tenant_context import set_tenant_id
 from server.db.session import AsyncSessionFactory
 from server.utils.custom_logger import get_logger
+from server.utils.error_sanitizer import sanitize_error_message, sanitize_error_payload
 
 if TYPE_CHECKING:
     from server.mcp.session_manager import MCPSessionManager
@@ -27,6 +29,30 @@ LEARNING_HINT = (
 )
 
 _session_manager: "MCPSessionManager | None" = None
+
+MCP_EVALUATION_DEFAULT_LIMIT = 20
+MCP_EVALUATION_MAX_LIMIT = 50
+
+
+def _json_error(error: Exception | str, *, operation: str | None = None) -> str:
+    payload = {"success": False, "error": sanitize_error_message(error)}
+    if operation:
+        payload["operation"] = operation
+    return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def _json_success(**payload: Any) -> str:
+    return json.dumps({"success": True, **payload}, ensure_ascii=False, default=str)
+
+
+def _stable_feedback_case_key(feedback: dict[str, Any]) -> str:
+    if feedback.get("case_key"):
+        return str(feedback["case_key"])
+    feedback_id = feedback.get("feedback_id") or feedback.get("trace_id")
+    if feedback_id:
+        return f"mcp-feedback-{feedback_id}"
+    digest = hashlib.sha256(json.dumps(feedback, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:16]
+    return f"mcp-feedback-{digest}"
 
 
 def set_session_manager(manager: "MCPSessionManager") -> None:
@@ -1290,3 +1316,394 @@ async def describe_sharing_grant_wrapper(grant_id: str, tenant_id: UUID, user_id
     except Exception as e:
         logger.error(f"Error in describe_sharing_grant_wrapper: {e}", exc_info=True)
         return json.dumps({"success": False, "error": str(e)})
+
+
+async def search_evaluation_suites_wrapper(
+    query: str,
+    target_kind: str,
+    status: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    limit: int = MCP_EVALUATION_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_suite_payload
+        from server.services.evaluation import EvaluationService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            suites = await EvaluationService(session).list_suites(
+                tenant_id=tenant_id,
+                query=query,
+                target_kind=target_kind,
+                status=status,
+                limit=max(1, min(limit, MCP_EVALUATION_MAX_LIMIT)),
+            )
+        return _json_success(items=[evaluation_suite_payload(suite) for suite in suites], total=len(suites))
+    except Exception as e:
+        logger.error(f"Error in search_evaluation_suites_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="search_evaluation_suites")
+
+
+async def describe_evaluation_suite_wrapper(
+    suite_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    include_manifests: bool = False,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_suite_payload
+        from server.services.evaluation import EvaluationService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            suite, versions = await EvaluationService(session).describe_suite(
+                tenant_id=tenant_id,
+                suite_id=UUID(suite_id),
+            )
+        return _json_success(
+            suite=evaluation_suite_payload(
+                suite,
+                versions=versions,
+                include_versions=True,
+                include_manifests=include_manifests,
+            )
+        )
+    except Exception as e:
+        logger.error(f"Error in describe_evaluation_suite_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="describe_evaluation_suite")
+
+
+async def list_evaluation_cases_wrapper(
+    suite_version_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    include_expected_contract: bool = False,
+    limit: int = MCP_EVALUATION_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_case_payload
+        from server.services.evaluation import EvaluationService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            cases = await EvaluationService(session).list_cases(
+                tenant_id=tenant_id,
+                suite_version_id=UUID(suite_version_id),
+            )
+        limit = max(1, min(limit, MCP_EVALUATION_MAX_LIMIT))
+        return _json_success(
+            items=[
+                evaluation_case_payload(case, include_expected_contract=include_expected_contract)
+                for case in cases[:limit]
+            ],
+            total=len(cases),
+            has_more=len(cases) > limit,
+        )
+    except Exception as e:
+        logger.error(f"Error in list_evaluation_cases_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="list_evaluation_cases")
+
+
+async def create_evaluation_case_draft_wrapper(
+    suite_version_id: str,
+    case_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_case_payload
+        from server.services.evaluation import EvaluationService
+
+        payload = json.loads(case_json or "{}")
+        if not isinstance(payload, dict):
+            raise ValueError("case_json must be a JSON object")
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            case, created = await EvaluationService(session).create_case_draft(
+                tenant_id=tenant_id,
+                suite_version_id=UUID(suite_version_id),
+                case_key=str(payload["case_key"]),
+                title=str(payload.get("title") or payload["case_key"]),
+                target_kinds=list(payload.get("target_kinds") or []),
+                operation=str(payload.get("operation") or "answer_question"),
+                question=str(payload["question"]),
+                expected_contract=dict(payload.get("expected_contract") or {}),
+                provenance=dict(payload.get("provenance") or {"source": "manual"}),
+                tags=[str(tag) for tag in payload.get("tags") or []],
+                actor_id=str(user_id),
+                actor_type="agent",
+            )
+        return _json_success(case=evaluation_case_payload(case), created=created)
+    except Exception as e:
+        logger.error(f"Error in create_evaluation_case_draft_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="create_evaluation_case_draft")
+
+
+async def preview_evaluation_ground_truth_wrapper(
+    expected_contract_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.schemas.evaluation import EvaluationExpectedContract
+
+        payload = json.loads(expected_contract_json or "{}")
+        if not isinstance(payload, dict):
+            raise ValueError("expected_contract_json must be a JSON object")
+        expected = EvaluationExpectedContract.model_validate(payload)
+        ground_truth = expected.ground_truth_sql
+        if ground_truth is None:
+            return _json_success(ground_truth={"present": False, "readonly": None})
+        return _json_success(
+            ground_truth={
+                "present": True,
+                "readonly": True,
+                "dialect": ground_truth.dialect,
+                "must_reference": ground_truth.must_reference,
+                "must_not_reference": ground_truth.must_not_reference,
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error in preview_evaluation_ground_truth_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="preview_evaluation_ground_truth")
+
+
+async def run_evaluation_wrapper(
+    suite_version_id: str,
+    target_snapshot_json: str,
+    idempotency_key: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_run_payload
+        from server.services.evaluation import EvaluationService
+
+        payload = json.loads(target_snapshot_json or "{}")
+        if not isinstance(payload, dict):
+            raise ValueError("target_snapshot_json must be a JSON object")
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            run = await EvaluationService(session).create_preflight_run(
+                tenant_id=tenant_id,
+                suite_version_id=UUID(suite_version_id),
+                target_snapshot_payload=payload,
+                actor_id=str(user_id),
+                idempotency_key=idempotency_key or None,
+                actor_type="agent",
+            )
+        return _json_success(run=evaluation_run_payload(run))
+    except Exception as e:
+        logger.error(f"Error in run_evaluation_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="run_evaluation")
+
+
+async def get_evaluation_run_wrapper(
+    run_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    include_case_results: bool = True,
+    limit: int = MCP_EVALUATION_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_case_run_payload, evaluation_run_payload
+        from server.services.evaluation import EvaluationService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            run, case_runs = await EvaluationService(session).get_run_report(
+                tenant_id=tenant_id,
+                run_id=UUID(run_id),
+            )
+        limit = max(1, min(limit, MCP_EVALUATION_MAX_LIMIT))
+        payload: dict[str, Any] = {"run": evaluation_run_payload(run)}
+        if include_case_results:
+            payload["case_runs"] = [
+                evaluation_case_run_payload(case_run, assessments=assessments)
+                for case_run, assessments in case_runs[:limit]
+            ]
+            payload["has_more_case_runs"] = len(case_runs) > limit
+        return _json_success(**payload)
+    except Exception as e:
+        logger.error(f"Error in get_evaluation_run_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="get_evaluation_run")
+
+
+async def compare_evaluation_runs_wrapper(
+    baseline_run_id: str,
+    candidate_run_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.services.evaluation import EvaluationService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            comparison = await EvaluationService(session).compare_runs(
+                tenant_id=tenant_id,
+                baseline_run_id=UUID(baseline_run_id),
+                candidate_run_id=UUID(candidate_run_id),
+            )
+        return _json_success(comparison=sanitize_error_payload(comparison))
+    except Exception as e:
+        logger.error(f"Error in compare_evaluation_runs_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="compare_evaluation_runs")
+
+
+async def describe_evaluation_failure_wrapper(
+    run_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    limit: int = MCP_EVALUATION_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_case_run_payload, evaluation_run_payload
+        from server.services.evaluation import EvaluationService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            run, case_runs = await EvaluationService(session).get_run_report(
+                tenant_id=tenant_id,
+                run_id=UUID(run_id),
+            )
+        failures = []
+        for case_run, assessments in case_runs:
+            failed_assessments = [
+                assessment for assessment in assessments if assessment.status != "passed" or assessment.hard_fail
+            ]
+            if case_run.status != "passed" or failed_assessments:
+                failures.append(evaluation_case_run_payload(case_run, assessments=failed_assessments))
+        limit = max(1, min(limit, MCP_EVALUATION_MAX_LIMIT))
+        return _json_success(
+            run=evaluation_run_payload(run),
+            failures=failures[:limit],
+            total=len(failures),
+            has_more=len(failures) > limit,
+        )
+    except Exception as e:
+        logger.error(f"Error in describe_evaluation_failure_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="describe_evaluation_failure")
+
+
+async def create_advisor_change_set_wrapper(
+    skill_suggestion_id: str,
+    suite_version_id: str,
+    affected_case_ids: list[str] | None,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.serializers.evaluation import advisor_change_set_payload, advisor_suggestion_payload
+        from server.services.evaluation import EvaluationService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            change_set, suggestions, created = await EvaluationService(session).create_advisor_change_set_from_skill_suggestion(
+                tenant_id=tenant_id,
+                suggestion_id=UUID(skill_suggestion_id),
+                suite_version_id=UUID(suite_version_id) if suite_version_id else None,
+                affected_case_ids=[UUID(case_id) for case_id in affected_case_ids or []],
+                actor_id=str(user_id),
+            )
+        return _json_success(
+            change_set=advisor_change_set_payload(change_set),
+            advisor_suggestions=[advisor_suggestion_payload(suggestion) for suggestion in suggestions],
+            created=created,
+        )
+    except Exception as e:
+        logger.error(f"Error in create_advisor_change_set_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="create_advisor_change_set")
+
+
+async def run_advisor_gate_wrapper(
+    change_set_id: str,
+    target_snapshot_json: str,
+    gate_kind: str,
+    idempotency_key: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.serializers.evaluation import advisor_change_set_payload, evaluation_run_payload
+        from server.services.evaluation import EvaluationService
+
+        payload = json.loads(target_snapshot_json or "{}")
+        if not isinstance(payload, dict):
+            raise ValueError("target_snapshot_json must be a JSON object")
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            change_set, run = await EvaluationService(session).create_advisor_gate_run(
+                tenant_id=tenant_id,
+                change_set_id=UUID(change_set_id),
+                gate_kind=gate_kind,
+                target_snapshot_payload=payload,
+                actor_id=str(user_id),
+                idempotency_key=idempotency_key or None,
+            )
+        return _json_success(change_set=advisor_change_set_payload(change_set), run=evaluation_run_payload(run))
+    except Exception as e:
+        logger.error(f"Error in run_advisor_gate_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation=f"run_advisor_{gate_kind}")
+
+
+async def submit_evaluation_feedback_wrapper(
+    suite_version_id: str,
+    feedback_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.serializers.evaluation import evaluation_case_payload
+        from server.services.evaluation import EvaluationService
+
+        feedback = json.loads(feedback_json or "{}")
+        if not isinstance(feedback, dict):
+            raise ValueError("feedback_json must be a JSON object")
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            service = EvaluationService(session)
+            legacy_id = feedback.get("legacy_conversation_evaluation_id") or feedback.get("conversation_evaluation_id")
+            if legacy_id:
+                case, created = await service.promote_conversation_evaluation_to_case_draft(
+                    tenant_id=tenant_id,
+                    evaluation_id=UUID(str(legacy_id)),
+                    suite_version_id=UUID(suite_version_id),
+                    question=feedback.get("question"),
+                    tags=list(feedback.get("tags") or []),
+                    actor_id=str(user_id),
+                )
+            else:
+                description = str(feedback.get("description") or "")
+                expected_contract = dict(feedback.get("expected_contract") or {})
+                if not expected_contract:
+                    expected_contract = {
+                        "semantic_intent": {"description": description},
+                        "answer": {"must_include_any": list(feedback.get("must_include_any") or [])},
+                    }
+                case, created = await service.create_case_draft(
+                    tenant_id=tenant_id,
+                    suite_version_id=UUID(suite_version_id),
+                    case_key=_stable_feedback_case_key(feedback),
+                    title=str(feedback.get("title") or description or "MCP evaluation feedback")[:255],
+                    target_kinds=list(feedback.get("target_kinds") or ["agent_answer"]),
+                    operation=str(feedback.get("operation") or "answer_question"),
+                    question=str(feedback.get("question") or description or "Review feedback regression"),
+                    expected_contract=expected_contract,
+                    provenance=sanitize_error_payload(
+                        {
+                            "source": feedback.get("source") or "human_feedback",
+                            "feedback_id": feedback.get("feedback_id"),
+                            "trace_id": feedback.get("trace_id"),
+                            "principal": feedback.get("principal") or {},
+                        }
+                    ),
+                    tags=[str(tag) for tag in feedback.get("tags") or []],
+                    actor_id=str(user_id),
+                    actor_type="agent",
+                )
+        return _json_success(case=evaluation_case_payload(case), created=created)
+    except Exception as e:
+        logger.error(f"Error in submit_evaluation_feedback_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="submit_evaluation_feedback")

--- a/server/mcp/tool_wrappers.py
+++ b/server/mcp/tool_wrappers.py
@@ -11,9 +11,18 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from agents.run_context import RunContextWrapper
+from fastapi import HTTPException
+from sqlalchemy import select
 
+from server.auth.scopes import Scope, get_scopes_for_role, has_scope
 from server.auth.tenant_context import set_tenant_id
 from server.db.session import AsyncSessionFactory
+from server.models.dashboard import Dashboard, DashboardAsset
+from server.models.notebooks import Notebook
+from server.models.tenant import Tenant
+from server.models.tenant_member import TenantMember, TenantRole
+from server.repositories.dashboard import DashboardRepository
+from server.services.dashboard import DashboardService
 from server.utils.custom_logger import get_logger
 from server.utils.error_sanitizer import sanitize_error_message, sanitize_error_payload
 
@@ -32,9 +41,25 @@ _session_manager: "MCPSessionManager | None" = None
 
 MCP_EVALUATION_DEFAULT_LIMIT = 20
 MCP_EVALUATION_MAX_LIMIT = 50
+MCP_DASHBOARD_DEFAULT_LIMIT = 20
+MCP_DASHBOARD_MAX_LIMIT = 50
 
 
 def _json_error(error: Exception | str, *, operation: str | None = None) -> str:
+    if isinstance(error, HTTPException):
+        detail = sanitize_error_payload(error.detail)
+        message = detail if isinstance(detail, str) else detail.get("message", detail.get("error", str(detail)))
+        payload: dict[str, Any] = {
+            "success": False,
+            "error": message,
+            "status_code": error.status_code,
+            "retryable": error.status_code >= 500,
+        }
+        if operation:
+            payload["operation"] = operation
+        if isinstance(detail, dict):
+            payload["details"] = detail
+        return json.dumps(payload, ensure_ascii=False, default=str)
     payload = {"success": False, "error": sanitize_error_message(error)}
     if operation:
         payload["operation"] = operation
@@ -53,6 +78,143 @@ def _stable_feedback_case_key(feedback: dict[str, Any]) -> str:
         return f"mcp-feedback-{feedback_id}"
     digest = hashlib.sha256(json.dumps(feedback, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:16]
     return f"mcp-feedback-{digest}"
+
+
+async def _require_mcp_dashboard_scope(db_session, tenant_id: UUID, user_id: UUID, scope: Scope) -> TenantRole:
+    tenant = await db_session.get(Tenant, tenant_id)
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    role = TenantRole.OWNER if tenant.owner_id == user_id else None
+    if role is None:
+        membership = await db_session.scalar(
+            select(TenantMember).where(TenantMember.tenant_id == tenant_id, TenantMember.user_id == user_id)
+        )
+        if not membership:
+            raise HTTPException(status_code=403, detail="MCP principal is not a tenant member")
+        role = TenantRole(membership.role)
+    if not has_scope(get_scopes_for_role(role), scope):
+        raise HTTPException(status_code=403, detail=f"Permission denied. Required scope: {scope.value}")
+    return role
+
+
+async def _assert_mcp_notebook_access(db_session, tenant_id: UUID, user_id: UUID, notebook_id: UUID) -> None:
+    notebook = await db_session.scalar(select(Notebook).where(Notebook.id == notebook_id, Notebook.tenant_id == tenant_id))
+    if not notebook:
+        raise HTTPException(status_code=404, detail="Notebook not found")
+    role = await _require_mcp_dashboard_scope(db_session, tenant_id, user_id, Scope.DASHBOARD_SHARE)
+    if role == TenantRole.MEMBER and str(notebook.created_by) != str(user_id):
+        raise HTTPException(status_code=403, detail="MCP principal can only use notebooks they created")
+
+
+def _asset_compact(asset: DashboardAsset) -> dict[str, Any]:
+    return {
+        "id": str(asset.id),
+        "slug": asset.slug,
+        "name": asset.name,
+        "description": asset.description,
+        "notebook_id": str(asset.notebook_id) if asset.notebook_id else None,
+        "lifecycle": asset.lifecycle,
+        "etag": asset.etag,
+        "current_draft_version_id": str(asset.current_draft_version_id) if asset.current_draft_version_id else None,
+        "published_version_id": str(asset.published_version_id) if asset.published_version_id else None,
+        "freshness_policy": asset.freshness_policy_json or {},
+        "health_summary": asset.health_summary_json or {},
+        "updated_at": asset.updated_at.isoformat() if asset.updated_at else None,
+    }
+
+
+def _version_compact(version: Dashboard, *, include_manifest: bool = False) -> dict[str, Any]:
+    payload = {
+        "id": str(version.id),
+        "version_num": version.version_num,
+        "status": version.status,
+        "content_hash": version.content_hash,
+        "manifest_schema_version": version.manifest_schema_version,
+        "pinned_model_versions": version.pinned_model_versions_json or {},
+        "pinned_source_snapshots": version.pinned_source_snapshots_json or [],
+        "validation_result": version.validation_result_json or {},
+        "migration_state": version.migration_state,
+        "is_published_immutable": version.is_published_immutable,
+        "created_at": version.created_at.isoformat() if version.created_at else None,
+    }
+    if include_manifest:
+        payload["manifest"] = version.manifest_json or {}
+    return payload
+
+
+def _lineage_from_manifest(manifest: dict[str, Any] | None, tile_id: str = "") -> dict[str, Any]:
+    manifest = manifest or {}
+    tile_data_view_ids = {
+        tile.get("data_view_id") for tile in manifest.get("tiles", []) if not tile_id or tile.get("id") == tile_id
+    }
+    data_views = []
+    for data_view in manifest.get("data_views", []):
+        if tile_id and data_view.get("id") not in tile_data_view_ids:
+            continue
+        data_views.append(
+            {
+                "id": data_view.get("id"),
+                "kind": data_view.get("kind"),
+                "question": data_view.get("question"),
+                "lineage": data_view.get("lineage") or data_view.get("saved_query", {}).get("lineage", []),
+                "evidence": data_view.get("evidence") or [],
+            }
+        )
+    return {
+        "dashboard_id": manifest.get("dashboard_id"),
+        "semantic_bindings": manifest.get("semantic_bindings") or [],
+        "data_views": data_views,
+        "migration": manifest.get("migration") or {},
+    }
+
+
+def _compact_dashboard_run(run: dict[str, Any], limit: int = MCP_DASHBOARD_DEFAULT_LIMIT) -> dict[str, Any]:
+    limit = max(1, min(limit, MCP_DASHBOARD_MAX_LIMIT))
+    views = []
+    for view in run.get("views", []):
+        result = view.get("result")
+        has_more = False
+        if isinstance(result, list):
+            has_more = len(result) > limit
+            result = result[:limit]
+        views.append(
+            {
+                "data_view_id": view.get("data_view_id"),
+                "status": view.get("status"),
+                "schema": view.get("schema", []),
+                "result": result,
+                "row_count": view.get("row_count", 0),
+                "cached": view.get("cached", False),
+                "stale": view.get("stale", False),
+                "as_of": view.get("as_of"),
+                "warnings": view.get("warnings", []),
+                "error": view.get("error"),
+                "evidence": view.get("evidence", []),
+                "lineage": view.get("lineage", []),
+                "pagination": {"limit": limit, "has_more": has_more},
+            }
+        )
+    return {
+        "contract_version": run.get("contract_version"),
+        "run_id": run.get("run_id"),
+        "dashboard_id": run.get("dashboard_id"),
+        "dashboard_version_id": run.get("dashboard_version_id"),
+        "actor_type": run.get("actor_type"),
+        "actor_id": run.get("actor_id"),
+        "correlation_id": run.get("correlation_id"),
+        "idempotency_key": run.get("idempotency_key"),
+        "mode": run.get("mode"),
+        "normalized_filters": run.get("normalized_filters", {}),
+        "filter_digest": run.get("filter_digest"),
+        "pinned_versions": run.get("pinned_versions", {}),
+        "execution_plan_digest": run.get("execution_plan_digest"),
+        "overall_freshness": run.get("overall_freshness"),
+        "started_at": run.get("started_at"),
+        "completed_at": run.get("completed_at"),
+        "views": views,
+        "warnings": run.get("warnings", []),
+        "errors": run.get("errors", []),
+    }
 
 
 def set_session_manager(manager: "MCPSessionManager") -> None:
@@ -1707,3 +1869,343 @@ async def submit_evaluation_feedback_wrapper(
     except Exception as e:
         logger.error(f"Error in submit_evaluation_feedback_wrapper: {e}", exc_info=True)
         return _json_error(e, operation="submit_evaluation_feedback")
+
+
+async def _select_dashboard_version(
+    repo: DashboardRepository,
+    tenant_id: UUID,
+    asset: DashboardAsset,
+    version: str,
+) -> Dashboard | None:
+    if version in {"", "published"}:
+        version_id = asset.published_version_id or asset.current_draft_version_id
+        if not version_id:
+            return None
+        return await repo.get_asset_version(tenant_id=tenant_id, asset_id=asset.id, version_id=version_id)
+    if version == "draft":
+        if not asset.current_draft_version_id:
+            return None
+        return await repo.get_asset_version(tenant_id=tenant_id, asset_id=asset.id, version_id=asset.current_draft_version_id)
+    return await repo.get_asset_version_by_num(tenant_id=tenant_id, asset_id=asset.id, version_num=int(version))
+
+
+async def search_dashboards_wrapper(
+    query: str,
+    tags: list[str] | None,
+    status: str,
+    freshness: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    limit: int = MCP_DASHBOARD_DEFAULT_LIMIT,
+) -> str:
+    try:
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_READ)
+            repo = DashboardRepository(session)
+            assets = await repo.list_assets(tenant_id, limit=MCP_DASHBOARD_MAX_LIMIT)
+            query_lower = query.lower().strip()
+            tag_filter = {tag.lower() for tag in tags or []}
+            items = []
+            for asset in assets:
+                if status and asset.lifecycle != status:
+                    continue
+                if query_lower and query_lower not in asset.name.lower() and query_lower not in asset.slug.lower():
+                    continue
+                asset_tags = {str(tag).lower() for tag in asset.tags_json or []}
+                if tag_filter and not tag_filter.issubset(asset_tags):
+                    continue
+                freshness_status = (asset.health_summary_json or {}).get("freshness")
+                if freshness and freshness_status != freshness:
+                    continue
+                items.append(_asset_compact(asset))
+            limit = max(1, min(limit, MCP_DASHBOARD_MAX_LIMIT))
+            return _json_success(items=items[:limit], total=len(items), cursor=None, has_more=len(items) > limit)
+    except Exception as e:
+        logger.error(f"Error in search_dashboards_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="search_dashboards")
+
+
+async def describe_dashboard_wrapper(
+    dashboard_id: str,
+    version: str,
+    detail: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        asset_id = UUID(dashboard_id)
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_READ)
+            repo = DashboardRepository(session)
+            asset = await repo.get_asset(asset_id, tenant_id)
+            if not asset:
+                raise HTTPException(status_code=404, detail="Dashboard asset not found")
+            selected_version = await _select_dashboard_version(repo, tenant_id, asset, version)
+            return _json_success(
+                dashboard=_asset_compact(asset),
+                version=_version_compact(selected_version, include_manifest=detail != "compact") if selected_version else None,
+            )
+    except Exception as e:
+        logger.error(f"Error in describe_dashboard_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="describe_dashboard")
+
+
+async def query_dashboard_wrapper(
+    dashboard_id: str,
+    data_view_ids: list[str] | None,
+    filters: dict[str, Any] | None,
+    cursor: str,
+    limit: int,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        if cursor:
+            raise HTTPException(status_code=400, detail="Cursor pagination is not available for dashboard runs yet")
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_EXPORT)
+            run = await DashboardService().query_dashboard(
+                session=session,
+                tenant_id=tenant_id,
+                asset_id=UUID(dashboard_id),
+                actor_id=str(user_id),
+                actor_type="agent",
+                filters=filters or {},
+                data_view_ids=data_view_ids,
+                correlation_id="mcp",
+            )
+            return _json_success(run=_compact_dashboard_run(run, limit=limit))
+    except Exception as e:
+        logger.error(f"Error in query_dashboard_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="query_dashboard")
+
+
+async def get_dashboard_state_wrapper(
+    dashboard_id: str,
+    filters_json: str,
+    data_view_ids: list[str] | None,
+    tenant_id: UUID,
+    user_id: UUID,
+    limit: int = MCP_DASHBOARD_DEFAULT_LIMIT,
+) -> str:
+    try:
+        filters = json.loads(filters_json or "{}")
+        run_result = await query_dashboard_wrapper(dashboard_id, data_view_ids, filters, "", limit, tenant_id, user_id)
+        run_payload = json.loads(run_result)
+        if not run_payload.get("success"):
+            return run_result
+        return _json_success(state=run_payload["run"])
+    except Exception as e:
+        logger.error(f"Error in get_dashboard_state_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="get_dashboard_state")
+
+
+async def explain_dashboard_tile_wrapper(
+    dashboard_id: str,
+    tile_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        asset_id = UUID(dashboard_id)
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_READ)
+            repo = DashboardRepository(session)
+            asset = await repo.get_asset(asset_id, tenant_id)
+            if not asset:
+                raise HTTPException(status_code=404, detail="Dashboard asset not found")
+            version = await _select_dashboard_version(repo, tenant_id, asset, "published")
+            if not version or not version.manifest_json:
+                raise HTTPException(status_code=404, detail="Dashboard version not found")
+            manifest = version.manifest_json
+            tile = next((item for item in manifest.get("tiles", []) if item.get("id") == tile_id), None)
+            if not tile:
+                raise HTTPException(status_code=404, detail="Dashboard tile not found")
+            data_view = next(
+                (item for item in manifest.get("data_views", []) if item.get("id") == tile.get("data_view_id")),
+                None,
+            )
+            return _json_success(
+                tile=tile,
+                data_view=data_view,
+                pinned_versions={
+                    "semantic_models": version.pinned_model_versions_json or {},
+                    "source_snapshots": version.pinned_source_snapshots_json or [],
+                },
+                lineage=_lineage_from_manifest(manifest, tile_id),
+            )
+    except Exception as e:
+        logger.error(f"Error in explain_dashboard_tile_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="explain_dashboard_tile")
+
+
+async def get_dashboard_lineage_wrapper(
+    dashboard_id: str,
+    tile_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        asset_id = UUID(dashboard_id)
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_READ)
+            repo = DashboardRepository(session)
+            asset = await repo.get_asset(asset_id, tenant_id)
+            if not asset:
+                raise HTTPException(status_code=404, detail="Dashboard asset not found")
+            version = await _select_dashboard_version(repo, tenant_id, asset, "published")
+            return _json_success(
+                dashboard_id=str(asset.id),
+                version_id=str(version.id) if version else None,
+                lineage=_lineage_from_manifest(version.manifest_json if version else None, tile_id),
+            )
+    except Exception as e:
+        logger.error(f"Error in get_dashboard_lineage_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="get_dashboard_lineage")
+
+
+async def create_dashboard_draft_wrapper(
+    slug: str,
+    notebook_id: str,
+    manifest_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    description: str = "",
+    tags: list[str] | None = None,
+) -> str:
+    try:
+        manifest = json.loads(manifest_json)
+        notebook_uuid = UUID(notebook_id)
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _assert_mcp_notebook_access(session, tenant_id, user_id, notebook_uuid)
+            asset = await DashboardService().create_asset_draft(
+                session=session,
+                tenant_id=tenant_id,
+                actor_id=user_id,
+                manifest_payload=manifest,
+                slug=slug,
+                notebook_id=notebook_uuid,
+                description=description,
+                tags=tags or [],
+                actor_type="agent",
+            )
+            return _json_success(dashboard=_asset_compact(asset))
+    except Exception as e:
+        logger.error(f"Error in create_dashboard_draft_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="create_dashboard_draft")
+
+
+async def patch_dashboard_draft_wrapper(
+    dashboard_id: str,
+    base_etag: str,
+    json_patch: str,
+    change_summary: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        patch_operations = json.loads(json_patch or "[]")
+        if not isinstance(patch_operations, list):
+            raise HTTPException(status_code=400, detail="json_patch must be a JSON array")
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_SHARE)
+            version = await DashboardService().apply_draft_patch(
+                session=session,
+                tenant_id=tenant_id,
+                asset_id=UUID(dashboard_id),
+                actor_id=user_id,
+                base_etag=base_etag,
+                patch_operations=patch_operations,
+                change_summary=change_summary,
+                actor_type="agent",
+            )
+            return _json_success(version=_version_compact(version, include_manifest=True))
+    except Exception as e:
+        logger.error(f"Error in patch_dashboard_draft_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="patch_dashboard_draft")
+
+
+async def validate_dashboard_wrapper(dashboard_id: str, tenant_id: UUID, user_id: UUID) -> str:
+    try:
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_SHARE)
+            repo = DashboardRepository(session)
+            asset = await repo.get_asset(UUID(dashboard_id), tenant_id)
+            if not asset:
+                raise HTTPException(status_code=404, detail="Dashboard asset not found")
+            if not asset.current_draft_version_id:
+                raise HTTPException(status_code=409, detail="Dashboard has no editable draft")
+            draft = await repo.get_asset_version(
+                tenant_id=tenant_id,
+                asset_id=asset.id,
+                version_id=asset.current_draft_version_id,
+            )
+            if not draft or not draft.manifest_json:
+                raise HTTPException(status_code=404, detail="Dashboard draft not found")
+            manifest = DashboardService.validate_manifest_payload(draft.manifest_json)
+            return _json_success(validation=DashboardService.validation_summary(manifest), manifest=manifest)
+    except Exception as e:
+        logger.error(f"Error in validate_dashboard_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="validate_dashboard")
+
+
+async def preview_dashboard_wrapper(
+    dashboard_id: str,
+    filters: dict[str, Any] | None,
+    data_view_ids: list[str] | None,
+    tenant_id: UUID,
+    user_id: UUID,
+    limit: int = MCP_DASHBOARD_DEFAULT_LIMIT,
+) -> str:
+    try:
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_EXPORT)
+            run = await DashboardService().preview_dashboard(
+                session=session,
+                tenant_id=tenant_id,
+                asset_id=UUID(dashboard_id),
+                actor_id=str(user_id),
+                actor_type="agent",
+                filters=filters or {},
+                data_view_ids=data_view_ids,
+                correlation_id="mcp-preview",
+            )
+            return _json_success(run=_compact_dashboard_run(run, limit=limit))
+    except Exception as e:
+        logger.error(f"Error in preview_dashboard_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="preview_dashboard")
+
+
+async def publish_dashboard_wrapper(
+    dashboard_id: str,
+    base_etag: str,
+    change_summary: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        async with AsyncSessionFactory() as session:
+            set_tenant_id(tenant_id)
+            await _require_mcp_dashboard_scope(session, tenant_id, user_id, Scope.DASHBOARD_SHARE)
+            version = await DashboardService().publish(
+                session=session,
+                tenant_id=tenant_id,
+                asset_id=UUID(dashboard_id),
+                actor_id=user_id,
+                base_etag=base_etag,
+                change_summary=change_summary,
+                actor_type="agent",
+            )
+            return _json_success(version=_version_compact(version, include_manifest=True))
+    except Exception as e:
+        logger.error(f"Error in publish_dashboard_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="publish_dashboard")

--- a/server/mcp/tool_wrappers.py
+++ b/server/mcp/tool_wrappers.py
@@ -1241,3 +1241,52 @@ async def create_custom_skill_wrapper(
     except Exception as e:
         logger.error(f"Error in create_custom_skill_wrapper: {e}", exc_info=True)
         return json.dumps({"success": False, "error": str(e)})
+
+
+async def list_sharing_grants_wrapper(
+    tenant_id: UUID,
+    user_id: UUID,
+    object_type: str | None = None,
+    object_id: str | None = None,
+    legacy_surface: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+) -> str:
+    try:
+        from server.serializers.sharing import sharing_grant_payload
+        from server.services.sharing import SharingService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            grants = await SharingService(session).list_grants(
+                tenant_id=tenant_id,
+                object_type=object_type,
+                object_id=object_id,
+                legacy_surface=legacy_surface,
+                status=status,
+                limit=limit,
+            )
+        return json.dumps(
+            {
+                "success": True,
+                "items": [sharing_grant_payload(grant) for grant in grants],
+                "total": len(grants),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error in list_sharing_grants_wrapper: {e}", exc_info=True)
+        return json.dumps({"success": False, "error": str(e)})
+
+
+async def describe_sharing_grant_wrapper(grant_id: str, tenant_id: UUID, user_id: UUID) -> str:
+    try:
+        from server.serializers.sharing import sharing_grant_evidence_payload
+        from server.services.sharing import SharingService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            evidence = await SharingService(session).grant_evidence(tenant_id=tenant_id, grant_id=grant_id)
+        return json.dumps({"success": True, **sharing_grant_evidence_payload(evidence)})
+    except Exception as e:
+        logger.error(f"Error in describe_sharing_grant_wrapper: {e}", exc_info=True)
+        return json.dumps({"success": False, "error": str(e)})

--- a/server/mcp/tool_wrappers.py
+++ b/server/mcp/tool_wrappers.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 from agents.run_context import RunContextWrapper
 from fastapi import HTTPException
+from pydantic import ValidationError
 from sqlalchemy import select
 
 from server.auth.scopes import Scope, get_scopes_for_role, has_scope
@@ -43,6 +44,10 @@ MCP_EVALUATION_DEFAULT_LIMIT = 20
 MCP_EVALUATION_MAX_LIMIT = 50
 MCP_DASHBOARD_DEFAULT_LIMIT = 20
 MCP_DASHBOARD_MAX_LIMIT = 50
+MCP_SOURCE_DEFAULT_LIMIT = 50
+MCP_SOURCE_MAX_LIMIT = 100
+MCP_SEMANTIC_DEFAULT_LIMIT = 50
+MCP_SEMANTIC_MAX_LIMIT = 100
 
 
 def _json_error(error: Exception | str, *, operation: str | None = None) -> str:
@@ -70,6 +75,26 @@ def _json_success(**payload: Any) -> str:
     return json.dumps({"success": True, **payload}, ensure_ascii=False, default=str)
 
 
+def _parse_json_object(payload_json: str, *, operation: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(payload_json or "{}")
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail=f"{operation} payload must be valid JSON")
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail=f"{operation} payload must be a JSON object")
+    return payload
+
+
+def _value_error_to_http(error: ValueError) -> HTTPException:
+    message = str(error)
+    code = 404 if "not found" in message.lower() else 400
+    return HTTPException(status_code=code, detail=message)
+
+
+def _validation_error_to_http(operation: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=f"Invalid {operation} payload")
+
+
 def _stable_feedback_case_key(feedback: dict[str, Any]) -> str:
     if feedback.get("case_key"):
         return str(feedback["case_key"])
@@ -80,7 +105,7 @@ def _stable_feedback_case_key(feedback: dict[str, Any]) -> str:
     return f"mcp-feedback-{digest}"
 
 
-async def _require_mcp_dashboard_scope(db_session, tenant_id: UUID, user_id: UUID, scope: Scope) -> TenantRole:
+async def _mcp_role_and_scopes(db_session, tenant_id: UUID, user_id: UUID) -> tuple[TenantRole, list[str]]:
     tenant = await db_session.get(Tenant, tenant_id)
     if not tenant:
         raise HTTPException(status_code=404, detail="Tenant not found")
@@ -92,13 +117,32 @@ async def _require_mcp_dashboard_scope(db_session, tenant_id: UUID, user_id: UUI
         if not membership:
             raise HTTPException(status_code=403, detail="MCP principal is not a tenant member")
         role = TenantRole(membership.role)
-    if not has_scope(get_scopes_for_role(role), scope):
+    return role, get_scopes_for_role(role)
+
+
+async def _require_mcp_scope(db_session, tenant_id: UUID, user_id: UUID, scope: Scope) -> TenantRole:
+    role, scopes = await _mcp_role_and_scopes(db_session, tenant_id, user_id)
+    if not has_scope(scopes, scope):
         raise HTTPException(status_code=403, detail=f"Permission denied. Required scope: {scope.value}")
     return role
 
 
+async def _require_mcp_any_scope(db_session, tenant_id: UUID, user_id: UUID, *required_scopes: Scope) -> TenantRole:
+    role, scopes = await _mcp_role_and_scopes(db_session, tenant_id, user_id)
+    if not any(has_scope(scopes, scope) for scope in required_scopes):
+        required = ", ".join(scope.value for scope in required_scopes)
+        raise HTTPException(status_code=403, detail=f"Permission denied. Required one of: {required}")
+    return role
+
+
+async def _require_mcp_dashboard_scope(db_session, tenant_id: UUID, user_id: UUID, scope: Scope) -> TenantRole:
+    return await _require_mcp_scope(db_session, tenant_id, user_id, scope)
+
+
 async def _assert_mcp_notebook_access(db_session, tenant_id: UUID, user_id: UUID, notebook_id: UUID) -> None:
-    notebook = await db_session.scalar(select(Notebook).where(Notebook.id == notebook_id, Notebook.tenant_id == tenant_id))
+    notebook = await db_session.scalar(
+        select(Notebook).where(Notebook.id == notebook_id, Notebook.tenant_id == tenant_id)
+    )
     if not notebook:
         raise HTTPException(status_code=404, detail="Notebook not found")
     role = await _require_mcp_dashboard_scope(db_session, tenant_id, user_id, Scope.DASHBOARD_SHARE)
@@ -1431,6 +1475,508 @@ async def create_custom_skill_wrapper(
         return json.dumps({"success": False, "error": str(e)})
 
 
+async def list_connector_definitions_wrapper(
+    tenant_id: UUID,
+    user_id: UUID,
+    provider: str = "",
+    category: str = "",
+    include_planned: bool = True,
+    limit: int = MCP_SOURCE_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.services.source_connections import SourceConnectionService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_READ)
+        catalog = SourceConnectionService().list_connector_definitions()
+        items = list(catalog["items"])
+        if provider:
+            items = [item for item in items if item.get("provider") == provider or item.get("id") == provider]
+        if category:
+            items = [item for item in items if item.get("category") == category]
+        if not include_planned:
+            items = [item for item in items if item.get("availability") != "planned"]
+        limit = max(1, min(limit, MCP_SOURCE_MAX_LIMIT))
+        return _json_success(
+            items=sanitize_error_payload(items[:limit]),
+            total=len(items),
+            has_more=len(items) > limit,
+            summary=catalog["summary"],
+            commercial_status="PARTIAL",
+            runtime_status="not_certified",
+        )
+    except Exception as e:
+        logger.error(f"Error in list_connector_definitions_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="list_connector_definitions")
+
+
+async def create_source_connection_wrapper(
+    connection_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.schemas.source_connections import SourceConnectionCreate
+        from server.services.source_connections import SourceConnectionService
+
+        try:
+            payload = SourceConnectionCreate.model_validate(
+                _parse_json_object(connection_json, operation="create_source_connection")
+            )
+        except ValidationError:
+            raise _validation_error_to_http("source connection")
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.CONNECTION_CREATE)
+            service = SourceConnectionService()
+            connection = await service.create_connection(
+                session=session,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                payload=payload,
+            )
+            return _json_success(
+                connection=sanitize_error_payload(service.connection_payload(connection)),
+                commercial_status="PARTIAL",
+                runtime_status="not_certified",
+            )
+    except ValueError as e:
+        logger.error(f"Error in create_source_connection_wrapper: {e}", exc_info=True)
+        return _json_error(_value_error_to_http(e), operation="create_source_connection")
+    except Exception as e:
+        logger.error(f"Error in create_source_connection_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="create_source_connection")
+
+
+async def list_source_connections_wrapper(
+    tenant_id: UUID,
+    user_id: UUID,
+    provider: str = "",
+    limit: int = MCP_SOURCE_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.services.source_connections import SourceConnectionService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            role = await _require_mcp_scope(session, tenant_id, user_id, Scope.CONNECTION_READ)
+            service = SourceConnectionService()
+            connections = await service.list_connections(
+                session=session,
+                tenant_id=tenant_id,
+                provider=provider or None,
+                user_id=user_id,
+                include_all=role in {TenantRole.OWNER, TenantRole.ADMIN},
+            )
+            limit = max(1, min(limit, MCP_SOURCE_MAX_LIMIT))
+            items = [service.connection_payload(connection) for connection in connections]
+            return _json_success(
+                items=sanitize_error_payload(items[:limit]),
+                total=len(items),
+                has_more=len(items) > limit,
+            )
+    except Exception as e:
+        logger.error(f"Error in list_source_connections_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="list_source_connections")
+
+
+async def disconnect_source_connection_wrapper(
+    connection_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.services.source_connections import SourceConnectionService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            role = await _require_mcp_any_scope(
+                session,
+                tenant_id,
+                user_id,
+                Scope.CONNECTION_DELETE,
+                Scope.CONNECTION_DELETE_OWN,
+            )
+            ok, resource_count = await SourceConnectionService().delete_connection(
+                session=session,
+                tenant_id=tenant_id,
+                connection_id=connection_id,
+                user_id=user_id,
+                include_all=role in {TenantRole.OWNER, TenantRole.ADMIN},
+            )
+            if not ok:
+                raise HTTPException(status_code=404, detail="Source connection not found")
+            return _json_success(disconnected=True, affected_resource_count=resource_count)
+    except Exception as e:
+        logger.error(f"Error in disconnect_source_connection_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="disconnect_source_connection")
+
+
+async def create_source_resource_wrapper(
+    resource_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.schemas.source_resources import SourceResourceCreate
+        from server.services.source_resources import SourceResourceService
+
+        try:
+            payload = SourceResourceCreate.model_validate(
+                _parse_json_object(resource_json, operation="create_source_resource")
+            )
+        except ValidationError:
+            raise _validation_error_to_http("source resource")
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            role = await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_CREATE)
+            resource = await SourceResourceService().create_resource(
+                session=session,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                payload=payload,
+                include_all_connections=role in {TenantRole.OWNER, TenantRole.ADMIN},
+            )
+            return _json_success(resource=sanitize_error_payload(resource), commercial_status="PARTIAL")
+    except ValueError as e:
+        logger.error(f"Error in create_source_resource_wrapper: {e}", exc_info=True)
+        return _json_error(_value_error_to_http(e), operation="create_source_resource")
+    except Exception as e:
+        logger.error(f"Error in create_source_resource_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="create_source_resource")
+
+
+async def list_source_resources_wrapper(
+    tenant_id: UUID,
+    user_id: UUID,
+    query: str = "",
+    resource_type: str = "",
+    status: str = "",
+    limit: int = MCP_SOURCE_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.services.source_resources import SourceResourceService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_READ)
+            items = await SourceResourceService().list_resources(session=session, tenant_id=tenant_id)
+            query_lower = query.lower().strip()
+            if query_lower:
+                items = [
+                    item
+                    for item in items
+                    if query_lower in str(item.get("name") or "").lower()
+                    or query_lower in str(item.get("external_id") or "").lower()
+                    or query_lower in str(item.get("source_url") or "").lower()
+                ]
+            if resource_type:
+                items = [item for item in items if item.get("resource_type") == resource_type]
+            if status:
+                items = [item for item in items if item.get("status") == status]
+            limit = max(1, min(limit, MCP_SOURCE_MAX_LIMIT))
+            return _json_success(
+                items=sanitize_error_payload(items[:limit]),
+                total=len(items),
+                has_more=len(items) > limit,
+            )
+    except Exception as e:
+        logger.error(f"Error in list_source_resources_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="list_source_resources")
+
+
+async def describe_source_resource_wrapper(
+    resource_id: str,
+    tenant_id: UUID,
+    user_id: UUID,
+    include_snapshots: bool = True,
+    limit: int = MCP_SOURCE_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.services.source_resources import SourceResourceService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_READ)
+            service = SourceResourceService()
+            resource = await service.get_resource(session=session, tenant_id=tenant_id, resource_id=resource_id)
+            if resource is None:
+                raise HTTPException(status_code=404, detail="Source resource not found")
+            payload = await service.resource_payload(session=session, resource=resource)
+            response: dict[str, Any] = {"resource": sanitize_error_payload(payload)}
+            if include_snapshots:
+                snapshots = await service.list_snapshots(session=session, tenant_id=tenant_id, resource_id=resource_id)
+                limit = max(1, min(limit, MCP_SOURCE_MAX_LIMIT))
+                items = list(snapshots["items"])
+                response["snapshots"] = {
+                    "items": sanitize_error_payload(items[:limit]),
+                    "total": len(items),
+                    "has_more": len(items) > limit,
+                }
+            return _json_success(**response)
+    except ValueError as e:
+        logger.error(f"Error in describe_source_resource_wrapper: {e}", exc_info=True)
+        return _json_error(_value_error_to_http(e), operation="describe_source_resource")
+    except Exception as e:
+        logger.error(f"Error in describe_source_resource_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="describe_source_resource")
+
+
+async def sync_source_resource_wrapper(
+    resource_id: str,
+    sync_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.schemas.source_resources import SourceResourceSyncRequest
+        from server.services.source_resources import SourceResourceService
+
+        try:
+            payload = SourceResourceSyncRequest.model_validate(
+                _parse_json_object(sync_json, operation="sync_source_resource")
+            )
+        except ValidationError:
+            raise _validation_error_to_http("source resource sync")
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            role = await _require_mcp_any_scope(
+                session,
+                tenant_id,
+                user_id,
+                Scope.DATASET_UPDATE,
+                Scope.DATASET_UPDATE_OWN,
+            )
+            resource = await SourceResourceService().sync_resource(
+                session=session,
+                tenant_id=tenant_id,
+                resource_id=resource_id,
+                payload=payload,
+                user_id=user_id,
+                include_all=role in {TenantRole.OWNER, TenantRole.ADMIN},
+            )
+            return _json_success(resource=sanitize_error_payload(resource), commercial_status="PARTIAL")
+    except PermissionError as e:
+        logger.error(f"Error in sync_source_resource_wrapper: {e}", exc_info=True)
+        return _json_error(HTTPException(status_code=403, detail=str(e)), operation="sync_source_resource")
+    except ValueError as e:
+        logger.error(f"Error in sync_source_resource_wrapper: {e}", exc_info=True)
+        return _json_error(_value_error_to_http(e), operation="sync_source_resource")
+    except Exception as e:
+        logger.error(f"Error in sync_source_resource_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="sync_source_resource")
+
+
+async def list_semantic_models_wrapper(
+    tenant_id: UUID,
+    user_id: UUID,
+    query: str = "",
+    status: str = "",
+    limit: int = MCP_SEMANTIC_DEFAULT_LIMIT,
+) -> str:
+    try:
+        from server.services.semantic_model_service import SemanticModelService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_READ)
+            items = await SemanticModelService.list_models(session=session, tenant_id=tenant_id)
+            query_lower = query.lower().strip()
+            if query_lower:
+                items = [
+                    item
+                    for item in items
+                    if query_lower in str(item.get("slug") or "").lower()
+                    or query_lower in str(item.get("name") or "").lower()
+                    or query_lower in str(item.get("domain") or "").lower()
+                ]
+            if status:
+                items = [item for item in items if item.get("status") == status]
+            limit = max(1, min(limit, MCP_SEMANTIC_MAX_LIMIT))
+            return _json_success(
+                items=sanitize_error_payload(items[:limit]),
+                total=len(items),
+                has_more=len(items) > limit,
+                commercial_status="PARTIAL",
+                runtime_status="not_certified",
+            )
+    except Exception as e:
+        logger.error(f"Error in list_semantic_models_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="list_semantic_models")
+
+
+async def describe_semantic_model_wrapper(model_slug: str, tenant_id: UUID, user_id: UUID) -> str:
+    try:
+        from server.services.semantic_model_service import SemanticModelService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_READ)
+            model = await SemanticModelService.get_model(session=session, tenant_id=tenant_id, slug=model_slug)
+            if model is None:
+                raise HTTPException(status_code=404, detail="Semantic model not found")
+            return _json_success(model=sanitize_error_payload(SemanticModelService.model_to_payload(model)))
+    except Exception as e:
+        logger.error(f"Error in describe_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="describe_semantic_model")
+
+
+async def create_semantic_model_wrapper(model_json: str, tenant_id: UUID, user_id: UUID) -> str:
+    try:
+        from server.schemas.semantic_models import SemanticModelCreate
+        from server.services.semantic_model_service import SemanticModelService
+
+        try:
+            payload = SemanticModelCreate.model_validate(
+                _parse_json_object(model_json, operation="create_semantic_model")
+            )
+        except ValidationError:
+            raise _validation_error_to_http("semantic model")
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_CREATE)
+            model = await SemanticModelService.create_model(
+                session=session,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                payload=payload,
+            )
+            return _json_success(model=sanitize_error_payload(SemanticModelService.model_to_payload(model)))
+    except ValueError as e:
+        logger.error(f"Error in create_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(_value_error_to_http(e), operation="create_semantic_model")
+    except Exception as e:
+        logger.error(f"Error in create_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="create_semantic_model")
+
+
+async def _assert_mcp_semantic_model_mutation_allowed(
+    session,
+    tenant_id: UUID,
+    user_id: UUID,
+    model_slug: str,
+) -> None:
+    from server.services.semantic_model_service import SemanticModelService
+
+    role = await _require_mcp_any_scope(session, tenant_id, user_id, Scope.DATASET_UPDATE, Scope.DATASET_UPDATE_OWN)
+    if role in {TenantRole.OWNER, TenantRole.ADMIN}:
+        return
+    model = await SemanticModelService.get_model(session=session, tenant_id=tenant_id, slug=model_slug)
+    if model is None:
+        raise HTTPException(status_code=404, detail="Semantic model not found")
+    if str(model.created_by) != str(user_id):
+        raise HTTPException(status_code=403, detail="MCP principal can only update semantic models they created")
+
+
+async def update_semantic_model_wrapper(
+    model_slug: str,
+    patch_json: str,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> str:
+    try:
+        from server.schemas.semantic_models import SemanticModelPatch
+        from server.services.semantic_model_service import SemanticModelService
+
+        try:
+            payload = SemanticModelPatch.model_validate(
+                _parse_json_object(patch_json, operation="update_semantic_model")
+            )
+        except ValidationError:
+            raise _validation_error_to_http("semantic model patch")
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _assert_mcp_semantic_model_mutation_allowed(session, tenant_id, user_id, model_slug)
+            model = await SemanticModelService.update_model(
+                session=session,
+                tenant_id=tenant_id,
+                slug=model_slug,
+                user_id=user_id,
+                payload=payload,
+            )
+            if model is None:
+                raise HTTPException(status_code=404, detail="Semantic model not found")
+            return _json_success(model=sanitize_error_payload(SemanticModelService.model_to_payload(model)))
+    except RuntimeError as e:
+        logger.error(f"Error in update_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(HTTPException(status_code=409, detail=str(e)), operation="update_semantic_model")
+    except ValueError as e:
+        logger.error(f"Error in update_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(_value_error_to_http(e), operation="update_semantic_model")
+    except Exception as e:
+        logger.error(f"Error in update_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="update_semantic_model")
+
+
+async def validate_semantic_model_wrapper(model_slug: str, tenant_id: UUID, user_id: UUID) -> str:
+    try:
+        from server.services.semantic_model_service import SemanticModelService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _assert_mcp_semantic_model_mutation_allowed(session, tenant_id, user_id, model_slug)
+            model = await SemanticModelService.validate_model(
+                session=session,
+                tenant_id=tenant_id,
+                slug=model_slug,
+                user_id=user_id,
+            )
+            if model is None:
+                raise HTTPException(status_code=404, detail="Semantic model not found")
+            return _json_success(
+                model=sanitize_error_payload(SemanticModelService.model_to_payload(model)),
+                commercial_status="PARTIAL",
+                runtime_status="not_certified",
+            )
+    except Exception as e:
+        logger.error(f"Error in validate_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="validate_semantic_model")
+
+
+async def publish_semantic_model_wrapper(model_slug: str, tenant_id: UUID, user_id: UUID) -> str:
+    try:
+        from server.services.semantic_model_service import SemanticModelService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.DATASET_UPDATE)
+            model = await SemanticModelService.publish_model(session=session, tenant_id=tenant_id, slug=model_slug)
+            if model is None:
+                raise HTTPException(status_code=404, detail="Semantic model not found")
+            return _json_success(model=sanitize_error_payload(SemanticModelService.model_to_payload(model)))
+    except RuntimeError as e:
+        logger.error(f"Error in publish_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(HTTPException(status_code=409, detail=str(e)), operation="publish_semantic_model")
+    except Exception as e:
+        logger.error(f"Error in publish_semantic_model_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="publish_semantic_model")
+
+
+async def query_semantic_metric_wrapper(model_slug: str, tenant_id: UUID, user_id: UUID) -> str:
+    try:
+        from server.services.semantic_model_service import SemanticModelService
+
+        set_tenant_id(tenant_id)
+        async with AsyncSessionFactory() as session:
+            await _require_mcp_scope(session, tenant_id, user_id, Scope.QUERY_EXECUTE)
+            model = await SemanticModelService.query_metric(session=session, tenant_id=tenant_id, slug=model_slug)
+            if model is None:
+                raise HTTPException(status_code=404, detail="Semantic model not found")
+            return _json_success(model=sanitize_error_payload(SemanticModelService.model_to_payload(model)))
+    except RuntimeError as e:
+        logger.error(f"Error in query_semantic_metric_wrapper: {e}", exc_info=True)
+        return _json_error(HTTPException(status_code=409, detail=str(e)), operation="query_semantic_metric")
+    except Exception as e:
+        logger.error(f"Error in query_semantic_metric_wrapper: {e}", exc_info=True)
+        return _json_error(e, operation="query_semantic_metric")
+
+
 async def list_sharing_grants_wrapper(
     tenant_id: UUID,
     user_id: UUID,
@@ -1762,7 +2308,9 @@ async def create_advisor_change_set_wrapper(
 
         set_tenant_id(tenant_id)
         async with AsyncSessionFactory() as session:
-            change_set, suggestions, created = await EvaluationService(session).create_advisor_change_set_from_skill_suggestion(
+            change_set, suggestions, created = await EvaluationService(
+                session
+            ).create_advisor_change_set_from_skill_suggestion(
                 tenant_id=tenant_id,
                 suggestion_id=UUID(skill_suggestion_id),
                 suite_version_id=UUID(suite_version_id) if suite_version_id else None,
@@ -1885,7 +2433,9 @@ async def _select_dashboard_version(
     if version == "draft":
         if not asset.current_draft_version_id:
             return None
-        return await repo.get_asset_version(tenant_id=tenant_id, asset_id=asset.id, version_id=asset.current_draft_version_id)
+        return await repo.get_asset_version(
+            tenant_id=tenant_id, asset_id=asset.id, version_id=asset.current_draft_version_id
+        )
     return await repo.get_asset_version_by_num(tenant_id=tenant_id, asset_id=asset.id, version_num=int(version))
 
 
@@ -1945,7 +2495,9 @@ async def describe_dashboard_wrapper(
             selected_version = await _select_dashboard_version(repo, tenant_id, asset, version)
             return _json_success(
                 dashboard=_asset_compact(asset),
-                version=_version_compact(selected_version, include_manifest=detail != "compact") if selected_version else None,
+                version=_version_compact(selected_version, include_manifest=detail != "compact")
+                if selected_version
+                else None,
             )
     except Exception as e:
         logger.error(f"Error in describe_dashboard_wrapper: {e}", exc_info=True)

--- a/server/mcp/tools.py
+++ b/server/mcp/tools.py
@@ -17,12 +17,18 @@ from server.mcp.tool_wrappers import (
     create_custom_skill_wrapper,
     create_dashboard_draft_wrapper,
     create_evaluation_case_draft_wrapper,
+    create_semantic_model_wrapper,
+    create_source_connection_wrapper,
+    create_source_resource_wrapper,
     dashboard_search_replace_wrapper,
     define_dashboard_filters_wrapper,
     describe_dashboard_wrapper,
     describe_evaluation_failure_wrapper,
     describe_evaluation_suite_wrapper,
+    describe_semantic_model_wrapper,
     describe_sharing_grant_wrapper,
+    describe_source_resource_wrapper,
+    disconnect_source_connection_wrapper,
     emit_plan_status_wrapper,
     ensure_notebook_exists,
     execute_duckdb_query_wrapper,
@@ -42,13 +48,19 @@ from server.mcp.tool_wrappers import (
     get_skill_definition_wrapper,
     get_user_instructions_wrapper,
     get_user_style_guidelines_wrapper,
+    list_connector_definitions_wrapper,
     list_evaluation_cases_wrapper,
+    list_semantic_models_wrapper,
     list_sharing_grants_wrapper,
+    list_source_connections_wrapper,
+    list_source_resources_wrapper,
     patch_dashboard_draft_wrapper,
     preview_dashboard_wrapper,
     preview_evaluation_ground_truth_wrapper,
     publish_dashboard_wrapper,
+    publish_semantic_model_wrapper,
     query_dashboard_wrapper,
+    query_semantic_metric_wrapper,
     remove_dashboard_filter_wrapper,
     remove_learning_wrapper,
     run_advisor_gate_wrapper,
@@ -64,10 +76,13 @@ from server.mcp.tool_wrappers import (
     search_learnings_wrapper,
     start_html_generation_wrapper,
     submit_evaluation_feedback_wrapper,
+    sync_source_resource_wrapper,
     update_custom_skill_wrapper,
     update_dashboard_filter_wrapper,
     update_learning_wrapper,
+    update_semantic_model_wrapper,
     validate_dashboard_wrapper,
+    validate_semantic_model_wrapper,
 )
 from server.utils.custom_logger import get_logger
 
@@ -171,6 +186,176 @@ def register_all_tools(mcp: FastMCP, get_or_create_session_func):
         return await get_dataset_schema_by_id_wrapper(
             dataset_id, session["tenant_id"], session["user_id"], session["notebook_id"], session["session_id"]
         )
+
+    # Source Connector Control-Plane Tools
+    @mcp.tool()
+    async def list_connector_definitions(
+        provider: str = "",
+        category: str = "",
+        include_planned: bool = True,
+        limit: int = 50,
+        context: Context = None,
+    ) -> str:
+        """
+        List official Source connector definitions and readiness gates.
+
+        All official connector definitions are beta or planned in this landing;
+        runtime execution and production credentials are not certified.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await list_connector_definitions_wrapper(
+            session["tenant_id"],
+            session["user_id"],
+            provider,
+            category,
+            include_planned,
+            limit,
+        )
+
+    @mcp.tool()
+    async def create_source_connection(connection_json: str, context: Context = None) -> str:
+        """
+        Create a beta Source connection from a JSON payload.
+
+        Credentials are encrypted server-side and never returned. This registers
+        control-plane metadata only; no live connector runtime is invoked.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await create_source_connection_wrapper(connection_json, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def list_source_connections(provider: str = "", limit: int = 50, context: Context = None) -> str:
+        """List beta Source connections visible to the MCP principal, with credentials redacted."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await list_source_connections_wrapper(
+            session["tenant_id"],
+            session["user_id"],
+            provider,
+            limit,
+        )
+
+    @mcp.tool()
+    async def disconnect_source_connection(connection_id: str, context: Context = None) -> str:
+        """Disconnect a Source connection without exposing or deleting stored credentials in the response."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await disconnect_source_connection_wrapper(connection_id, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def create_source_resource(resource_json: str, context: Context = None) -> str:
+        """
+        Register a governed Source resource from a JSON payload.
+
+        Optional caller-supplied content creates immutable snapshot metadata; no
+        external connector runtime, crawler, parser worker, or object storage sync is invoked.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await create_source_resource_wrapper(resource_json, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def list_source_resources(
+        query: str = "",
+        resource_type: str = "",
+        status: str = "",
+        limit: int = 50,
+        context: Context = None,
+    ) -> str:
+        """List governed Source resources and latest snapshot metadata for the current tenant."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await list_source_resources_wrapper(
+            session["tenant_id"],
+            session["user_id"],
+            query,
+            resource_type,
+            status,
+            limit,
+        )
+
+    @mcp.tool()
+    async def describe_source_resource(
+        resource_id: str,
+        include_snapshots: bool = True,
+        limit: int = 50,
+        context: Context = None,
+    ) -> str:
+        """Describe a Source resource, its connection metadata, and immutable snapshot evidence."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await describe_source_resource_wrapper(
+            resource_id,
+            session["tenant_id"],
+            session["user_id"],
+            include_snapshots,
+            limit,
+        )
+
+    @mcp.tool()
+    async def sync_source_resource(resource_id: str, sync_json: str, context: Context = None) -> str:
+        """
+        Record caller-supplied content as a new Source snapshot.
+
+        This is a beta control-plane sync surface. It does not run external connector
+        runtime code or fetch remote data.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await sync_source_resource_wrapper(resource_id, sync_json, session["tenant_id"], session["user_id"])
+
+    # Semantic Modeling Beta Tools
+    @mcp.tool()
+    async def list_semantic_models(
+        query: str = "",
+        status: str = "",
+        limit: int = 50,
+        context: Context = None,
+    ) -> str:
+        """List beta semantic models and readiness summaries for the current tenant."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await list_semantic_models_wrapper(
+            session["tenant_id"],
+            session["user_id"],
+            query,
+            status,
+            limit,
+        )
+
+    @mcp.tool()
+    async def describe_semantic_model(model_slug: str, context: Context = None) -> str:
+        """Describe a beta semantic model, manifest, Source provenance, and readiness blockers."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await describe_semantic_model_wrapper(model_slug, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def create_semantic_model(model_json: str, context: Context = None) -> str:
+        """Create a beta semantic model from a semantic.model.v1beta JSON payload."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await create_semantic_model_wrapper(model_json, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def update_semantic_model(model_slug: str, patch_json: str, context: Context = None) -> str:
+        """Patch a beta semantic model using an expected_revision guard."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await update_semantic_model_wrapper(model_slug, patch_json, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def validate_semantic_model(model_slug: str, context: Context = None) -> str:
+        """Validate beta semantic model readiness. Result remains PARTIAL until runtime certification."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await validate_semantic_model_wrapper(model_slug, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def publish_semantic_model(model_slug: str, context: Context = None) -> str:
+        """Attempt semantic model publish. Official beta blocks publish with a 409-style error."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await publish_semantic_model_wrapper(model_slug, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def query_semantic_metric(
+        model_slug: str,
+        metric_name: str = "",
+        filters_json: str = "{}",
+        context: Context = None,
+    ) -> str:
+        """Attempt semantic metric execution. Official beta blocks query execution."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await query_semantic_metric_wrapper(model_slug, session["tenant_id"], session["user_id"])
 
     # Query Execution Tools
     @mcp.tool()

--- a/server/mcp/tools.py
+++ b/server/mcp/tools.py
@@ -14,6 +14,7 @@ from server.mcp.tool_wrappers import (
     create_custom_skill_wrapper,
     dashboard_search_replace_wrapper,
     define_dashboard_filters_wrapper,
+    describe_sharing_grant_wrapper,
     emit_plan_status_wrapper,
     ensure_notebook_exists,
     execute_duckdb_query_wrapper,
@@ -30,6 +31,7 @@ from server.mcp.tool_wrappers import (
     get_skill_definition_wrapper,
     get_user_instructions_wrapper,
     get_user_style_guidelines_wrapper,
+    list_sharing_grants_wrapper,
     remove_dashboard_filter_wrapper,
     remove_learning_wrapper,
     save_query_wrapper,
@@ -478,6 +480,43 @@ def register_all_tools(mcp: FastMCP, get_or_create_session_func):
         return await remove_learning_wrapper(
             learning_id, session["tenant_id"], session["user_id"], session["notebook_id"]
         )
+
+    # Sharing Read Tools
+    @mcp.tool()
+    async def list_sharing_grants(
+        object_type: str | None = None,
+        object_id: str | None = None,
+        legacy_surface: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        context: Context = None,
+    ) -> str:
+        """
+        List canonical sharing grants visible in the current workspace.
+
+        Values are redacted before they are returned. Use legacy_surface to inspect
+        compatibility-backed shares such as folder_notebook, folder_dashboard,
+        html_notebook_share, or json_notebook_share.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await list_sharing_grants_wrapper(
+            session["tenant_id"],
+            session["user_id"],
+            object_type=object_type,
+            object_id=object_id,
+            legacy_surface=legacy_surface,
+            status=status,
+            limit=limit,
+        )
+
+    @mcp.tool()
+    async def describe_sharing_grant(grant_id: str, context: Context = None) -> str:
+        """
+        Describe one canonical sharing grant, including redacted compatibility,
+        secret-count, viewer-session, and audit evidence.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await describe_sharing_grant_wrapper(grant_id, session["tenant_id"], session["user_id"])
 
     # Plan Tools
     @mcp.tool()

--- a/server/mcp/tools.py
+++ b/server/mcp/tools.py
@@ -11,9 +11,14 @@ from fastmcp import Context, FastMCP
 from server.mcp.tool_wrappers import (
     add_learning_wrapper,
     apply_html_patch_wrapper,
+    compare_evaluation_runs_wrapper,
+    create_advisor_change_set_wrapper,
     create_custom_skill_wrapper,
+    create_evaluation_case_draft_wrapper,
     dashboard_search_replace_wrapper,
     define_dashboard_filters_wrapper,
+    describe_evaluation_failure_wrapper,
+    describe_evaluation_suite_wrapper,
     describe_sharing_grant_wrapper,
     emit_plan_status_wrapper,
     ensure_notebook_exists,
@@ -25,23 +30,30 @@ from server.mcp.tool_wrappers import (
     get_dashboard_filter_config_wrapper,
     get_database_schema_wrapper,
     get_dataset_schema_by_id_wrapper,
+    get_evaluation_run_wrapper,
     get_existing_html_wrapper,
     get_filter_options_wrapper,
     get_learning_wrapper,
     get_skill_definition_wrapper,
     get_user_instructions_wrapper,
     get_user_style_guidelines_wrapper,
+    list_evaluation_cases_wrapper,
     list_sharing_grants_wrapper,
+    preview_evaluation_ground_truth_wrapper,
     remove_dashboard_filter_wrapper,
     remove_learning_wrapper,
+    run_advisor_gate_wrapper,
+    run_evaluation_wrapper,
     save_query_wrapper,
     save_skill_query_wrapper,
     saved_query_schema_wrapper,
     search_datasets_wrapper,
     search_enabled_skills_wrapper,
+    search_evaluation_suites_wrapper,
     search_instructions_wrapper,
     search_learnings_wrapper,
     start_html_generation_wrapper,
+    submit_evaluation_feedback_wrapper,
     update_custom_skill_wrapper,
     update_dashboard_filter_wrapper,
     update_learning_wrapper,
@@ -517,6 +529,218 @@ def register_all_tools(mcp: FastMCP, get_or_create_session_func):
         """
         session = await extract_session_from_context(get_or_create_session_func, context)
         return await describe_sharing_grant_wrapper(grant_id, session["tenant_id"], session["user_id"])
+
+    # Evaluation Governance Tools
+    @mcp.tool()
+    async def search_evaluation_suites(
+        query: str = "",
+        target_kind: str = "",
+        status: str = "",
+        limit: int = 20,
+        context: Context = None,
+    ) -> str:
+        """
+        Search Evaluation suites by text, target kind, or lifecycle status.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await search_evaluation_suites_wrapper(
+            query,
+            target_kind,
+            status,
+            session["tenant_id"],
+            session["user_id"],
+            limit,
+        )
+
+    @mcp.tool()
+    async def describe_evaluation_suite(
+        suite_id: str,
+        include_manifests: bool = False,
+        context: Context = None,
+    ) -> str:
+        """
+        Describe an Evaluation suite, versions, gate policy, and optional manifests.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await describe_evaluation_suite_wrapper(
+            suite_id,
+            session["tenant_id"],
+            session["user_id"],
+            include_manifests,
+        )
+
+    @mcp.tool()
+    async def list_evaluation_cases(
+        suite_version_id: str,
+        include_expected_contract: bool = False,
+        limit: int = 20,
+        context: Context = None,
+    ) -> str:
+        """
+        List Evaluation cases for a suite version. Expected contracts are omitted unless requested.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await list_evaluation_cases_wrapper(
+            suite_version_id,
+            session["tenant_id"],
+            session["user_id"],
+            include_expected_contract,
+            limit,
+        )
+
+    @mcp.tool()
+    async def create_evaluation_case_draft(
+        suite_version_id: str,
+        case_json: str,
+        context: Context = None,
+    ) -> str:
+        """
+        Create an Evaluation case draft from a JSON case payload. Published suite versions remain immutable.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await create_evaluation_case_draft_wrapper(
+            suite_version_id,
+            case_json,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def preview_evaluation_ground_truth(expected_contract_json: str, context: Context = None) -> str:
+        """
+        Validate ground-truth SQL as read-only and return redacted preview metadata.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await preview_evaluation_ground_truth_wrapper(
+            expected_contract_json,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def run_evaluation(
+        suite_version_id: str,
+        target_snapshot_json: str,
+        idempotency_key: str = "",
+        context: Context = None,
+    ) -> str:
+        """
+        Create a DB-backed Evaluation run preflight for a pinned target snapshot.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await run_evaluation_wrapper(
+            suite_version_id,
+            target_snapshot_json,
+            idempotency_key,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def get_evaluation_run(
+        run_id: str,
+        include_case_results: bool = True,
+        limit: int = 20,
+        context: Context = None,
+    ) -> str:
+        """
+        Get an Evaluation run report, including redacted case results and assessments.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await get_evaluation_run_wrapper(
+            run_id,
+            session["tenant_id"],
+            session["user_id"],
+            include_case_results,
+            limit,
+        )
+
+    @mcp.tool()
+    async def compare_evaluation_runs(
+        baseline_run_id: str,
+        candidate_run_id: str,
+        context: Context = None,
+    ) -> str:
+        """
+        Compare baseline and candidate Evaluation runs and surface regressions first.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await compare_evaluation_runs_wrapper(
+            baseline_run_id,
+            candidate_run_id,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def describe_evaluation_failure(run_id: str, limit: int = 20, context: Context = None) -> str:
+        """
+        Return failed case runs and hard-fail assessments for an Evaluation run.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await describe_evaluation_failure_wrapper(
+            run_id,
+            session["tenant_id"],
+            session["user_id"],
+            limit,
+        )
+
+    @mcp.tool()
+    async def create_advisor_change_set(
+        skill_suggestion_id: str,
+        suite_version_id: str = "",
+        affected_case_ids: list[str] | None = None,
+        context: Context = None,
+    ) -> str:
+        """
+        Convert a skill suggestion into a draft Evaluation advisor change set.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await create_advisor_change_set_wrapper(
+            skill_suggestion_id,
+            suite_version_id,
+            affected_case_ids,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def run_advisor_gate(
+        change_set_id: str,
+        target_snapshot_json: str,
+        gate_kind: str,
+        idempotency_key: str = "",
+        context: Context = None,
+    ) -> str:
+        """
+        Queue an advisor verification or regression Evaluation run.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await run_advisor_gate_wrapper(
+            change_set_id,
+            target_snapshot_json,
+            gate_kind,
+            idempotency_key,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def submit_evaluation_feedback(
+        suite_version_id: str,
+        feedback_json: str,
+        context: Context = None,
+    ) -> str:
+        """
+        Submit redacted feedback into Evaluation as a reviewed draft case.
+        """
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await submit_evaluation_feedback_wrapper(
+            suite_version_id,
+            feedback_json,
+            session["tenant_id"],
+            session["user_id"],
+        )
 
     # Plan Tools
     @mcp.tool()

--- a/server/mcp/tools.py
+++ b/server/mcp/tools.py
@@ -4,6 +4,7 @@ MCP tool registrations for FastMCP.
 This file registers all Byaan tools as MCP tools with proper authentication and session handling.
 """
 
+import json
 from uuid import UUID
 
 from fastmcp import Context, FastMCP
@@ -14,9 +15,11 @@ from server.mcp.tool_wrappers import (
     compare_evaluation_runs_wrapper,
     create_advisor_change_set_wrapper,
     create_custom_skill_wrapper,
+    create_dashboard_draft_wrapper,
     create_evaluation_case_draft_wrapper,
     dashboard_search_replace_wrapper,
     define_dashboard_filters_wrapper,
+    describe_dashboard_wrapper,
     describe_evaluation_failure_wrapper,
     describe_evaluation_suite_wrapper,
     describe_sharing_grant_wrapper,
@@ -28,6 +31,8 @@ from server.mcp.tool_wrappers import (
     execute_sql_query_wrapper,
     get_chart_styling_wrapper,
     get_dashboard_filter_config_wrapper,
+    get_dashboard_lineage_wrapper,
+    get_dashboard_state_wrapper,
     get_database_schema_wrapper,
     get_dataset_schema_by_id_wrapper,
     get_evaluation_run_wrapper,
@@ -39,7 +44,11 @@ from server.mcp.tool_wrappers import (
     get_user_style_guidelines_wrapper,
     list_evaluation_cases_wrapper,
     list_sharing_grants_wrapper,
+    patch_dashboard_draft_wrapper,
+    preview_dashboard_wrapper,
     preview_evaluation_ground_truth_wrapper,
+    publish_dashboard_wrapper,
+    query_dashboard_wrapper,
     remove_dashboard_filter_wrapper,
     remove_learning_wrapper,
     run_advisor_gate_wrapper,
@@ -47,6 +56,7 @@ from server.mcp.tool_wrappers import (
     save_query_wrapper,
     save_skill_query_wrapper,
     saved_query_schema_wrapper,
+    search_dashboards_wrapper,
     search_datasets_wrapper,
     search_enabled_skills_wrapper,
     search_evaluation_suites_wrapper,
@@ -57,6 +67,7 @@ from server.mcp.tool_wrappers import (
     update_custom_skill_wrapper,
     update_dashboard_filter_wrapper,
     update_learning_wrapper,
+    validate_dashboard_wrapper,
 )
 from server.utils.custom_logger import get_logger
 
@@ -284,6 +295,175 @@ def register_all_tools(mcp: FastMCP, get_or_create_session_func):
             return '{"success": false, "error": "No notebook context available"}'
         return await dashboard_search_replace_wrapper(
             diff_content, session["tenant_id"], session["user_id"], session["notebook_id"]
+        )
+
+    # Governed Dashboard Tools
+    @mcp.tool()
+    async def search_dashboards(
+        query: str = "",
+        tags: list[str] | None = None,
+        status: str = "",
+        freshness: str = "",
+        limit: int = 20,
+        context: Context = None,
+    ) -> str:
+        """Search governed Dashboard assets by text, tags, lifecycle status, or freshness."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await search_dashboards_wrapper(
+            query,
+            tags,
+            status,
+            freshness,
+            session["tenant_id"],
+            session["user_id"],
+            limit,
+        )
+
+    @mcp.tool()
+    async def describe_dashboard(
+        dashboard_id: str,
+        version: str = "published",
+        detail: str = "compact",
+        context: Context = None,
+    ) -> str:
+        """Describe a governed Dashboard asset and selected manifest version."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await describe_dashboard_wrapper(
+            dashboard_id,
+            version,
+            detail,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def query_dashboard(
+        dashboard_id: str,
+        data_view_ids: list[str] | None = None,
+        filters_json: str = "{}",
+        cursor: str = "",
+        limit: int = 20,
+        context: Context = None,
+    ) -> str:
+        """Query governed Dashboard data views. Accepts data_view_ids, not raw saved query IDs."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        filters = json.loads(filters_json or "{}")
+        return await query_dashboard_wrapper(
+            dashboard_id,
+            data_view_ids,
+            filters,
+            cursor,
+            limit,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def get_dashboard_state(
+        dashboard_id: str,
+        filters_json: str = "{}",
+        data_view_ids: list[str] | None = None,
+        limit: int = 20,
+        context: Context = None,
+    ) -> str:
+        """Return compact governed Dashboard state for selected data views."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await get_dashboard_state_wrapper(
+            dashboard_id,
+            filters_json,
+            data_view_ids,
+            session["tenant_id"],
+            session["user_id"],
+            limit,
+        )
+
+    @mcp.tool()
+    async def get_dashboard_lineage(dashboard_id: str, tile_id: str = "", context: Context = None) -> str:
+        """Return Dashboard lineage for the published version, optionally scoped to a tile."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await get_dashboard_lineage_wrapper(dashboard_id, tile_id, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def create_dashboard_draft(
+        slug: str,
+        notebook_id: str,
+        manifest_json: str,
+        description: str = "",
+        tags: list[str] | None = None,
+        context: Context = None,
+    ) -> str:
+        """Create a governed Dashboard draft from a dashboard.manifest.v1 JSON payload."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await create_dashboard_draft_wrapper(
+            slug,
+            notebook_id,
+            manifest_json,
+            session["tenant_id"],
+            session["user_id"],
+            description,
+            tags,
+        )
+
+    @mcp.tool()
+    async def patch_dashboard_draft(
+        dashboard_id: str,
+        base_etag: str,
+        json_patch: str,
+        change_summary: str = "Patch dashboard draft from MCP",
+        context: Context = None,
+    ) -> str:
+        """Patch a governed Dashboard draft with allowlisted JSON Patch and optimistic ETag."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await patch_dashboard_draft_wrapper(
+            dashboard_id,
+            base_etag,
+            json_patch,
+            change_summary,
+            session["tenant_id"],
+            session["user_id"],
+        )
+
+    @mcp.tool()
+    async def validate_dashboard(dashboard_id: str, context: Context = None) -> str:
+        """Validate the current Dashboard draft and return blockers/warnings."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await validate_dashboard_wrapper(dashboard_id, session["tenant_id"], session["user_id"])
+
+    @mcp.tool()
+    async def preview_dashboard(
+        dashboard_id: str,
+        filters_json: str = "{}",
+        data_view_ids: list[str] | None = None,
+        limit: int = 20,
+        context: Context = None,
+    ) -> str:
+        """Preview the current governed Dashboard draft."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        filters = json.loads(filters_json or "{}")
+        return await preview_dashboard_wrapper(
+            dashboard_id,
+            filters,
+            data_view_ids,
+            session["tenant_id"],
+            session["user_id"],
+            limit,
+        )
+
+    @mcp.tool()
+    async def publish_dashboard(
+        dashboard_id: str,
+        base_etag: str,
+        change_summary: str = "Publish dashboard from MCP",
+        context: Context = None,
+    ) -> str:
+        """Publish a validated governed Dashboard draft."""
+        session = await extract_session_from_context(get_or_create_session_func, context)
+        return await publish_dashboard_wrapper(
+            dashboard_id,
+            base_etag,
+            change_summary,
+            session["tenant_id"],
+            session["user_id"],
         )
 
     # Configuration Tools

--- a/server/migrations/versions/add_canonical_sharing_model.py
+++ b/server/migrations/versions/add_canonical_sharing_model.py
@@ -1,0 +1,190 @@
+"""add canonical sharing model
+
+Revision ID: add_canonical_sharing_model
+Revises: add_skill_loop_lease
+Create Date: 2026-08-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from server.db.base import GUID
+
+revision = "add_canonical_sharing_model"
+down_revision = "add_skill_loop_lease"
+branch_labels = None
+depends_on = None
+
+
+def _tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _drop_table_if_present(table_name: str) -> None:
+    if table_name in _tables():
+        op.drop_table(table_name)
+
+
+def upgrade() -> None:
+    existing = _tables()
+    if "sharing_grants" not in existing:
+        op.create_table(
+            "sharing_grants",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("object_type", sa.String(length=60), nullable=False),
+            sa.Column("object_id", GUID(), nullable=False),
+            sa.Column("object_version_id", GUID(), nullable=True),
+            sa.Column("object_version_digest", sa.String(length=128), nullable=False, server_default=""),
+            sa.Column("mode", sa.String(length=60), nullable=False, server_default="immutable_version"),
+            sa.Column("channel", sa.String(length=60), nullable=False, server_default="public_link"),
+            sa.Column("audience", sa.String(length=60), nullable=False, server_default="link_holder"),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="active"),
+            sa.Column("created_by", GUID(), nullable=True),
+            sa.Column("expires_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("revoked_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("revoked_by", GUID(), nullable=True),
+            sa.Column("revocation_reason", sa.Text(), nullable=True),
+            sa.Column("metadata_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.Column("updated_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["revoked_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_sharing_grants")),
+        )
+        for column_name in (
+            "tenant_id",
+            "object_type",
+            "object_id",
+            "object_version_id",
+            "mode",
+            "channel",
+            "audience",
+            "status",
+        ):
+            op.create_index(f"ix_sharing_grants_{column_name}", "sharing_grants", [column_name])
+
+    if "sharing_secrets" not in existing:
+        op.create_table(
+            "sharing_secrets",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("grant_id", GUID(), nullable=False),
+            sa.Column("secret_type", sa.String(length=40), nullable=False, server_default="password"),
+            sa.Column("algorithm", sa.String(length=60), nullable=False),
+            sa.Column("salt", sa.String(length=128), nullable=False),
+            sa.Column("verifier_hash", sa.String(length=128), nullable=False),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="active"),
+            sa.Column("created_by", GUID(), nullable=True),
+            sa.Column("rotated_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("expires_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["grant_id"], ["sharing_grants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_sharing_secrets")),
+            sa.UniqueConstraint("grant_id", "secret_type", "status", name="uq_sharing_secrets_grant_type_status"),
+        )
+        for column_name in ("tenant_id", "grant_id", "secret_type", "status"):
+            op.create_index(f"ix_sharing_secrets_{column_name}", "sharing_secrets", [column_name])
+
+    if "sharing_viewer_sessions" not in existing:
+        op.create_table(
+            "sharing_viewer_sessions",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("grant_id", GUID(), nullable=False),
+            sa.Column("object_type", sa.String(length=60), nullable=False),
+            sa.Column("object_id", GUID(), nullable=False),
+            sa.Column("object_version_id", GUID(), nullable=True),
+            sa.Column("token_id", sa.String(length=80), nullable=False),
+            sa.Column("token_digest", sa.String(length=128), nullable=False),
+            sa.Column("viewer_user_id", GUID(), nullable=True),
+            sa.Column("viewer_principal_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("issued_at", sa.TIMESTAMP(), nullable=False),
+            sa.Column("expires_at", sa.TIMESTAMP(), nullable=False),
+            sa.Column("revoked_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["grant_id"], ["sharing_grants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["viewer_user_id"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_sharing_viewer_sessions")),
+            sa.UniqueConstraint("token_digest", name="uq_sharing_viewer_sessions_token_digest"),
+        )
+        for column_name in (
+            "tenant_id",
+            "grant_id",
+            "object_type",
+            "object_id",
+            "object_version_id",
+            "token_id",
+        ):
+            op.create_index(f"ix_sharing_viewer_sessions_{column_name}", "sharing_viewer_sessions", [column_name])
+
+    if "sharing_audit_events" not in existing:
+        op.create_table(
+            "sharing_audit_events",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("grant_id", GUID(), nullable=True),
+            sa.Column("viewer_session_id", GUID(), nullable=True),
+            sa.Column("object_type", sa.String(length=60), nullable=False),
+            sa.Column("object_id", GUID(), nullable=True),
+            sa.Column("object_version_id", GUID(), nullable=True),
+            sa.Column("actor_type", sa.String(length=40), nullable=False),
+            sa.Column("actor_id", sa.String(length=160), nullable=False),
+            sa.Column("action", sa.String(length=120), nullable=False),
+            sa.Column("outcome", sa.String(length=40), nullable=False),
+            sa.Column("details_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["grant_id"], ["sharing_grants.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["viewer_session_id"], ["sharing_viewer_sessions.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_sharing_audit_events")),
+        )
+        for column_name in (
+            "tenant_id",
+            "grant_id",
+            "viewer_session_id",
+            "object_type",
+            "object_id",
+            "object_version_id",
+            "actor_id",
+            "action",
+            "outcome",
+        ):
+            op.create_index(f"ix_sharing_audit_events_{column_name}", "sharing_audit_events", [column_name])
+
+    if "sharing_compatibility_links" not in existing:
+        op.create_table(
+            "sharing_compatibility_links",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("grant_id", GUID(), nullable=False),
+            sa.Column("legacy_surface", sa.String(length=80), nullable=False),
+            sa.Column("legacy_id", sa.String(length=255), nullable=False),
+            sa.Column("metadata_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["grant_id"], ["sharing_grants.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_sharing_compatibility_links")),
+            sa.UniqueConstraint("legacy_surface", "legacy_id", name="uq_sharing_compatibility_links_legacy"),
+        )
+        for column_name in ("tenant_id", "grant_id", "legacy_surface", "legacy_id"):
+            op.create_index(
+                f"ix_sharing_compatibility_links_{column_name}", "sharing_compatibility_links", [column_name]
+            )
+
+
+def downgrade() -> None:
+    for table_name in (
+        "sharing_compatibility_links",
+        "sharing_audit_events",
+        "sharing_viewer_sessions",
+        "sharing_secrets",
+        "sharing_grants",
+    ):
+        _drop_table_if_present(table_name)

--- a/server/migrations/versions/add_evaluation_authoritative_model.py
+++ b/server/migrations/versions/add_evaluation_authoritative_model.py
@@ -1,0 +1,369 @@
+"""add evaluation authoritative model
+
+Revision ID: add_evaluation_authoritative_model
+Revises: add_canonical_sharing_model
+Create Date: 2026-08-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from server.db.base import GUID
+
+revision = "add_evaluation_authoritative_model"
+down_revision = "add_canonical_sharing_model"
+branch_labels = None
+depends_on = None
+
+
+def _tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _drop_table_if_present(table_name: str) -> None:
+    if table_name in _tables():
+        op.drop_table(table_name)
+
+
+def upgrade() -> None:
+    existing = _tables()
+    if "evaluation_suites" not in existing:
+        op.create_table(
+            "evaluation_suites",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("slug", sa.String(length=160), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("description", sa.Text(), nullable=False, server_default=""),
+            sa.Column("owner_id", GUID(), nullable=True),
+            sa.Column("target_kinds_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("lifecycle", sa.String(length=40), nullable=False, server_default="draft"),
+            sa.Column("current_draft_version_id", GUID(), nullable=True),
+            sa.Column("published_version_id", GUID(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.Column("updated_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_suites")),
+            sa.UniqueConstraint("tenant_id", "slug", name="uq_evaluation_suites_tenant_slug"),
+        )
+        op.create_index("ix_evaluation_suites_tenant_id", "evaluation_suites", ["tenant_id"])
+        op.create_index("ix_evaluation_suites_lifecycle", "evaluation_suites", ["lifecycle"])
+
+    if "evaluation_suite_versions" not in existing:
+        op.create_table(
+            "evaluation_suite_versions",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("suite_id", GUID(), nullable=False),
+            sa.Column("version_num", sa.Integer(), nullable=False),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="draft"),
+            sa.Column("contract_version", sa.String(length=80), nullable=False),
+            sa.Column("manifest_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("gate_policy_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("case_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("content_hash", sa.String(length=128), nullable=False, server_default=""),
+            sa.Column("created_by", GUID(), nullable=True),
+            sa.Column("published_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["suite_id"], ["evaluation_suites.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_suite_versions")),
+            sa.UniqueConstraint("suite_id", "version_num", name="uq_evaluation_suite_versions_suite_version"),
+        )
+        op.create_index("ix_evaluation_suite_versions_tenant_id", "evaluation_suite_versions", ["tenant_id"])
+        op.create_index("ix_evaluation_suite_versions_suite_id", "evaluation_suite_versions", ["suite_id"])
+        op.create_index("ix_evaluation_suite_versions_status", "evaluation_suite_versions", ["status"])
+        op.create_index("ix_evaluation_suite_versions_content_hash", "evaluation_suite_versions", ["content_hash"])
+
+    existing = _tables()
+    if "evaluation_suites" in existing:
+        with op.batch_alter_table("evaluation_suites") as batch_op:
+            batch_op.create_foreign_key(
+                "fk_evaluation_suites_current_draft_version_id_versions",
+                "evaluation_suite_versions",
+                ["current_draft_version_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+            batch_op.create_foreign_key(
+                "fk_evaluation_suites_published_version_id_versions",
+                "evaluation_suite_versions",
+                ["published_version_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
+    if "evaluation_cases" not in existing:
+        op.create_table(
+            "evaluation_cases",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("suite_version_id", GUID(), nullable=False),
+            sa.Column("case_key", sa.String(length=160), nullable=False),
+            sa.Column("title", sa.String(length=255), nullable=False),
+            sa.Column("target_kinds_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("operation", sa.String(length=80), nullable=False),
+            sa.Column("question", sa.Text(), nullable=False),
+            sa.Column("expected_contract_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("provenance_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("tags_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("content_hash", sa.String(length=128), nullable=False, server_default=""),
+            sa.Column("immutable", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["suite_version_id"], ["evaluation_suite_versions.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_cases")),
+            sa.UniqueConstraint("suite_version_id", "case_key", name="uq_evaluation_cases_version_key"),
+        )
+        for column_name in ("tenant_id", "suite_version_id", "content_hash"):
+            op.create_index(f"ix_evaluation_cases_{column_name}", "evaluation_cases", [column_name])
+
+    if "evaluation_target_snapshots" not in existing:
+        op.create_table(
+            "evaluation_target_snapshots",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("target_kind", sa.String(length=60), nullable=False),
+            sa.Column("target_ref", sa.String(length=255), nullable=False),
+            sa.Column("contract_version", sa.String(length=80), nullable=False),
+            sa.Column("snapshot_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("pin_digest", sa.String(length=128), nullable=False),
+            sa.Column("blockers_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_target_snapshots")),
+        )
+        for column_name in ("tenant_id", "target_kind", "target_ref", "pin_digest"):
+            op.create_index(f"ix_evaluation_target_snapshots_{column_name}", "evaluation_target_snapshots", [column_name])
+
+    if "evaluation_runs" not in existing:
+        op.create_table(
+            "evaluation_runs",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("suite_version_id", GUID(), nullable=False),
+            sa.Column("target_snapshot_id", GUID(), nullable=False),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="queued"),
+            sa.Column("actor_type", sa.String(length=40), nullable=False, server_default="human"),
+            sa.Column("actor_id", sa.String(length=160), nullable=False),
+            sa.Column("baseline_run_id", GUID(), nullable=True),
+            sa.Column("candidate_label", sa.String(length=160), nullable=True),
+            sa.Column("idempotency_key", sa.String(length=160), nullable=True),
+            sa.Column("attempt", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("lease_holder", sa.String(length=160), nullable=True),
+            sa.Column("lease_expires_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("heartbeat_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("stop_requested", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("preflight_blockers_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("summary_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("started_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("completed_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["suite_version_id"], ["evaluation_suite_versions.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["target_snapshot_id"], ["evaluation_target_snapshots.id"], ondelete="RESTRICT"),
+            sa.ForeignKeyConstraint(["baseline_run_id"], ["evaluation_runs.id"]),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_runs")),
+            sa.UniqueConstraint("suite_version_id", "idempotency_key", name="uq_evaluation_runs_suite_idempotency"),
+        )
+        for column_name in ("tenant_id", "suite_version_id", "target_snapshot_id", "status", "actor_id"):
+            op.create_index(f"ix_evaluation_runs_{column_name}", "evaluation_runs", [column_name])
+
+    if "evaluation_case_runs" not in existing:
+        op.create_table(
+            "evaluation_case_runs",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("run_id", GUID(), nullable=False),
+            sa.Column("case_id", GUID(), nullable=False),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="queued"),
+            sa.Column("attempt", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("input_digest", sa.String(length=128), nullable=False, server_default=""),
+            sa.Column("output_digest", sa.String(length=128), nullable=False, server_default=""),
+            sa.Column("result_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("error_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("immutable", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("started_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("completed_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["run_id"], ["evaluation_runs.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["case_id"], ["evaluation_cases.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_case_runs")),
+        )
+        for column_name in ("tenant_id", "run_id", "case_id", "status"):
+            op.create_index(f"ix_evaluation_case_runs_{column_name}", "evaluation_case_runs", [column_name])
+
+    if "evaluation_assessments" not in existing:
+        op.create_table(
+            "evaluation_assessments",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("case_run_id", GUID(), nullable=False),
+            sa.Column("category", sa.String(length=80), nullable=False),
+            sa.Column("status", sa.String(length=40), nullable=False),
+            sa.Column("score", sa.String(length=80), nullable=True),
+            sa.Column("hard_fail", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("details_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("immutable", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["case_run_id"], ["evaluation_case_runs.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_assessments")),
+        )
+        for column_name in ("tenant_id", "case_run_id", "category"):
+            op.create_index(f"ix_evaluation_assessments_{column_name}", "evaluation_assessments", [column_name])
+
+    if "evaluation_overrides" not in existing:
+        op.create_table(
+            "evaluation_overrides",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("assessment_id", GUID(), nullable=False),
+            sa.Column("override_type", sa.String(length=40), nullable=False),
+            sa.Column("reason", sa.Text(), nullable=False),
+            sa.Column("created_by", GUID(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["assessment_id"], ["evaluation_assessments.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_overrides")),
+        )
+        for column_name in ("tenant_id", "assessment_id"):
+            op.create_index(f"ix_evaluation_overrides_{column_name}", "evaluation_overrides", [column_name])
+
+    if "evaluation_artifacts" not in existing:
+        op.create_table(
+            "evaluation_artifacts",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("run_id", GUID(), nullable=True),
+            sa.Column("case_run_id", GUID(), nullable=True),
+            sa.Column("artifact_type", sa.String(length=80), nullable=False),
+            sa.Column("uri", sa.Text(), nullable=False),
+            sa.Column("content_hash", sa.String(length=128), nullable=False),
+            sa.Column("metadata_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("immutable", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["run_id"], ["evaluation_runs.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["case_run_id"], ["evaluation_case_runs.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_artifacts")),
+        )
+        for column_name in ("tenant_id", "run_id", "case_run_id", "artifact_type", "content_hash"):
+            op.create_index(f"ix_evaluation_artifacts_{column_name}", "evaluation_artifacts", [column_name])
+
+    if "advisor_change_sets" not in existing:
+        op.create_table(
+            "advisor_change_sets",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("suite_version_id", GUID(), nullable=True),
+            sa.Column("target_ref", sa.String(length=255), nullable=False),
+            sa.Column("base_version_ref", sa.String(length=255), nullable=False),
+            sa.Column("base_etag", sa.String(length=128), nullable=False),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="draft"),
+            sa.Column("evidence_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("verification_run_id", GUID(), nullable=True),
+            sa.Column("regression_run_id", GUID(), nullable=True),
+            sa.Column("created_by", sa.String(length=160), nullable=False),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["suite_version_id"], ["evaluation_suite_versions.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["verification_run_id"], ["evaluation_runs.id"]),
+            sa.ForeignKeyConstraint(["regression_run_id"], ["evaluation_runs.id"]),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_advisor_change_sets")),
+        )
+        for column_name in ("tenant_id", "target_ref", "status"):
+            op.create_index(f"ix_advisor_change_sets_{column_name}", "advisor_change_sets", [column_name])
+
+    if "advisor_suggestions" not in existing:
+        op.create_table(
+            "advisor_suggestions",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("change_set_id", GUID(), nullable=False),
+            sa.Column("suggestion_type", sa.String(length=80), nullable=False),
+            sa.Column("patch_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("affected_case_ids_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="draft"),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["change_set_id"], ["advisor_change_sets.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_advisor_suggestions")),
+        )
+        for column_name in ("tenant_id", "change_set_id", "status"):
+            op.create_index(f"ix_advisor_suggestions_{column_name}", "advisor_suggestions", [column_name])
+
+    if "promotion_decisions" not in existing:
+        op.create_table(
+            "promotion_decisions",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("change_set_id", GUID(), nullable=True),
+            sa.Column("verification_run_id", GUID(), nullable=True),
+            sa.Column("regression_run_id", GUID(), nullable=True),
+            sa.Column("decision", sa.String(length=40), nullable=False),
+            sa.Column("decided_by", GUID(), nullable=True),
+            sa.Column("rationale", sa.Text(), nullable=False, server_default=""),
+            sa.Column("audit_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["change_set_id"], ["advisor_change_sets.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["verification_run_id"], ["evaluation_runs.id"]),
+            sa.ForeignKeyConstraint(["regression_run_id"], ["evaluation_runs.id"]),
+            sa.ForeignKeyConstraint(["decided_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_promotion_decisions")),
+        )
+        op.create_index("ix_promotion_decisions_tenant_id", "promotion_decisions", ["tenant_id"])
+
+    if "evaluation_audit_events" not in existing:
+        op.create_table(
+            "evaluation_audit_events",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("suite_id", GUID(), nullable=True),
+            sa.Column("suite_version_id", GUID(), nullable=True),
+            sa.Column("run_id", GUID(), nullable=True),
+            sa.Column("actor_type", sa.String(length=40), nullable=False),
+            sa.Column("actor_id", sa.String(length=160), nullable=False),
+            sa.Column("action", sa.String(length=120), nullable=False),
+            sa.Column("outcome", sa.String(length=40), nullable=False),
+            sa.Column("details_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["suite_id"], ["evaluation_suites.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["suite_version_id"], ["evaluation_suite_versions.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["run_id"], ["evaluation_runs.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_audit_events")),
+        )
+        for column_name in ("tenant_id", "suite_id", "suite_version_id", "run_id", "actor_id", "action"):
+            op.create_index(f"ix_evaluation_audit_events_{column_name}", "evaluation_audit_events", [column_name])
+
+
+def downgrade() -> None:
+    for table_name in (
+        "evaluation_audit_events",
+        "promotion_decisions",
+        "advisor_suggestions",
+        "advisor_change_sets",
+        "evaluation_artifacts",
+        "evaluation_overrides",
+        "evaluation_assessments",
+        "evaluation_case_runs",
+        "evaluation_runs",
+        "evaluation_target_snapshots",
+        "evaluation_cases",
+    ):
+        _drop_table_if_present(table_name)
+
+    if "evaluation_suites" in _tables():
+        with op.batch_alter_table("evaluation_suites") as batch_op:
+            batch_op.drop_constraint("fk_evaluation_suites_published_version_id_versions", type_="foreignkey")
+            batch_op.drop_constraint("fk_evaluation_suites_current_draft_version_id_versions", type_="foreignkey")
+    _drop_table_if_present("evaluation_suite_versions")
+    _drop_table_if_present("evaluation_suites")

--- a/server/migrations/versions/add_evaluation_authoritative_model.py
+++ b/server/migrations/versions/add_evaluation_authoritative_model.py
@@ -138,7 +138,9 @@ def upgrade() -> None:
             sa.PrimaryKeyConstraint("id", name=op.f("pk_evaluation_target_snapshots")),
         )
         for column_name in ("tenant_id", "target_kind", "target_ref", "pin_digest"):
-            op.create_index(f"ix_evaluation_target_snapshots_{column_name}", "evaluation_target_snapshots", [column_name])
+            op.create_index(
+                f"ix_evaluation_target_snapshots_{column_name}", "evaluation_target_snapshots", [column_name]
+            )
 
     if "evaluation_runs" not in existing:
         op.create_table(

--- a/server/migrations/versions/add_governed_dashboard_assets.py
+++ b/server/migrations/versions/add_governed_dashboard_assets.py
@@ -1,0 +1,242 @@
+"""add governed dashboard assets
+
+Revision ID: add_governed_dashboard_assets
+Revises: add_evaluation_authoritative_model
+Create Date: 2026-08-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from fastapi_users_db_sqlalchemy.generics import GUID
+
+revision = "add_governed_dashboard_assets"
+down_revision = "add_evaluation_authoritative_model"
+branch_labels = None
+depends_on = None
+
+
+def _tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _columns(table_name: str) -> set[str]:
+    if table_name not in _tables():
+        return set()
+    return {column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)}
+
+
+def _add_dashboard_column_if_missing(column: sa.Column) -> None:
+    if "dashboards" not in _tables() or column.name in _columns("dashboards"):
+        return
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.add_column(column)
+
+
+def _drop_dashboard_column_if_present(column_name: str) -> None:
+    if "dashboards" not in _tables() or column_name not in _columns("dashboards"):
+        return
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.drop_column(column_name)
+
+
+def upgrade() -> None:
+    if "dashboard_assets" not in _tables():
+        op.create_table(
+            "dashboard_assets",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("notebook_id", GUID(), nullable=True),
+            sa.Column("slug", sa.String(length=160), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("description", sa.Text(), nullable=False, server_default=""),
+            sa.Column("owner_id", GUID(), nullable=True),
+            sa.Column("tags_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("lifecycle", sa.String(length=40), nullable=False, server_default="legacy_unstructured"),
+            sa.Column("current_draft_version_id", GUID(), nullable=True),
+            sa.Column("published_version_id", GUID(), nullable=True),
+            sa.Column("access_policy_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("freshness_policy_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("consumer_summary_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("health_summary_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("etag", sa.String(length=128), nullable=False, server_default=""),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.Column("updated_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["notebook_id"], ["notebooks.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(
+                ["current_draft_version_id"],
+                ["dashboards.id"],
+                name="fk_dashboard_assets_current_draft_version_id_dashboards",
+                ondelete="SET NULL",
+                use_alter=True,
+            ),
+            sa.ForeignKeyConstraint(
+                ["published_version_id"],
+                ["dashboards.id"],
+                name="fk_dashboard_assets_published_version_id_dashboards",
+                ondelete="SET NULL",
+                use_alter=True,
+            ),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_dashboard_assets")),
+            sa.UniqueConstraint("tenant_id", "slug", name="uq_dashboard_assets_tenant_slug"),
+        )
+        op.create_index("ix_dashboard_assets_tenant_id", "dashboard_assets", ["tenant_id"])
+        op.create_index("ix_dashboard_assets_notebook_id", "dashboard_assets", ["notebook_id"])
+        op.create_index("ix_dashboard_assets_lifecycle", "dashboard_assets", ["lifecycle"])
+
+    dashboard_columns = [
+        sa.Column("asset_id", GUID(), nullable=True),
+        sa.Column("manifest_schema_version", sa.String(length=64), nullable=True),
+        sa.Column("manifest_json", sa.JSON(), nullable=True),
+        sa.Column("content_hash", sa.String(length=128), nullable=True),
+        sa.Column("status", sa.String(length=40), nullable=False, server_default="legacy_unstructured"),
+        sa.Column("created_by", GUID(), nullable=True),
+        sa.Column("actor_type", sa.String(length=40), nullable=True),
+        sa.Column("change_summary", sa.Text(), nullable=False, server_default=""),
+        sa.Column("pinned_model_versions_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("pinned_source_snapshots_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("validation_result_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("renderer_version", sa.String(length=80), nullable=True),
+        sa.Column("migration_state", sa.String(length=40), nullable=False, server_default="legacy_unstructured"),
+        sa.Column("is_published_immutable", sa.Boolean(), nullable=False, server_default=sa.false()),
+    ]
+    for column in dashboard_columns:
+        _add_dashboard_column_if_missing(column)
+
+    if "dashboards" in _tables():
+        existing_indexes = {index["name"] for index in sa.inspect(op.get_bind()).get_indexes("dashboards")}
+        for index_name, column_name in (
+            ("ix_dashboards_asset_id", "asset_id"),
+            ("ix_dashboards_content_hash", "content_hash"),
+            ("ix_dashboards_status", "status"),
+            ("ix_dashboards_migration_state", "migration_state"),
+        ):
+            if index_name not in existing_indexes and column_name in _columns("dashboards"):
+                op.create_index(index_name, "dashboards", [column_name])
+
+    if "dashboard_runs" not in _tables():
+        op.create_table(
+            "dashboard_runs",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("asset_id", GUID(), nullable=False),
+            sa.Column("version_id", GUID(), nullable=False),
+            sa.Column("actor_type", sa.String(length=40), nullable=False),
+            sa.Column("actor_id", sa.String(length=160), nullable=False),
+            sa.Column("correlation_id", sa.String(length=160), nullable=True),
+            sa.Column("session_id", sa.String(length=160), nullable=True),
+            sa.Column("idempotency_key", sa.String(length=160), nullable=True),
+            sa.Column("mode", sa.String(length=40), nullable=False, server_default="live"),
+            sa.Column("normalized_filters_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("filter_digest", sa.String(length=128), nullable=False),
+            sa.Column("pinned_versions_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("execution_plan_digest", sa.String(length=128), nullable=False),
+            sa.Column("overall_freshness", sa.String(length=40), nullable=False, server_default="unknown"),
+            sa.Column("result_manifest_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("warnings_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("errors_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("started_at", sa.TIMESTAMP(), nullable=False),
+            sa.Column("completed_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["asset_id"], ["dashboard_assets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["version_id"], ["dashboards.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_dashboard_runs")),
+            sa.UniqueConstraint("asset_id", "idempotency_key", name="uq_dashboard_runs_asset_idempotency"),
+        )
+        for column_name in (
+            "tenant_id",
+            "asset_id",
+            "version_id",
+            "actor_id",
+            "correlation_id",
+            "mode",
+            "filter_digest",
+            "execution_plan_digest",
+        ):
+            op.create_index(f"ix_dashboard_runs_{column_name}", "dashboard_runs", [column_name])
+
+    if "dashboard_audit_events" not in _tables():
+        op.create_table(
+            "dashboard_audit_events",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("asset_id", GUID(), nullable=True),
+            sa.Column("version_id", GUID(), nullable=True),
+            sa.Column("run_id", GUID(), nullable=True),
+            sa.Column("actor_type", sa.String(length=40), nullable=False),
+            sa.Column("actor_id", sa.String(length=160), nullable=False),
+            sa.Column("action", sa.String(length=120), nullable=False),
+            sa.Column("correlation_id", sa.String(length=160), nullable=True),
+            sa.Column("before_digest", sa.String(length=128), nullable=True),
+            sa.Column("after_digest", sa.String(length=128), nullable=True),
+            sa.Column("outcome", sa.String(length=40), nullable=False),
+            sa.Column("details_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["asset_id"], ["dashboard_assets.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["version_id"], ["dashboards.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["run_id"], ["dashboard_runs.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_dashboard_audit_events")),
+        )
+        for column_name in ("tenant_id", "asset_id", "version_id", "run_id", "actor_id", "action", "correlation_id"):
+            op.create_index(f"ix_dashboard_audit_events_{column_name}", "dashboard_audit_events", [column_name])
+
+
+def downgrade() -> None:
+    if "dashboard_audit_events" in _tables():
+        for column_name in ("correlation_id", "action", "actor_id", "run_id", "version_id", "asset_id", "tenant_id"):
+            op.drop_index(f"ix_dashboard_audit_events_{column_name}", table_name="dashboard_audit_events")
+        op.drop_table("dashboard_audit_events")
+
+    if "dashboard_runs" in _tables():
+        for column_name in (
+            "execution_plan_digest",
+            "filter_digest",
+            "mode",
+            "correlation_id",
+            "actor_id",
+            "version_id",
+            "asset_id",
+            "tenant_id",
+        ):
+            op.drop_index(f"ix_dashboard_runs_{column_name}", table_name="dashboard_runs")
+        op.drop_table("dashboard_runs")
+
+    if "dashboards" in _tables():
+        existing_indexes = {index["name"] for index in sa.inspect(op.get_bind()).get_indexes("dashboards")}
+        for index_name in (
+            "ix_dashboards_migration_state",
+            "ix_dashboards_status",
+            "ix_dashboards_content_hash",
+            "ix_dashboards_asset_id",
+        ):
+            if index_name in existing_indexes:
+                op.drop_index(index_name, table_name="dashboards")
+
+    for column_name in (
+        "is_published_immutable",
+        "migration_state",
+        "renderer_version",
+        "validation_result_json",
+        "pinned_source_snapshots_json",
+        "pinned_model_versions_json",
+        "change_summary",
+        "actor_type",
+        "created_by",
+        "status",
+        "content_hash",
+        "manifest_json",
+        "manifest_schema_version",
+        "asset_id",
+    ):
+        _drop_dashboard_column_if_present(column_name)
+
+    if "dashboard_assets" in _tables():
+        op.drop_index("ix_dashboard_assets_lifecycle", table_name="dashboard_assets")
+        op.drop_index("ix_dashboard_assets_notebook_id", table_name="dashboard_assets")
+        op.drop_index("ix_dashboard_assets_tenant_id", table_name="dashboard_assets")
+        op.drop_table("dashboard_assets")

--- a/server/migrations/versions/add_semantic_model_beta_foundation.py
+++ b/server/migrations/versions/add_semantic_model_beta_foundation.py
@@ -1,0 +1,141 @@
+"""add semantic model beta foundation
+
+Revision ID: add_semantic_model_beta_foundation
+Revises: add_source_connector_foundation
+Create Date: 2026-08-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from server.db.base import GUID
+
+revision = "add_semantic_model_beta_foundation"
+down_revision = "add_source_connector_foundation"
+branch_labels = None
+depends_on = None
+
+
+def _tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _drop_index_if_present(index_name: str, table_name: str) -> None:
+    if table_name not in _tables():
+        return
+    indexes = {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+    if index_name in indexes:
+        op.drop_index(index_name, table_name=table_name)
+
+
+def upgrade() -> None:
+    existing = _tables()
+    if "semantic_models" not in existing:
+        op.create_table(
+            "semantic_models",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("created_by", GUID(), nullable=True),
+            sa.Column("slug", sa.String(length=160), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("domain", sa.String(length=255), nullable=False, server_default=""),
+            sa.Column("owner", sa.String(length=255), nullable=False, server_default=""),
+            sa.Column("description", sa.Text(), nullable=False, server_default=""),
+            sa.Column("datasource_id", sa.Text(), nullable=True),
+            sa.Column("datasource_name", sa.Text(), nullable=True),
+            sa.Column("datasource_kind", sa.String(length=64), nullable=False, server_default="source"),
+            sa.Column("contract_version", sa.String(length=80), nullable=False, server_default="semantic.model.v1beta"),
+            sa.Column("manifest_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("source_resource_ids_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("source_snapshot_ids_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="beta"),
+            sa.Column("readiness", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("readiness_level", sa.String(length=32), nullable=False, server_default="partial"),
+            sa.Column("revision", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("draft_revision", sa.String(length=64), nullable=False, server_default="draft-1"),
+            sa.Column("published_version", sa.String(length=64), nullable=True),
+            sa.Column("validation_result_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("consumer_summary_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.Column("updated_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.CheckConstraint(
+                "status IN ('beta', 'draft', 'needs_review', 'validation_failed', 'archived')",
+                name=op.f("ck_semantic_models_semantic_models_status"),
+            ),
+            sa.CheckConstraint(
+                "readiness_level IN ('blocked', 'partial')",
+                name=op.f("ck_semantic_models_semantic_models_readiness_level"),
+            ),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_semantic_models")),
+            sa.UniqueConstraint("tenant_id", "slug", name="uq_semantic_models_tenant_slug"),
+        )
+        for column_name in ("tenant_id", "created_by", "datasource_id", "status"):
+            op.create_index(f"ix_semantic_models_{column_name}", "semantic_models", [column_name])
+
+    existing = _tables()
+    if "semantic_model_versions" not in existing:
+        op.create_table(
+            "semantic_model_versions",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("model_id", GUID(), nullable=False),
+            sa.Column("version_label", sa.String(length=64), nullable=False),
+            sa.Column("revision", sa.Integer(), nullable=False),
+            sa.Column("snapshot_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("source_snapshot_ids_json", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+            sa.Column("validation_result_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("content_hash", sa.String(length=128), nullable=False),
+            sa.Column("created_by", GUID(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["model_id"], ["semantic_models.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_semantic_model_versions")),
+            sa.UniqueConstraint("model_id", "version_label", name="uq_semantic_model_versions_model_label"),
+        )
+        for column_name in ("tenant_id", "model_id", "created_by", "content_hash"):
+            op.create_index(f"ix_semantic_model_versions_{column_name}", "semantic_model_versions", [column_name])
+
+    existing = _tables()
+    if "semantic_model_audit_events" not in existing:
+        op.create_table(
+            "semantic_model_audit_events",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("model_id", GUID(), nullable=False),
+            sa.Column("actor_id", GUID(), nullable=True),
+            sa.Column("action", sa.String(length=120), nullable=False),
+            sa.Column("details_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["model_id"], ["semantic_models.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["actor_id"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_semantic_model_audit_events")),
+        )
+        for column_name in ("tenant_id", "model_id", "actor_id", "action"):
+            op.create_index(
+                f"ix_semantic_model_audit_events_{column_name}",
+                "semantic_model_audit_events",
+                [column_name],
+            )
+
+
+def downgrade() -> None:
+    if "semantic_model_audit_events" in _tables():
+        for column_name in ("action", "actor_id", "model_id", "tenant_id"):
+            _drop_index_if_present(f"ix_semantic_model_audit_events_{column_name}", "semantic_model_audit_events")
+        op.drop_table("semantic_model_audit_events")
+
+    if "semantic_model_versions" in _tables():
+        for column_name in ("content_hash", "created_by", "model_id", "tenant_id"):
+            _drop_index_if_present(f"ix_semantic_model_versions_{column_name}", "semantic_model_versions")
+        op.drop_table("semantic_model_versions")
+
+    if "semantic_models" in _tables():
+        for column_name in ("status", "datasource_id", "created_by", "tenant_id"):
+            _drop_index_if_present(f"ix_semantic_models_{column_name}", "semantic_models")
+        op.drop_table("semantic_models")

--- a/server/migrations/versions/add_source_connector_foundation.py
+++ b/server/migrations/versions/add_source_connector_foundation.py
@@ -1,0 +1,181 @@
+"""add source connector foundation
+
+Revision ID: add_source_connector_foundation
+Revises: backfill_legacy_dashboard_assets
+Create Date: 2026-08-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from server.db.base import GUID
+
+revision = "add_source_connector_foundation"
+down_revision = "backfill_legacy_dashboard_assets"
+branch_labels = None
+depends_on = None
+
+
+def _tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _drop_index_if_present(index_name: str, table_name: str) -> None:
+    if table_name not in _tables():
+        return
+    indexes = {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+    if index_name in indexes:
+        op.drop_index(index_name, table_name=table_name)
+
+
+def upgrade() -> None:
+    existing = _tables()
+    if "source_connections" not in existing:
+        op.create_table(
+            "source_connections",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("provider", sa.String(length=60), nullable=False),
+            sa.Column("auth_mode", sa.String(length=30), nullable=False),
+            sa.Column("encrypted_credentials", sa.Text(), nullable=False),
+            sa.Column("external_account_id", sa.Text(), nullable=True),
+            sa.Column("display_name", sa.String(length=255), nullable=False),
+            sa.Column("status", sa.String(length=40), nullable=False, server_default="beta"),
+            sa.Column("capabilities_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("token_expires_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("created_by", GUID(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.Column("updated_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.CheckConstraint(
+                "provider IN ('local_files', 'web', 'feishu', 'sql_databases', 'volcengine_tos', 'databricks')",
+                name=op.f("ck_source_connections_source_connections_provider"),
+            ),
+            sa.CheckConstraint(
+                "auth_mode IN ('oauth', 'access_key', 'connection_string', 'none')",
+                name=op.f("ck_source_connections_source_connections_auth_mode"),
+            ),
+            sa.CheckConstraint(
+                "status IN ('beta', 'pending', 'connected', 'authorization_required', "
+                "'reauthorization_required', 'failed', 'disconnected')",
+                name=op.f("ck_source_connections_source_connections_status"),
+            ),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_source_connections")),
+            sa.UniqueConstraint(
+                "tenant_id",
+                "provider",
+                "created_by",
+                "external_account_id",
+                name="uq_source_connections_account",
+            ),
+        )
+        for column_name in ("tenant_id", "provider", "status", "token_expires_at", "created_by"):
+            op.create_index(f"ix_source_connections_{column_name}", "source_connections", [column_name])
+
+    existing = _tables()
+    if "source_resources" not in existing:
+        op.create_table(
+            "source_resources",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("connection_id", GUID(), nullable=True),
+            sa.Column("source_connection_id", GUID(), nullable=True),
+            sa.Column("resource_type", sa.String(length=40), nullable=False),
+            sa.Column("name", sa.Text(), nullable=False),
+            sa.Column("external_id", sa.Text(), nullable=True),
+            sa.Column("source_url", sa.Text(), nullable=True),
+            sa.Column("parent_external_id", sa.Text(), nullable=True),
+            sa.Column("selection_config_json", sa.JSON(), nullable=True),
+            sa.Column("owner_id", GUID(), nullable=True),
+            sa.Column("visibility", sa.String(length=30), nullable=False, server_default="workspace"),
+            sa.Column("sync_mode", sa.String(length=20), nullable=False, server_default="manual"),
+            sa.Column("sync_config_json", sa.JSON(), nullable=True),
+            sa.Column("status", sa.String(length=30), nullable=False, server_default="beta"),
+            sa.Column("latest_snapshot_id", GUID(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.Column("updated_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.CheckConstraint(
+                "resource_type IN ('file', 'pdf', 'web', 'feishu_doc', 'feishu_wiki', 'feishu_sheet', "
+                "'feishu_base', 'tos_bucket', 'tos_prefix', 'tos_object', 'database_catalog', "
+                "'database_schema', 'database_table', 'databricks_catalog', 'databricks_schema', "
+                "'databricks_table')",
+                name=op.f("ck_source_resources_source_resources_resource_type"),
+            ),
+            sa.CheckConstraint(
+                "sync_mode IN ('manual', 'scheduled')",
+                name=op.f("ck_source_resources_source_resources_sync_mode"),
+            ),
+            sa.CheckConstraint(
+                "status IN ('pending', 'beta', 'syncing', 'understanding', 'authorization_required', "
+                "'reauthorization_required', 'blocked', 'source_unavailable', 'permission_lost', "
+                "'needs_confirmation', 'ready', 'failed')",
+                name=op.f("ck_source_resources_source_resources_status"),
+            ),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["connection_id"], ["connections.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["source_connection_id"], ["source_connections.id"], ondelete="SET NULL"),
+            sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_source_resources")),
+        )
+        for column_name in (
+            "tenant_id",
+            "connection_id",
+            "source_connection_id",
+            "owner_id",
+            "status",
+            "latest_snapshot_id",
+        ):
+            op.create_index(f"ix_source_resources_{column_name}", "source_resources", [column_name])
+
+    existing = _tables()
+    if "source_snapshots" not in existing:
+        op.create_table(
+            "source_snapshots",
+            sa.Column("id", GUID(), nullable=False),
+            sa.Column("tenant_id", GUID(), nullable=False),
+            sa.Column("resource_id", GUID(), nullable=False),
+            sa.Column("external_revision", sa.Text(), nullable=True),
+            sa.Column("content_hash", sa.String(length=128), nullable=False),
+            sa.Column("raw_storage_uri", sa.Text(), nullable=False),
+            sa.Column("captured_at", sa.TIMESTAMP(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
+            sa.Column("parser_version", sa.String(length=100), nullable=True),
+            sa.Column("metadata_json", sa.JSON(), nullable=True),
+            sa.Column("status", sa.String(length=30), nullable=False, server_default="captured"),
+            sa.Column("error_json", sa.JSON(), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('pending', 'captured', 'parsed', 'indexed', 'failed')",
+                name=op.f("ck_source_snapshots_source_snapshots_status"),
+            ),
+            sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(["resource_id"], ["source_resources.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id", name=op.f("pk_source_snapshots")),
+        )
+        for column_name in ("tenant_id", "resource_id", "content_hash", "status"):
+            op.create_index(f"ix_source_snapshots_{column_name}", "source_snapshots", [column_name])
+
+
+def downgrade() -> None:
+    if "source_snapshots" in _tables():
+        for column_name in ("status", "content_hash", "resource_id", "tenant_id"):
+            _drop_index_if_present(f"ix_source_snapshots_{column_name}", "source_snapshots")
+        op.drop_table("source_snapshots")
+
+    if "source_resources" in _tables():
+        for column_name in (
+            "latest_snapshot_id",
+            "status",
+            "owner_id",
+            "source_connection_id",
+            "connection_id",
+            "tenant_id",
+        ):
+            _drop_index_if_present(f"ix_source_resources_{column_name}", "source_resources")
+        op.drop_table("source_resources")
+
+    if "source_connections" in _tables():
+        for column_name in ("created_by", "token_expires_at", "status", "provider", "tenant_id"):
+            _drop_index_if_present(f"ix_source_connections_{column_name}", "source_connections")
+        op.drop_table("source_connections")

--- a/server/migrations/versions/backfill_legacy_dashboard_assets.py
+++ b/server/migrations/versions/backfill_legacy_dashboard_assets.py
@@ -1,0 +1,235 @@
+"""backfill legacy dashboard assets
+
+Revision ID: backfill_legacy_dashboard_assets
+Revises: add_governed_dashboard_assets
+Create Date: 2026-08-16
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "backfill_legacy_dashboard_assets"
+down_revision = "add_governed_dashboard_assets"
+branch_labels = None
+depends_on = None
+
+
+def _tables() -> set[str]:
+    return set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _columns(table_name: str) -> set[str]:
+    if table_name not in _tables():
+        return set()
+    return {column["name"] for column in sa.inspect(op.get_bind()).get_columns(table_name)}
+
+
+def _digest_payload(payload: object) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _unique_slug(connection: sa.Connection, tenant_id: object, notebook_id: object) -> str:
+    base = f"legacy-{str(notebook_id)[:48]}"
+    slug = base
+    counter = 2
+    while connection.execute(
+        sa.text("SELECT 1 FROM dashboard_assets WHERE tenant_id = :tenant_id AND slug = :slug"),
+        {"tenant_id": tenant_id, "slug": slug},
+    ).first():
+        slug = f"{base}-{counter}"
+        counter += 1
+    return slug[:160]
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)
+
+
+def _mapping_from_json(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(loaded, dict):
+            return loaded
+    return {}
+
+
+def upgrade() -> None:
+    if not {"dashboard_assets", "dashboards", "notebooks"}.issubset(_tables()):
+        return
+    dashboard_columns = _columns("dashboards")
+    required_dashboard_columns = {"id", "tenant_id", "notebook_id", "version_num", "html_content", "asset_id"}
+    if not required_dashboard_columns.issubset(dashboard_columns):
+        return
+
+    connection = op.get_bind()
+    notebook_columns = _columns("notebooks")
+    notebook_name_select = "n.notebook_name" if "notebook_name" in notebook_columns else "NULL"
+    created_by_select = "n.created_by" if "created_by" in notebook_columns else "NULL"
+    group_by_columns = ["d.tenant_id", "d.notebook_id", "n.id"]
+    if "notebook_name" in notebook_columns:
+        group_by_columns.append("n.notebook_name")
+    if "created_by" in notebook_columns:
+        group_by_columns.append("n.created_by")
+    families = connection.execute(
+        sa.text(
+            f"""
+            SELECT d.tenant_id, d.notebook_id, {notebook_name_select} AS notebook_name, {created_by_select} AS created_by
+            FROM dashboards d
+            LEFT JOIN notebooks n ON n.id = d.notebook_id
+            WHERE d.asset_id IS NULL
+            GROUP BY {", ".join(group_by_columns)}
+            ORDER BY d.notebook_id
+            """
+        )
+    ).mappings()
+
+    for family in families:
+        versions = list(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT id, version_num, html_content
+                    FROM dashboards
+                    WHERE tenant_id = :tenant_id AND notebook_id = :notebook_id AND asset_id IS NULL
+                    ORDER BY version_num
+                    """
+                ),
+                {"tenant_id": family["tenant_id"], "notebook_id": family["notebook_id"]},
+            ).mappings()
+        )
+        if not versions:
+            continue
+
+        latest = versions[-1]
+        asset_id = str(uuid4())
+        slug = _unique_slug(connection, family["tenant_id"], family["notebook_id"])
+        name = family["notebook_name"] or f"Legacy Dashboard {str(family['notebook_id'])[:8]}"
+        validation = {
+            "valid": False,
+            "blockers": ["legacy HTML dashboard requires structured manifest review before agent-ready publish"],
+            "warnings": [],
+            "migration_state": "legacy_unstructured",
+            "backfilled_at": datetime.utcnow().isoformat(),
+        }
+        health_summary = {
+            "freshness": "unknown",
+            "migration": {
+                "state": "legacy_unstructured",
+                "backfilled_by": revision,
+                "latest_dashboard_version_id": str(latest["id"]),
+            },
+        }
+        etag = _digest_payload({"legacy_dashboard_id": str(latest["id"]), "notebook_id": str(family["notebook_id"])})
+
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO dashboard_assets (
+                    id, tenant_id, notebook_id, slug, name, description, owner_id, tags_json, lifecycle,
+                    current_draft_version_id, published_version_id, access_policy_json, freshness_policy_json,
+                    consumer_summary_json, health_summary_json, etag
+                )
+                VALUES (
+                    :id, :tenant_id, :notebook_id, :slug, :name, :description, :owner_id, :tags_json,
+                    'legacy_unstructured', NULL, :published_version_id, :access_policy_json,
+                    :freshness_policy_json, :consumer_summary_json, :health_summary_json, :etag
+                )
+                """
+            ),
+            {
+                "id": asset_id,
+                "tenant_id": family["tenant_id"],
+                "notebook_id": family["notebook_id"],
+                "slug": slug,
+                "name": name,
+                "description": "Backfilled from preserved legacy dashboard HTML; structured review required.",
+                "owner_id": family["created_by"],
+                "tags_json": _json(["legacy_unstructured"]),
+                "published_version_id": latest["id"],
+                "access_policy_json": _json({"required_scopes": ["dashboard:read"]}),
+                "freshness_policy_json": _json({"mode": "live", "allow_stale": True, "require_as_of": False}),
+                "consumer_summary_json": _json({}),
+                "health_summary_json": _json(health_summary),
+                "etag": etag,
+            },
+        )
+
+        for dashboard in versions:
+            content_hash = _digest_payload({"html_content": dashboard["html_content"] or ""})
+            connection.execute(
+                sa.text(
+                    """
+                    UPDATE dashboards
+                    SET asset_id = :asset_id,
+                        content_hash = :content_hash,
+                        status = 'legacy_unstructured',
+                        change_summary = :change_summary,
+                        pinned_model_versions_json = :pinned_model_versions_json,
+                        pinned_source_snapshots_json = :pinned_source_snapshots_json,
+                        validation_result_json = :validation_result_json,
+                        migration_state = 'legacy_unstructured',
+                        is_published_immutable = :is_published_immutable
+                    WHERE id = :dashboard_id
+                    """
+                ),
+                {
+                    "asset_id": asset_id,
+                    "content_hash": content_hash,
+                    "change_summary": "Backfilled legacy Dashboard asset; structured manifest review required.",
+                    "pinned_model_versions_json": _json({}),
+                    "pinned_source_snapshots_json": _json([]),
+                    "validation_result_json": _json(validation),
+                    "is_published_immutable": False,
+                    "dashboard_id": dashboard["id"],
+                },
+            )
+
+
+def downgrade() -> None:
+    if not {"dashboard_assets", "dashboards"}.issubset(_tables()):
+        return
+    connection = op.get_bind()
+    asset_ids: list[object] = []
+    candidates = connection.execute(
+        sa.text(
+            """
+            SELECT id, health_summary_json
+            FROM dashboard_assets
+            WHERE lifecycle = 'legacy_unstructured'
+              AND slug LIKE 'legacy-%'
+              AND current_draft_version_id IS NULL
+            """
+        )
+    ).mappings()
+    for candidate in candidates:
+        health_summary = _mapping_from_json(candidate["health_summary_json"])
+        migration_summary = health_summary.get("migration")
+        if not isinstance(migration_summary, dict) or migration_summary.get("backfilled_by") != revision:
+            continue
+        asset_ids.append(candidate["id"])
+
+    for asset_id in asset_ids:
+        connection.execute(
+            sa.text(
+                """
+                UPDATE dashboards
+                SET asset_id = NULL
+                WHERE asset_id = :asset_id
+                """
+            ),
+            {"asset_id": asset_id},
+        )
+        connection.execute(sa.text("DELETE FROM dashboard_assets WHERE id = :asset_id"), {"asset_id": asset_id})

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -4,6 +4,21 @@ from server.models.custom_skill import CustomSkill
 from server.models.dashboard import Dashboard
 from server.models.datasets import Dataset
 from server.models.datasource_annotations import DatasourceAnnotation
+from server.models.evaluation import (
+    AdvisorChangeSet,
+    AdvisorSuggestion,
+    EvaluationArtifact,
+    EvaluationAssessment,
+    EvaluationAuditEvent,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationOverride,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    EvaluationTargetSnapshot,
+    PromotionDecision,
+)
 from server.models.files import File
 from server.models.folder import Folder
 from server.models.folder_dashboard import FolderDashboard
@@ -54,6 +69,18 @@ __all__ = [
     "Dashboard",
     "DatasourceAnnotation",
     "Dataset",
+    "AdvisorChangeSet",
+    "AdvisorSuggestion",
+    "EvaluationArtifact",
+    "EvaluationAssessment",
+    "EvaluationAuditEvent",
+    "EvaluationCase",
+    "EvaluationCaseRun",
+    "EvaluationOverride",
+    "EvaluationRun",
+    "EvaluationSuite",
+    "EvaluationSuiteVersion",
+    "EvaluationTargetSnapshot",
     "File",
     "Folder",
     "GitHubRepository",
@@ -74,6 +101,7 @@ __all__ = [
     "Query",
     "QueryCache",
     "RefreshToken",
+    "PromotionDecision",
     "Schedule",
     "ScheduleRun",
     "Setting",

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -54,6 +54,9 @@ from server.models.skill_version import SkillVersion
 from server.models.slack_conversation import SlackConversation
 from server.models.slack_event_log import SlackEventLog
 from server.models.slack_workspace import SlackWorkspace
+from server.models.source_connections import SourceConnection
+from server.models.source_resources import SourceResource
+from server.models.source_snapshots import SourceSnapshot
 from server.models.tenant import Tenant
 from server.models.tenant_invitation import InvitationRole, InvitationStatus, TenantInvitation
 from server.models.tenant_member import TenantMember, TenantRole
@@ -113,6 +116,9 @@ __all__ = [
     "SharingGrant",
     "SharingSecret",
     "SharingViewerSession",
+    "SourceConnection",
+    "SourceResource",
+    "SourceSnapshot",
     "SkillCitation",
     "SkillCredential",
     "SkillLoopLease",

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -23,6 +23,13 @@ from server.models.query_cache import QueryCache
 from server.models.refresh_token import RefreshToken
 from server.models.schedules import Schedule, ScheduleRun
 from server.models.settings import Setting
+from server.models.sharing import (
+    SharingAuditEvent,
+    SharingCompatibilityLink,
+    SharingGrant,
+    SharingSecret,
+    SharingViewerSession,
+)
 from server.models.skill_citation import SkillCitation
 from server.models.skill_credentials import SkillCredential
 from server.models.skill_loop_lease import SkillLoopLease
@@ -70,6 +77,11 @@ __all__ = [
     "Schedule",
     "ScheduleRun",
     "Setting",
+    "SharingAuditEvent",
+    "SharingCompatibilityLink",
+    "SharingGrant",
+    "SharingSecret",
+    "SharingViewerSession",
     "SkillCitation",
     "SkillCredential",
     "SkillLoopLease",

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -37,6 +37,7 @@ from server.models.queries import Query
 from server.models.query_cache import QueryCache
 from server.models.refresh_token import RefreshToken
 from server.models.schedules import Schedule, ScheduleRun
+from server.models.semantic_models import SemanticModel, SemanticModelAuditEvent, SemanticModelVersion
 from server.models.settings import Setting
 from server.models.sharing import (
     SharingAuditEvent,
@@ -110,6 +111,9 @@ __all__ = [
     "PromotionDecision",
     "Schedule",
     "ScheduleRun",
+    "SemanticModel",
+    "SemanticModelAuditEvent",
+    "SemanticModelVersion",
     "Setting",
     "SharingAuditEvent",
     "SharingCompatibilityLink",

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -1,7 +1,7 @@
 from server.models.connections import Connection
 from server.models.conversation_evaluation import ConversationEvaluation
 from server.models.custom_skill import CustomSkill
-from server.models.dashboard import Dashboard
+from server.models.dashboard import Dashboard, DashboardAsset, DashboardAuditEvent, DashboardRun
 from server.models.datasets import Dataset
 from server.models.datasource_annotations import DatasourceAnnotation
 from server.models.evaluation import (
@@ -67,6 +67,9 @@ __all__ = [
     "ConversationEvaluation",
     "CustomSkill",
     "Dashboard",
+    "DashboardAsset",
+    "DashboardAuditEvent",
+    "DashboardRun",
     "DatasourceAnnotation",
     "Dataset",
     "AdvisorChangeSet",

--- a/server/models/dashboard.py
+++ b/server/models/dashboard.py
@@ -4,13 +4,14 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import TIMESTAMP, ForeignKey, Integer, Text, func
+from sqlalchemy import JSON, TIMESTAMP, Boolean, ForeignKey, Integer, String, Text, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from server.db.base import GUID, Base
 
 if TYPE_CHECKING:
     from server.models.notebooks import Notebook
+    from server.models.user import User
 
 
 def generate_uuid() -> UUID:
@@ -27,6 +28,155 @@ class Dashboard(Base):
     notebook_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("notebooks.id", ondelete="CASCADE"), nullable=False)
     version_num: Mapped[int] = mapped_column(Integer, nullable=False)
     html_content: Mapped[str] = mapped_column(Text, nullable=False)
+    asset_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("dashboard_assets.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    manifest_schema_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    manifest_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    content_hash: Mapped[str | None] = mapped_column(String(128), nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="legacy_unstructured", index=True)
+    created_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    actor_type: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    change_summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    pinned_model_versions_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    pinned_source_snapshots_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    validation_result_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    renderer_version: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    migration_state: Mapped[str] = mapped_column(String(40), nullable=False, default="legacy_unstructured", index=True)
+    is_published_immutable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
 
     notebook: Mapped[Notebook] = relationship("Notebook", back_populates="dashboards")
+    asset: Mapped[DashboardAsset | None] = relationship(
+        "DashboardAsset",
+        back_populates="versions",
+        foreign_keys=[asset_id],
+    )
+    creator: Mapped[User | None] = relationship("User", foreign_keys=[created_by])
+
+
+class DashboardAsset(Base):
+    __tablename__ = "dashboard_assets"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    notebook_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("notebooks.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    slug: Mapped[str] = mapped_column(String(160), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    owner_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    tags_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    lifecycle: Mapped[str] = mapped_column(String(40), nullable=False, default="legacy_unstructured", index=True)
+    current_draft_version_id: Mapped[UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey(
+            "dashboards.id",
+            name="fk_dashboard_assets_current_draft_version_id_dashboards",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        nullable=True,
+    )
+    published_version_id: Mapped[UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey(
+            "dashboards.id",
+            name="fk_dashboard_assets_published_version_id_dashboards",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        nullable=True,
+    )
+    access_policy_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    freshness_policy_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    consumer_summary_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    health_summary_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    etag: Mapped[str] = mapped_column(String(128), nullable=False, default="")
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=False), server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+    )
+
+    notebook: Mapped[Notebook | None] = relationship("Notebook", foreign_keys=[notebook_id])
+    owner: Mapped[User | None] = relationship("User", foreign_keys=[owner_id])
+    versions: Mapped[list[Dashboard]] = relationship(
+        "Dashboard",
+        back_populates="asset",
+        foreign_keys="Dashboard.asset_id",
+    )
+    current_draft_version: Mapped[Dashboard | None] = relationship("Dashboard", foreign_keys=[current_draft_version_id])
+    published_version: Mapped[Dashboard | None] = relationship("Dashboard", foreign_keys=[published_version_id])
+
+    __table_args__ = (UniqueConstraint("tenant_id", "slug", name="uq_dashboard_assets_tenant_slug"),)
+
+
+class DashboardRun(Base):
+    __tablename__ = "dashboard_runs"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    asset_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("dashboard_assets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    version_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("dashboards.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    actor_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    actor_id: Mapped[str] = mapped_column(String(160), nullable=False, index=True)
+    correlation_id: Mapped[str | None] = mapped_column(String(160), nullable=True, index=True)
+    session_id: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    idempotency_key: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    mode: Mapped[str] = mapped_column(String(40), nullable=False, default="live", index=True)
+    normalized_filters_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    filter_digest: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    pinned_versions_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    execution_plan_digest: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    overall_freshness: Mapped[str] = mapped_column(String(40), nullable=False, default="unknown")
+    result_manifest_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    warnings_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    errors_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    asset: Mapped[DashboardAsset] = relationship("DashboardAsset", foreign_keys=[asset_id])
+    version: Mapped[Dashboard] = relationship("Dashboard", foreign_keys=[version_id])
+
+    __table_args__ = (UniqueConstraint("asset_id", "idempotency_key", name="uq_dashboard_runs_asset_idempotency"),)
+
+
+class DashboardAuditEvent(Base):
+    __tablename__ = "dashboard_audit_events"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    asset_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("dashboard_assets.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    version_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("dashboards.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    run_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("dashboard_runs.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    actor_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    actor_id: Mapped[str] = mapped_column(String(160), nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String(120), nullable=False, index=True)
+    correlation_id: Mapped[str | None] = mapped_column(String(160), nullable=True, index=True)
+    before_digest: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    after_digest: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    outcome: Mapped[str] = mapped_column(String(40), nullable=False)
+    details_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    asset: Mapped[DashboardAsset | None] = relationship("DashboardAsset", foreign_keys=[asset_id])
+    version: Mapped[Dashboard | None] = relationship("Dashboard", foreign_keys=[version_id])
+    run: Mapped[DashboardRun | None] = relationship("DashboardRun", foreign_keys=[run_id])

--- a/server/models/evaluation.py
+++ b/server/models/evaluation.py
@@ -90,9 +90,7 @@ class EvaluationSuiteVersion(Base):
     published_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
 
-    suite: Mapped[EvaluationSuite] = relationship(
-        "EvaluationSuite", back_populates="versions", foreign_keys=[suite_id]
-    )
+    suite: Mapped[EvaluationSuite] = relationship("EvaluationSuite", back_populates="versions", foreign_keys=[suite_id])
     creator: Mapped[User | None] = relationship("User", foreign_keys=[created_by])
     cases: Mapped[list[EvaluationCase]] = relationship(back_populates="suite_version", cascade="all, delete-orphan")
 
@@ -172,19 +170,31 @@ class EvaluationRun(Base):
     completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
 
-    suite_version: Mapped[EvaluationSuiteVersion] = relationship("EvaluationSuiteVersion", foreign_keys=[suite_version_id])
-    target_snapshot: Mapped[EvaluationTargetSnapshot] = relationship("EvaluationTargetSnapshot", foreign_keys=[target_snapshot_id])
+    suite_version: Mapped[EvaluationSuiteVersion] = relationship(
+        "EvaluationSuiteVersion", foreign_keys=[suite_version_id]
+    )
+    target_snapshot: Mapped[EvaluationTargetSnapshot] = relationship(
+        "EvaluationTargetSnapshot", foreign_keys=[target_snapshot_id]
+    )
 
-    __table_args__ = (UniqueConstraint("suite_version_id", "idempotency_key", name="uq_evaluation_runs_suite_idempotency"),)
+    __table_args__ = (
+        UniqueConstraint("suite_version_id", "idempotency_key", name="uq_evaluation_runs_suite_idempotency"),
+    )
 
 
 class EvaluationCaseRun(Base):
     __tablename__ = "evaluation_case_runs"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    run_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_runs.id", ondelete="CASCADE"), nullable=False, index=True)
-    case_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_cases.id", ondelete="CASCADE"), nullable=False, index=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    run_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_runs.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    case_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_cases.id", ondelete="CASCADE"), nullable=False, index=True
+    )
     status: Mapped[str] = mapped_column(String(40), nullable=False, default="queued", index=True)
     attempt: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     input_digest: Mapped[str] = mapped_column(String(128), nullable=False, default="")
@@ -201,8 +211,12 @@ class EvaluationAssessment(Base):
     __tablename__ = "evaluation_assessments"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    case_run_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_case_runs.id", ondelete="CASCADE"), nullable=False, index=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    case_run_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_case_runs.id", ondelete="CASCADE"), nullable=False, index=True
+    )
     category: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
     status: Mapped[str] = mapped_column(String(40), nullable=False)
     score: Mapped[str | None] = mapped_column(String(80), nullable=True)
@@ -216,8 +230,12 @@ class EvaluationOverride(Base):
     __tablename__ = "evaluation_overrides"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    assessment_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_assessments.id", ondelete="CASCADE"), nullable=False, index=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    assessment_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_assessments.id", ondelete="CASCADE"), nullable=False, index=True
+    )
     override_type: Mapped[str] = mapped_column(String(40), nullable=False)
     reason: Mapped[str] = mapped_column(Text, nullable=False)
     created_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
@@ -228,9 +246,15 @@ class EvaluationArtifact(Base):
     __tablename__ = "evaluation_artifacts"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id", ondelete="CASCADE"), nullable=True, index=True)
-    case_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_case_runs.id", ondelete="CASCADE"), nullable=True, index=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    run_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("evaluation_runs.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    case_run_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("evaluation_case_runs.id", ondelete="CASCADE"), nullable=True, index=True
+    )
     artifact_type: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
     uri: Mapped[str] = mapped_column(Text, nullable=False)
     content_hash: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
@@ -243,8 +267,12 @@ class AdvisorChangeSet(Base):
     __tablename__ = "advisor_change_sets"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    suite_version_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="SET NULL"), nullable=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    suite_version_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="SET NULL"), nullable=True
+    )
     target_ref: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     base_version_ref: Mapped[str] = mapped_column(String(255), nullable=False)
     base_etag: Mapped[str] = mapped_column(String(128), nullable=False)
@@ -260,8 +288,12 @@ class AdvisorSuggestion(Base):
     __tablename__ = "advisor_suggestions"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    change_set_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("advisor_change_sets.id", ondelete="CASCADE"), nullable=False, index=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    change_set_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("advisor_change_sets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
     suggestion_type: Mapped[str] = mapped_column(String(80), nullable=False)
     patch_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
     affected_case_ids_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
@@ -273,8 +305,12 @@ class PromotionDecision(Base):
     __tablename__ = "promotion_decisions"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    change_set_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("advisor_change_sets.id", ondelete="SET NULL"), nullable=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    change_set_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("advisor_change_sets.id", ondelete="SET NULL"), nullable=True
+    )
     verification_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id"), nullable=True)
     regression_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id"), nullable=True)
     decision: Mapped[str] = mapped_column(String(40), nullable=False)
@@ -288,10 +324,18 @@ class EvaluationAuditEvent(Base):
     __tablename__ = "evaluation_audit_events"
 
     id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
-    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
-    suite_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_suites.id", ondelete="SET NULL"), nullable=True, index=True)
-    suite_version_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="SET NULL"), nullable=True, index=True)
-    run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id", ondelete="SET NULL"), nullable=True, index=True)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    suite_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("evaluation_suites.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    suite_version_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    run_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("evaluation_runs.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     actor_type: Mapped[str] = mapped_column(String(40), nullable=False)
     actor_id: Mapped[str] = mapped_column(String(160), nullable=False, index=True)
     action: Mapped[str] = mapped_column(String(120), nullable=False, index=True)

--- a/server/models/evaluation.py
+++ b/server/models/evaluation.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, TIMESTAMP, Boolean, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from server.db.base import GUID, Base
+
+if TYPE_CHECKING:
+    from server.models.tenant import Tenant
+    from server.models.user import User
+
+
+class EvaluationSuite(Base):
+    __tablename__ = "evaluation_suites"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    slug: Mapped[str] = mapped_column(String(160), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    owner_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    target_kinds_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    lifecycle: Mapped[str] = mapped_column(String(40), nullable=False, default="draft", index=True)
+    current_draft_version_id: Mapped[UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey(
+            "evaluation_suite_versions.id",
+            name="fk_evaluation_suites_current_draft_version_id_versions",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        nullable=True,
+    )
+    published_version_id: Mapped[UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey(
+            "evaluation_suite_versions.id",
+            name="fk_evaluation_suites_published_version_id_versions",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=False), server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+    )
+
+    tenant: Mapped[Tenant] = relationship("Tenant", foreign_keys=[tenant_id])
+    owner: Mapped[User | None] = relationship("User", foreign_keys=[owner_id])
+    versions: Mapped[list[EvaluationSuiteVersion]] = relationship(
+        "EvaluationSuiteVersion",
+        back_populates="suite",
+        foreign_keys="EvaluationSuiteVersion.suite_id",
+    )
+    current_draft_version: Mapped[EvaluationSuiteVersion | None] = relationship(
+        "EvaluationSuiteVersion", foreign_keys=[current_draft_version_id]
+    )
+    published_version: Mapped[EvaluationSuiteVersion | None] = relationship(
+        "EvaluationSuiteVersion", foreign_keys=[published_version_id]
+    )
+
+    __table_args__ = (UniqueConstraint("tenant_id", "slug", name="uq_evaluation_suites_tenant_slug"),)
+
+
+class EvaluationSuiteVersion(Base):
+    __tablename__ = "evaluation_suite_versions"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    suite_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_suites.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    version_num: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="draft", index=True)
+    contract_version: Mapped[str] = mapped_column(String(80), nullable=False)
+    manifest_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    gate_policy_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    case_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    content_hash: Mapped[str] = mapped_column(String(128), nullable=False, default="", index=True)
+    created_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    suite: Mapped[EvaluationSuite] = relationship(
+        "EvaluationSuite", back_populates="versions", foreign_keys=[suite_id]
+    )
+    creator: Mapped[User | None] = relationship("User", foreign_keys=[created_by])
+    cases: Mapped[list[EvaluationCase]] = relationship(back_populates="suite_version", cascade="all, delete-orphan")
+
+    __table_args__ = (UniqueConstraint("suite_id", "version_num", name="uq_evaluation_suite_versions_suite_version"),)
+
+
+class EvaluationCase(Base):
+    __tablename__ = "evaluation_cases"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    suite_version_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    case_key: Mapped[str] = mapped_column(String(160), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    target_kinds_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    operation: Mapped[str] = mapped_column(String(80), nullable=False)
+    question: Mapped[str] = mapped_column(Text, nullable=False)
+    expected_contract_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    provenance_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    tags_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    content_hash: Mapped[str] = mapped_column(String(128), nullable=False, default="", index=True)
+    immutable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    suite_version: Mapped[EvaluationSuiteVersion] = relationship(back_populates="cases")
+
+    __table_args__ = (UniqueConstraint("suite_version_id", "case_key", name="uq_evaluation_cases_version_key"),)
+
+
+class EvaluationTargetSnapshot(Base):
+    __tablename__ = "evaluation_target_snapshots"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    target_kind: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    target_ref: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    contract_version: Mapped[str] = mapped_column(String(80), nullable=False)
+    snapshot_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    pin_digest: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    blockers_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class EvaluationRun(Base):
+    __tablename__ = "evaluation_runs"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    suite_version_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    target_snapshot_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("evaluation_target_snapshots.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="queued", index=True)
+    actor_type: Mapped[str] = mapped_column(String(40), nullable=False, default="human")
+    actor_id: Mapped[str] = mapped_column(String(160), nullable=False, index=True)
+    baseline_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id"), nullable=True)
+    candidate_label: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    idempotency_key: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    attempt: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    lease_holder: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    heartbeat_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    stop_requested: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    preflight_blockers_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    summary_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    started_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    suite_version: Mapped[EvaluationSuiteVersion] = relationship("EvaluationSuiteVersion", foreign_keys=[suite_version_id])
+    target_snapshot: Mapped[EvaluationTargetSnapshot] = relationship("EvaluationTargetSnapshot", foreign_keys=[target_snapshot_id])
+
+    __table_args__ = (UniqueConstraint("suite_version_id", "idempotency_key", name="uq_evaluation_runs_suite_idempotency"),)
+
+
+class EvaluationCaseRun(Base):
+    __tablename__ = "evaluation_case_runs"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    run_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_runs.id", ondelete="CASCADE"), nullable=False, index=True)
+    case_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_cases.id", ondelete="CASCADE"), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="queued", index=True)
+    attempt: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    input_digest: Mapped[str] = mapped_column(String(128), nullable=False, default="")
+    output_digest: Mapped[str] = mapped_column(String(128), nullable=False, default="")
+    result_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    error_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    immutable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    started_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class EvaluationAssessment(Base):
+    __tablename__ = "evaluation_assessments"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    case_run_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_case_runs.id", ondelete="CASCADE"), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(40), nullable=False)
+    score: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    hard_fail: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    details_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    immutable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class EvaluationOverride(Base):
+    __tablename__ = "evaluation_overrides"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    assessment_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("evaluation_assessments.id", ondelete="CASCADE"), nullable=False, index=True)
+    override_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    created_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class EvaluationArtifact(Base):
+    __tablename__ = "evaluation_artifacts"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id", ondelete="CASCADE"), nullable=True, index=True)
+    case_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_case_runs.id", ondelete="CASCADE"), nullable=True, index=True)
+    artifact_type: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    uri: Mapped[str] = mapped_column(Text, nullable=False)
+    content_hash: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    metadata_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    immutable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class AdvisorChangeSet(Base):
+    __tablename__ = "advisor_change_sets"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    suite_version_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="SET NULL"), nullable=True)
+    target_ref: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    base_version_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+    base_etag: Mapped[str] = mapped_column(String(128), nullable=False)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="draft", index=True)
+    evidence_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    verification_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id"), nullable=True)
+    regression_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id"), nullable=True)
+    created_by: Mapped[str] = mapped_column(String(160), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class AdvisorSuggestion(Base):
+    __tablename__ = "advisor_suggestions"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    change_set_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("advisor_change_sets.id", ondelete="CASCADE"), nullable=False, index=True)
+    suggestion_type: Mapped[str] = mapped_column(String(80), nullable=False)
+    patch_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    affected_case_ids_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="draft", index=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class PromotionDecision(Base):
+    __tablename__ = "promotion_decisions"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    change_set_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("advisor_change_sets.id", ondelete="SET NULL"), nullable=True)
+    verification_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id"), nullable=True)
+    regression_run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id"), nullable=True)
+    decision: Mapped[str] = mapped_column(String(40), nullable=False)
+    decided_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    rationale: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    audit_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class EvaluationAuditEvent(Base):
+    __tablename__ = "evaluation_audit_events"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+    suite_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_suites.id", ondelete="SET NULL"), nullable=True, index=True)
+    suite_version_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_suite_versions.id", ondelete="SET NULL"), nullable=True, index=True)
+    run_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("evaluation_runs.id", ondelete="SET NULL"), nullable=True, index=True)
+    actor_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    actor_id: Mapped[str] = mapped_column(String(160), nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String(120), nullable=False, index=True)
+    outcome: Mapped[str] = mapped_column(String(40), nullable=False)
+    details_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())

--- a/server/models/semantic_models.py
+++ b/server/models/semantic_models.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, TIMESTAMP, CheckConstraint, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from server.db.base import GUID, Base
+
+if TYPE_CHECKING:
+    from server.models.user import User
+
+
+def generate_uuid() -> UUID:
+    return uuid4()
+
+
+SEMANTIC_MODEL_STATUSES = ("beta", "draft", "needs_review", "validation_failed", "archived")
+SEMANTIC_READINESS_LEVELS = ("blocked", "partial")
+
+
+class SemanticModel(Base):
+    __tablename__ = "semantic_models"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_by: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    slug: Mapped[str] = mapped_column(String(160), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    domain: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    owner: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    datasource_id: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
+    datasource_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    datasource_kind: Mapped[str] = mapped_column(String(64), nullable=False, default="source")
+    contract_version: Mapped[str] = mapped_column(String(80), nullable=False, default="semantic.model.v1beta")
+    manifest_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    source_resource_ids_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    source_snapshot_ids_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="beta", index=True)
+    readiness: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    readiness_level: Mapped[str] = mapped_column(String(32), nullable=False, default="partial")
+    revision: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    draft_revision: Mapped[str] = mapped_column(String(64), nullable=False, default="draft-1")
+    published_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    validation_result_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    consumer_summary_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=False), server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+    )
+
+    creator: Mapped[User | None] = relationship("User", foreign_keys=[created_by])
+    versions: Mapped[list[SemanticModelVersion]] = relationship(
+        "SemanticModelVersion", back_populates="model", cascade="all, delete-orphan", passive_deletes=True
+    )
+    audit_events: Mapped[list[SemanticModelAuditEvent]] = relationship(
+        "SemanticModelAuditEvent", back_populates="model", cascade="all, delete-orphan", passive_deletes=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "slug", name="uq_semantic_models_tenant_slug"),
+        CheckConstraint(f"status IN {SEMANTIC_MODEL_STATUSES}", name="semantic_models_status"),
+        CheckConstraint(f"readiness_level IN {SEMANTIC_READINESS_LEVELS}", name="semantic_models_readiness_level"),
+    )
+
+
+class SemanticModelVersion(Base):
+    __tablename__ = "semantic_model_versions"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    model_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("semantic_models.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    version_label: Mapped[str] = mapped_column(String(64), nullable=False)
+    revision: Mapped[int] = mapped_column(Integer, nullable=False)
+    snapshot_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    source_snapshot_ids_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    validation_result_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    content_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    created_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    model: Mapped[SemanticModel] = relationship("SemanticModel", back_populates="versions")
+    creator: Mapped[User | None] = relationship("User")
+
+    __table_args__ = (UniqueConstraint("model_id", "version_label", name="uq_semantic_model_versions_model_label"),)
+
+
+class SemanticModelAuditEvent(Base):
+    __tablename__ = "semantic_model_audit_events"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    model_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("semantic_models.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    actor_id: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    action: Mapped[str] = mapped_column(String(120), nullable=False)
+    details_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    model: Mapped[SemanticModel] = relationship("SemanticModel", back_populates="audit_events")
+    actor: Mapped[User | None] = relationship("User")

--- a/server/models/sharing.py
+++ b/server/models/sharing.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, TIMESTAMP, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from server.db.base import GUID, Base
+
+
+def generate_uuid() -> UUID:
+    return uuid4()
+
+
+class SharingGrant(Base):
+    __tablename__ = "sharing_grants"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    object_type: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    object_id: Mapped[UUID] = mapped_column(GUID(), nullable=False, index=True)
+    object_version_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True, index=True)
+    object_version_digest: Mapped[str] = mapped_column(String(128), nullable=False, default="")
+    mode: Mapped[str] = mapped_column(String(60), nullable=False, default="immutable_version", index=True)
+    channel: Mapped[str] = mapped_column(String(60), nullable=False, default="public_link", index=True)
+    audience: Mapped[str] = mapped_column(String(60), nullable=False, default="link_holder", index=True)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="active", index=True)
+    created_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    revoked_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    revocation_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=False), server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+    )
+
+    secrets: Mapped[list[SharingSecret]] = relationship(
+        "SharingSecret", back_populates="grant", cascade="all, delete-orphan"
+    )
+    viewer_sessions: Mapped[list[SharingViewerSession]] = relationship(
+        "SharingViewerSession", back_populates="grant", cascade="all, delete-orphan"
+    )
+
+
+class SharingSecret(Base):
+    __tablename__ = "sharing_secrets"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    grant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("sharing_grants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    secret_type: Mapped[str] = mapped_column(String(40), nullable=False, default="password", index=True)
+    algorithm: Mapped[str] = mapped_column(String(60), nullable=False)
+    salt: Mapped[str] = mapped_column(String(128), nullable=False)
+    verifier_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="active", index=True)
+    created_by: Mapped[UUID | None] = mapped_column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    rotated_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    grant: Mapped[SharingGrant] = relationship("SharingGrant", back_populates="secrets")
+
+    __table_args__ = (
+        UniqueConstraint("grant_id", "secret_type", "status", name="uq_sharing_secrets_grant_type_status"),
+    )
+
+
+class SharingViewerSession(Base):
+    __tablename__ = "sharing_viewer_sessions"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    grant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("sharing_grants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    object_type: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    object_id: Mapped[UUID] = mapped_column(GUID(), nullable=False, index=True)
+    object_version_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True, index=True)
+    token_id: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    token_digest: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    viewer_user_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    viewer_principal_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    issued_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    grant: Mapped[SharingGrant] = relationship("SharingGrant", back_populates="viewer_sessions")
+
+
+class SharingAuditEvent(Base):
+    __tablename__ = "sharing_audit_events"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    grant_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("sharing_grants.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    viewer_session_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("sharing_viewer_sessions.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    object_type: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    object_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True, index=True)
+    object_version_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True, index=True)
+    actor_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    actor_id: Mapped[str] = mapped_column(String(160), nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String(120), nullable=False, index=True)
+    outcome: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    details_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+
+class SharingCompatibilityLink(Base):
+    __tablename__ = "sharing_compatibility_links"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    grant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("sharing_grants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    legacy_surface: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    legacy_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+
+    __table_args__ = (UniqueConstraint("legacy_surface", "legacy_id", name="uq_sharing_compatibility_links_legacy"),)

--- a/server/models/source_connections.py
+++ b/server/models/source_connections.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, TIMESTAMP, CheckConstraint, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from server.db.base import GUID, Base
+
+if TYPE_CHECKING:
+    from server.models.source_resources import SourceResource
+    from server.models.user import User
+
+
+def generate_uuid() -> UUID:
+    return uuid4()
+
+
+SOURCE_CONNECTION_PROVIDERS = (
+    "local_files",
+    "web",
+    "feishu",
+    "sql_databases",
+    "volcengine_tos",
+    "databricks",
+)
+SOURCE_CONNECTION_AUTH_MODES = (
+    "oauth",
+    "access_key",
+    "connection_string",
+    "none",
+)
+SOURCE_CONNECTION_STATUSES = (
+    "beta",
+    "pending",
+    "connected",
+    "authorization_required",
+    "reauthorization_required",
+    "failed",
+    "disconnected",
+)
+
+
+class SourceConnection(Base):
+    __tablename__ = "source_connections"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    provider: Mapped[str] = mapped_column(String(60), nullable=False, index=True)
+    auth_mode: Mapped[str] = mapped_column(String(30), nullable=False)
+    encrypted_credentials: Mapped[str] = mapped_column(Text, nullable=False)
+    external_account_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    status: Mapped[str] = mapped_column(String(40), nullable=False, default="beta", index=True)
+    capabilities_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    token_expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=False), nullable=True, index=True)
+    created_by: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=False), server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+    )
+
+    creator: Mapped[User | None] = relationship("User", foreign_keys=[created_by])
+    resources: Mapped[list[SourceResource]] = relationship(
+        "SourceResource", back_populates="source_connection", passive_deletes=True
+    )
+
+    __table_args__ = (
+        CheckConstraint(f"provider IN {SOURCE_CONNECTION_PROVIDERS}", name="source_connections_provider"),
+        CheckConstraint(f"auth_mode IN {SOURCE_CONNECTION_AUTH_MODES}", name="source_connections_auth_mode"),
+        CheckConstraint(f"status IN {SOURCE_CONNECTION_STATUSES}", name="source_connections_status"),
+        UniqueConstraint(
+            "tenant_id",
+            "provider",
+            "created_by",
+            "external_account_id",
+            name="uq_source_connections_account",
+        ),
+    )

--- a/server/models/source_resources.py
+++ b/server/models/source_resources.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, TIMESTAMP, CheckConstraint, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from server.db.base import GUID, Base
+
+if TYPE_CHECKING:
+    from server.models.connections import Connection
+    from server.models.source_connections import SourceConnection
+    from server.models.source_snapshots import SourceSnapshot
+    from server.models.user import User
+
+
+def generate_uuid() -> UUID:
+    return uuid4()
+
+
+SOURCE_RESOURCE_TYPES = (
+    "file",
+    "pdf",
+    "web",
+    "feishu_doc",
+    "feishu_wiki",
+    "feishu_sheet",
+    "feishu_base",
+    "tos_bucket",
+    "tos_prefix",
+    "tos_object",
+    "database_catalog",
+    "database_schema",
+    "database_table",
+    "databricks_catalog",
+    "databricks_schema",
+    "databricks_table",
+)
+SOURCE_SYNC_MODES = ("manual", "scheduled")
+SOURCE_RESOURCE_STATUSES = (
+    "pending",
+    "beta",
+    "syncing",
+    "understanding",
+    "authorization_required",
+    "reauthorization_required",
+    "blocked",
+    "source_unavailable",
+    "permission_lost",
+    "needs_confirmation",
+    "ready",
+    "failed",
+)
+
+
+class SourceResource(Base):
+    __tablename__ = "source_resources"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    connection_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("connections.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    source_connection_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("source_connections.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    resource_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    parent_external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    selection_config_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    owner_id: Mapped[UUID | None] = mapped_column(
+        GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    visibility: Mapped[str] = mapped_column(String(30), nullable=False, default="workspace")
+    sync_mode: Mapped[str] = mapped_column(String(20), nullable=False, default="manual")
+    sync_config_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="beta", index=True)
+    latest_snapshot_id: Mapped[UUID | None] = mapped_column(GUID(), nullable=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=False), server_default=func.current_timestamp(), onupdate=func.current_timestamp()
+    )
+
+    connection: Mapped[Connection | None] = relationship("Connection", foreign_keys=[connection_id])
+    source_connection: Mapped[SourceConnection | None] = relationship(
+        "SourceConnection", foreign_keys=[source_connection_id], back_populates="resources"
+    )
+    owner: Mapped[User | None] = relationship("User", foreign_keys=[owner_id])
+    snapshots: Mapped[list[SourceSnapshot]] = relationship(
+        "SourceSnapshot", back_populates="resource", cascade="all, delete-orphan", passive_deletes=True
+    )
+
+    __table_args__ = (
+        CheckConstraint(f"resource_type IN {SOURCE_RESOURCE_TYPES}", name="source_resources_resource_type"),
+        CheckConstraint(f"sync_mode IN {SOURCE_SYNC_MODES}", name="source_resources_sync_mode"),
+        CheckConstraint(f"status IN {SOURCE_RESOURCE_STATUSES}", name="source_resources_status"),
+    )

--- a/server/models/source_snapshots.py
+++ b/server/models/source_snapshots.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, TIMESTAMP, CheckConstraint, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from server.db.base import GUID, Base
+
+if TYPE_CHECKING:
+    from server.models.source_resources import SourceResource
+
+
+def generate_uuid() -> UUID:
+    return uuid4()
+
+
+SOURCE_SNAPSHOT_STATUSES = ("pending", "captured", "parsed", "indexed", "failed")
+
+
+class SourceSnapshot(Base):
+    __tablename__ = "source_snapshots"
+
+    id: Mapped[UUID] = mapped_column(GUID(), primary_key=True, default=generate_uuid)
+    tenant_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    resource_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("source_resources.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    external_revision: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content_hash: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    raw_storage_uri: Mapped[str] = mapped_column(Text, nullable=False)
+    captured_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=False), server_default=func.current_timestamp())
+    parser_version: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="captured", index=True)
+    error_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+    resource: Mapped[SourceResource] = relationship("SourceResource", back_populates="snapshots")
+
+    __table_args__ = (CheckConstraint(f"status IN {SOURCE_SNAPSHOT_STATUSES}", name="source_snapshots_status"),)

--- a/server/repositories/dashboard.py
+++ b/server/repositories/dashboard.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from sqlalchemy import desc, func, select, update
 
-from server.models.dashboard import Dashboard
+from server.models.dashboard import Dashboard, DashboardAsset, DashboardAuditEvent
 from server.repositories.base import AsyncCRUDRepository
 
 
@@ -68,3 +68,92 @@ class DashboardRepository(AsyncCRUDRepository[Dashboard]):
         result = await self._session.execute(query)
         await self._session.commit()
         return result.scalar_one()
+
+    async def get_asset(self, asset_id: str | UUID, tenant_id: str | UUID) -> DashboardAsset | None:
+        result = await self._session.execute(
+            select(DashboardAsset).where(DashboardAsset.id == asset_id, DashboardAsset.tenant_id == tenant_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_asset_by_slug(self, tenant_id: str | UUID, slug: str) -> DashboardAsset | None:
+        result = await self._session.execute(
+            select(DashboardAsset).where(DashboardAsset.tenant_id == tenant_id, DashboardAsset.slug == slug)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_assets(self, tenant_id: str | UUID, limit: int = 100) -> list[DashboardAsset]:
+        result = await self._session.execute(
+            select(DashboardAsset)
+            .where(DashboardAsset.tenant_id == tenant_id)
+            .order_by(desc(DashboardAsset.updated_at))
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def get_asset_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        asset_id: str | UUID,
+        version_id: str | UUID,
+    ) -> Dashboard | None:
+        result = await self._session.execute(
+            select(Dashboard).where(
+                Dashboard.tenant_id == tenant_id,
+                Dashboard.asset_id == asset_id,
+                Dashboard.id == version_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_asset_version_by_num(
+        self,
+        *,
+        tenant_id: str | UUID,
+        asset_id: str | UUID,
+        version_num: int,
+    ) -> Dashboard | None:
+        result = await self._session.execute(
+            select(Dashboard).where(
+                Dashboard.tenant_id == tenant_id,
+                Dashboard.asset_id == asset_id,
+                Dashboard.version_num == version_num,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_asset_versions(
+        self,
+        *,
+        tenant_id: str | UUID,
+        asset_id: str | UUID,
+        limit: int = 100,
+    ) -> list[Dashboard]:
+        result = await self._session.execute(
+            select(Dashboard)
+            .where(Dashboard.tenant_id == tenant_id, Dashboard.asset_id == asset_id)
+            .order_by(desc(Dashboard.version_num))
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def list_asset_audit_events(
+        self,
+        *,
+        tenant_id: str | UUID,
+        asset_id: str | UUID,
+        limit: int = 100,
+    ) -> list[DashboardAuditEvent]:
+        result = await self._session.execute(
+            select(DashboardAuditEvent)
+            .where(DashboardAuditEvent.tenant_id == tenant_id, DashboardAuditEvent.asset_id == asset_id)
+            .order_by(desc(DashboardAuditEvent.created_at))
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def get_asset_next_version_num(self, asset_id: str | UUID) -> int:
+        query = select(func.max(Dashboard.version_num)).where(Dashboard.asset_id == asset_id)
+        result = await self._session.execute(query)
+        max_version = result.scalar_one_or_none()
+        return (max_version or 0) + 1

--- a/server/repositories/evaluation.py
+++ b/server/repositories/evaluation.py
@@ -1,0 +1,681 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.evaluation import (
+    AdvisorChangeSet,
+    AdvisorSuggestion,
+    EvaluationArtifact,
+    EvaluationAssessment,
+    EvaluationAuditEvent,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    EvaluationTargetSnapshot,
+    PromotionDecision,
+)
+
+
+def _has_no_preflight_blockers():
+    return func.json_array_length(EvaluationRun.preflight_blockers_json) == 0
+
+
+class EvaluationRepository:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def get_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+    ) -> EvaluationSuiteVersion | None:
+        result = await self._session.execute(
+            select(EvaluationSuiteVersion).where(
+                EvaluationSuiteVersion.tenant_id == tenant_id,
+                EvaluationSuiteVersion.id == suite_version_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_suite(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_id: str | UUID,
+    ) -> EvaluationSuite | None:
+        result = await self._session.execute(
+            select(EvaluationSuite).where(
+                EvaluationSuite.tenant_id == tenant_id,
+                EvaluationSuite.id == suite_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_suite_by_slug(
+        self,
+        *,
+        tenant_id: str | UUID,
+        slug: str,
+    ) -> EvaluationSuite | None:
+        result = await self._session.execute(
+            select(EvaluationSuite).where(
+                EvaluationSuite.tenant_id == tenant_id,
+                EvaluationSuite.slug == slug,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_suites(
+        self,
+        *,
+        tenant_id: str | UUID,
+        query: str = "",
+        target_kind: str = "",
+        status: str = "",
+        limit: int = 50,
+    ) -> list[EvaluationSuite]:
+        statement = select(EvaluationSuite).where(EvaluationSuite.tenant_id == tenant_id)
+        if status:
+            statement = statement.where(EvaluationSuite.lifecycle == status)
+        result = await self._session.execute(
+            statement.order_by(EvaluationSuite.updated_at.desc(), EvaluationSuite.id).limit(max(1, limit))
+        )
+        suites = list(result.scalars().all())
+        query_lower = query.lower().strip()
+        if query_lower:
+            suites = [
+                suite
+                for suite in suites
+                if query_lower in suite.name.lower()
+                or query_lower in suite.slug.lower()
+                or query_lower in (suite.description or "").lower()
+            ]
+        if target_kind:
+            suites = [suite for suite in suites if target_kind in (suite.target_kinds_json or [])]
+        return suites
+
+    async def list_suite_versions(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_id: str | UUID,
+    ) -> list[EvaluationSuiteVersion]:
+        result = await self._session.execute(
+            select(EvaluationSuiteVersion)
+            .where(
+                EvaluationSuiteVersion.tenant_id == tenant_id,
+                EvaluationSuiteVersion.suite_id == suite_id,
+            )
+            .order_by(EvaluationSuiteVersion.version_num.desc())
+        )
+        return list(result.scalars().all())
+
+    async def create_suite(
+        self,
+        *,
+        tenant_id: str | UUID,
+        slug: str,
+        name: str,
+        description: str,
+        owner_id: str | UUID | None,
+        target_kinds_json: list[str],
+        lifecycle: str,
+    ) -> EvaluationSuite:
+        suite = EvaluationSuite(
+            tenant_id=tenant_id,
+            slug=slug,
+            name=name,
+            description=description,
+            owner_id=owner_id,
+            target_kinds_json=target_kinds_json,
+            lifecycle=lifecycle,
+        )
+        self._session.add(suite)
+        await self._session.flush()
+        return suite
+
+    async def create_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_id: str | UUID,
+        version_num: int,
+        status: str,
+        contract_version: str,
+        manifest_json: dict,
+        gate_policy_json: dict,
+        case_count: int,
+        content_hash: str,
+        created_by: str | UUID | None,
+    ) -> EvaluationSuiteVersion:
+        version = EvaluationSuiteVersion(
+            tenant_id=tenant_id,
+            suite_id=suite_id,
+            version_num=version_num,
+            status=status,
+            contract_version=contract_version,
+            manifest_json=manifest_json,
+            gate_policy_json=gate_policy_json,
+            case_count=case_count,
+            content_hash=content_hash,
+            created_by=created_by,
+        )
+        self._session.add(version)
+        await self._session.flush()
+        return version
+
+    async def get_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+    ) -> EvaluationRun | None:
+        result = await self._session.execute(
+            select(EvaluationRun).where(
+                EvaluationRun.tenant_id == tenant_id,
+                EvaluationRun.id == run_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_change_set(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID,
+    ) -> AdvisorChangeSet | None:
+        result = await self._session.execute(
+            select(AdvisorChangeSet).where(
+                AdvisorChangeSet.tenant_id == tenant_id,
+                AdvisorChangeSet.id == change_set_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_change_sets_for_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        limit: int = 50,
+    ) -> list[AdvisorChangeSet]:
+        result = await self._session.execute(
+            select(AdvisorChangeSet)
+            .where(
+                AdvisorChangeSet.tenant_id == tenant_id,
+                AdvisorChangeSet.suite_version_id == suite_version_id,
+            )
+            .order_by(AdvisorChangeSet.created_at.desc(), AdvisorChangeSet.id)
+            .limit(max(1, limit))
+        )
+        return list(result.scalars().all())
+
+    async def get_change_set_for_legacy_skill_suggestion(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID | None,
+        suggestion_id: str | UUID,
+        target_ref: str,
+    ) -> AdvisorChangeSet | None:
+        statement = select(AdvisorChangeSet).where(
+            AdvisorChangeSet.tenant_id == tenant_id,
+            AdvisorChangeSet.target_ref == target_ref,
+        )
+        if suite_version_id is None:
+            statement = statement.where(AdvisorChangeSet.suite_version_id.is_(None))
+        else:
+            statement = statement.where(AdvisorChangeSet.suite_version_id == suite_version_id)
+        result = await self._session.execute(statement)
+        for change_set in result.scalars().all():
+            if str((change_set.evidence_json or {}).get("legacy_skill_suggestion_id")) == str(suggestion_id):
+                return change_set
+        return None
+
+    async def list_advisor_suggestions_for_change_set(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID,
+    ) -> list[AdvisorSuggestion]:
+        result = await self._session.execute(
+            select(AdvisorSuggestion)
+            .where(
+                AdvisorSuggestion.tenant_id == tenant_id,
+                AdvisorSuggestion.change_set_id == change_set_id,
+            )
+            .order_by(AdvisorSuggestion.created_at, AdvisorSuggestion.id)
+        )
+        return list(result.scalars().all())
+
+    async def list_promotion_decisions_for_change_set(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID,
+    ) -> list[PromotionDecision]:
+        result = await self._session.execute(
+            select(PromotionDecision)
+            .where(
+                PromotionDecision.tenant_id == tenant_id,
+                PromotionDecision.change_set_id == change_set_id,
+            )
+            .order_by(PromotionDecision.created_at.desc(), PromotionDecision.id)
+        )
+        return list(result.scalars().all())
+
+    async def get_run_by_idempotency_key(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        idempotency_key: str,
+    ) -> EvaluationRun | None:
+        result = await self._session.execute(
+            select(EvaluationRun).where(
+                EvaluationRun.tenant_id == tenant_id,
+                EvaluationRun.suite_version_id == suite_version_id,
+                EvaluationRun.idempotency_key == idempotency_key,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_next_claimable_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        now: datetime,
+    ) -> EvaluationRun | None:
+        result = await self._session.execute(
+            select(EvaluationRun)
+            .where(
+                EvaluationRun.tenant_id == tenant_id,
+                _has_no_preflight_blockers(),
+                (
+                    (EvaluationRun.status == "queued")
+                    | ((EvaluationRun.status == "running") & (EvaluationRun.lease_expires_at < now))
+                ),
+            )
+            .order_by(EvaluationRun.created_at, EvaluationRun.id)
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_cases_for_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+    ) -> list[EvaluationCase]:
+        result = await self._session.execute(
+            select(EvaluationCase)
+            .where(
+                EvaluationCase.tenant_id == tenant_id,
+                EvaluationCase.suite_version_id == suite_version_id,
+            )
+            .order_by(EvaluationCase.case_key)
+        )
+        return list(result.scalars().all())
+
+    async def list_runs_for_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        limit: int = 50,
+    ) -> list[EvaluationRun]:
+        result = await self._session.execute(
+            select(EvaluationRun)
+            .where(
+                EvaluationRun.tenant_id == tenant_id,
+                EvaluationRun.suite_version_id == suite_version_id,
+            )
+            .order_by(EvaluationRun.created_at.desc(), EvaluationRun.id)
+            .limit(max(1, limit))
+        )
+        return list(result.scalars().all())
+
+    async def list_case_runs_for_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+    ) -> list[EvaluationCaseRun]:
+        result = await self._session.execute(
+            select(EvaluationCaseRun)
+            .where(
+                EvaluationCaseRun.tenant_id == tenant_id,
+                EvaluationCaseRun.run_id == run_id,
+            )
+            .order_by(EvaluationCaseRun.created_at, EvaluationCaseRun.id)
+        )
+        return list(result.scalars().all())
+
+    async def list_assessments_for_case_runs(
+        self,
+        *,
+        tenant_id: str | UUID,
+        case_run_ids: list[str | UUID],
+    ) -> list[EvaluationAssessment]:
+        if not case_run_ids:
+            return []
+        result = await self._session.execute(
+            select(EvaluationAssessment)
+            .where(
+                EvaluationAssessment.tenant_id == tenant_id,
+                EvaluationAssessment.case_run_id.in_(case_run_ids),
+            )
+            .order_by(EvaluationAssessment.created_at, EvaluationAssessment.id)
+        )
+        return list(result.scalars().all())
+
+    async def get_case_by_key(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        case_key: str,
+    ) -> EvaluationCase | None:
+        result = await self._session.execute(
+            select(EvaluationCase).where(
+                EvaluationCase.tenant_id == tenant_id,
+                EvaluationCase.suite_version_id == suite_version_id,
+                EvaluationCase.case_key == case_key,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_cases_by_ids(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        case_ids: list[str | UUID],
+    ) -> list[EvaluationCase]:
+        if not case_ids:
+            return []
+        result = await self._session.execute(
+            select(EvaluationCase).where(
+                EvaluationCase.tenant_id == tenant_id,
+                EvaluationCase.suite_version_id == suite_version_id,
+                EvaluationCase.id.in_(case_ids),
+            )
+        )
+        return list(result.scalars().all())
+
+    async def create_case(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        case_key: str,
+        title: str,
+        target_kinds_json: list[str],
+        operation: str,
+        question: str,
+        expected_contract_json: dict,
+        provenance_json: dict,
+        tags_json: list[str],
+        content_hash: str,
+        immutable: bool,
+    ) -> EvaluationCase:
+        case = EvaluationCase(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+            case_key=case_key,
+            title=title,
+            target_kinds_json=target_kinds_json,
+            operation=operation,
+            question=question,
+            expected_contract_json=expected_contract_json,
+            provenance_json=provenance_json,
+            tags_json=tags_json,
+            content_hash=content_hash,
+            immutable=immutable,
+        )
+        self._session.add(case)
+        await self._session.flush()
+        return case
+
+    async def create_target_snapshot(
+        self,
+        *,
+        tenant_id: str | UUID,
+        target_kind: str,
+        target_ref: str,
+        contract_version: str,
+        snapshot_json: dict,
+        pin_digest: str,
+        blockers_json: list[str],
+    ) -> EvaluationTargetSnapshot:
+        snapshot = EvaluationTargetSnapshot(
+            tenant_id=tenant_id,
+            target_kind=target_kind,
+            target_ref=target_ref,
+            contract_version=contract_version,
+            snapshot_json=snapshot_json,
+            pin_digest=pin_digest,
+            blockers_json=blockers_json,
+        )
+        self._session.add(snapshot)
+        await self._session.flush()
+        return snapshot
+
+    async def create_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        target_snapshot_id: str | UUID,
+        status: str,
+        actor_type: str,
+        actor_id: str,
+        idempotency_key: str | None,
+        preflight_blockers_json: list[str],
+    ) -> EvaluationRun:
+        run = EvaluationRun(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+            target_snapshot_id=target_snapshot_id,
+            status=status,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            idempotency_key=idempotency_key,
+            preflight_blockers_json=preflight_blockers_json,
+        )
+        self._session.add(run)
+        await self._session.flush()
+        return run
+
+    async def create_case_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+        case_id: str | UUID,
+        status: str,
+        attempt: int,
+        input_digest: str,
+        output_digest: str,
+        result_json: dict,
+        error_json: dict,
+        immutable: bool,
+        started_at: datetime,
+        completed_at: datetime,
+    ) -> EvaluationCaseRun:
+        case_run = EvaluationCaseRun(
+            tenant_id=tenant_id,
+            run_id=run_id,
+            case_id=case_id,
+            status=status,
+            attempt=attempt,
+            input_digest=input_digest,
+            output_digest=output_digest,
+            result_json=result_json,
+            error_json=error_json,
+            immutable=immutable,
+            started_at=started_at,
+            completed_at=completed_at,
+        )
+        self._session.add(case_run)
+        await self._session.flush()
+        return case_run
+
+    async def create_assessment(
+        self,
+        *,
+        tenant_id: str | UUID,
+        case_run_id: str | UUID,
+        category: str,
+        status: str,
+        score: str | None,
+        hard_fail: bool,
+        details_json: dict,
+    ) -> EvaluationAssessment:
+        assessment = EvaluationAssessment(
+            tenant_id=tenant_id,
+            case_run_id=case_run_id,
+            category=category,
+            status=status,
+            score=score,
+            hard_fail=hard_fail,
+            details_json=details_json,
+            immutable=True,
+        )
+        self._session.add(assessment)
+        await self._session.flush()
+        return assessment
+
+    async def create_artifact(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID | None,
+        case_run_id: str | UUID | None,
+        artifact_type: str,
+        uri: str,
+        content_hash: str,
+        metadata_json: dict,
+    ) -> EvaluationArtifact:
+        artifact = EvaluationArtifact(
+            tenant_id=tenant_id,
+            run_id=run_id,
+            case_run_id=case_run_id,
+            artifact_type=artifact_type,
+            uri=uri,
+            content_hash=content_hash,
+            metadata_json=metadata_json,
+            immutable=True,
+        )
+        self._session.add(artifact)
+        await self._session.flush()
+        return artifact
+
+    async def create_promotion_decision(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID | None,
+        verification_run_id: str | UUID | None,
+        regression_run_id: str | UUID | None,
+        decision: str,
+        decided_by: str | UUID | None,
+        rationale: str,
+        audit_json: dict,
+    ) -> PromotionDecision:
+        promotion = PromotionDecision(
+            tenant_id=tenant_id,
+            change_set_id=change_set_id,
+            verification_run_id=verification_run_id,
+            regression_run_id=regression_run_id,
+            decision=decision,
+            decided_by=decided_by,
+            rationale=rationale,
+            audit_json=audit_json,
+        )
+        self._session.add(promotion)
+        await self._session.flush()
+        return promotion
+
+    async def create_advisor_change_set(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID | None,
+        target_ref: str,
+        base_version_ref: str,
+        base_etag: str,
+        status: str,
+        evidence_json: dict,
+        created_by: str,
+    ) -> AdvisorChangeSet:
+        change_set = AdvisorChangeSet(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+            target_ref=target_ref,
+            base_version_ref=base_version_ref,
+            base_etag=base_etag,
+            status=status,
+            evidence_json=evidence_json,
+            created_by=created_by,
+        )
+        self._session.add(change_set)
+        await self._session.flush()
+        return change_set
+
+    async def create_advisor_suggestion(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID,
+        suggestion_type: str,
+        patch_json: dict,
+        affected_case_ids_json: list[str],
+        status: str,
+    ) -> AdvisorSuggestion:
+        suggestion = AdvisorSuggestion(
+            tenant_id=tenant_id,
+            change_set_id=change_set_id,
+            suggestion_type=suggestion_type,
+            patch_json=patch_json,
+            affected_case_ids_json=affected_case_ids_json,
+            status=status,
+        )
+        self._session.add(suggestion)
+        await self._session.flush()
+        return suggestion
+
+    async def create_audit_event(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_id: str | UUID | None,
+        suite_version_id: str | UUID | None,
+        run_id: str | UUID | None,
+        actor_type: str,
+        actor_id: str,
+        action: str,
+        outcome: str,
+        details_json: dict,
+    ) -> EvaluationAuditEvent:
+        event = EvaluationAuditEvent(
+            tenant_id=tenant_id,
+            suite_id=suite_id,
+            suite_version_id=suite_version_id,
+            run_id=run_id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action=action,
+            outcome=outcome,
+            details_json=details_json,
+        )
+        self._session.add(event)
+        await self._session.flush()
+        return event

--- a/server/routers/dashboard.py
+++ b/server/routers/dashboard.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext, require_scope
+from server.auth.scopes import Scope
+from server.db.session import get_async_session
+from server.models.dashboard import Dashboard, DashboardAsset, DashboardAuditEvent
+from server.models.notebooks import Notebook
+from server.repositories.dashboard import DashboardRepository
+from server.schemas.standard_response import success_response
+from server.services.dashboard import DashboardService
+
+router = APIRouter()
+
+
+class DashboardAssetCreateRequest(BaseModel):
+    slug: str = Field(min_length=1, max_length=160)
+    notebook_id: UUID
+    manifest: dict[str, Any]
+    description: str = ""
+    tags: list[str] = Field(default_factory=list)
+    change_summary: str = "Create structured dashboard draft"
+
+
+class DashboardDraftPatchRequest(BaseModel):
+    base_etag: str = Field(min_length=1)
+    manifest: dict[str, Any] | None = None
+    json_patch: list[dict[str, Any]] | None = None
+    change_summary: str = Field(default="Update structured dashboard draft", min_length=1)
+
+
+class DashboardValidateRequest(BaseModel):
+    manifest: dict[str, Any] | None = None
+
+
+class DashboardPublishRequest(BaseModel):
+    base_etag: str = Field(min_length=1)
+    change_summary: str = Field(default="Publish structured dashboard", min_length=1)
+
+
+class DashboardReloadRequest(BaseModel):
+    base_etag: str = Field(min_length=1)
+    semantic_model_versions: dict[str, str] = Field(default_factory=dict)
+    source_snapshot_ids: list[str] | None = None
+    change_summary: str = Field(default="Reload Dashboard semantic bindings", min_length=1)
+
+
+class DashboardQueryRequest(BaseModel):
+    filters: dict[str, Any] = Field(default_factory=dict)
+    data_view_ids: list[str] | None = None
+    mode: Literal["live", "pinned_snapshot"] = "live"
+    correlation_id: str | None = None
+    idempotency_key: str | None = None
+
+
+class DashboardPreviewRequest(BaseModel):
+    filters: dict[str, Any] = Field(default_factory=dict)
+    data_view_ids: list[str] | None = None
+    correlation_id: str | None = None
+
+
+def _require_non_viewer(auth: AuthContext) -> None:
+    if auth.is_viewer:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Viewer access to governed dashboards must use shared viewer routes",
+        )
+
+
+async def _assert_notebook_access(session: AsyncSession, notebook_id: UUID, auth: AuthContext) -> None:
+    notebook = await session.scalar(select(Notebook).where(Notebook.id == notebook_id, Notebook.tenant_id == auth.tenant_id))
+    if not notebook:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    if not auth.has_scope(Scope.NOTEBOOK_READ) and str(notebook.created_by) != str(auth.user_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only use notebooks you created")
+
+
+async def _get_asset_or_404(repo: DashboardRepository, auth: AuthContext, asset_id: UUID) -> DashboardAsset:
+    asset = await repo.get_asset(asset_id, auth.tenant_id)
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+    return asset
+
+
+async def _get_version_or_404(
+    repo: DashboardRepository,
+    auth: AuthContext,
+    asset_id: UUID,
+    version_num: int,
+) -> Dashboard:
+    version = await repo.get_asset_version_by_num(
+        tenant_id=auth.tenant_id,
+        asset_id=asset_id,
+        version_num=version_num,
+    )
+    if not version:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard version not found")
+    return version
+
+
+def _dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _asset_payload(asset: DashboardAsset) -> dict[str, Any]:
+    return {
+        "id": str(asset.id),
+        "tenant_id": str(asset.tenant_id),
+        "notebook_id": str(asset.notebook_id) if asset.notebook_id else None,
+        "slug": asset.slug,
+        "name": asset.name,
+        "description": asset.description,
+        "owner_id": str(asset.owner_id) if asset.owner_id else None,
+        "tags": asset.tags_json or [],
+        "lifecycle": asset.lifecycle,
+        "current_draft_version_id": str(asset.current_draft_version_id) if asset.current_draft_version_id else None,
+        "published_version_id": str(asset.published_version_id) if asset.published_version_id else None,
+        "access_policy": asset.access_policy_json or {},
+        "freshness_policy": asset.freshness_policy_json or {},
+        "consumer_summary": asset.consumer_summary_json or {},
+        "health_summary": asset.health_summary_json or {},
+        "etag": asset.etag,
+        "created_at": _dt(asset.created_at),
+        "updated_at": _dt(asset.updated_at),
+    }
+
+
+def _version_summary_payload(version: Dashboard) -> dict[str, Any]:
+    return {
+        "id": str(version.id),
+        "asset_id": str(version.asset_id) if version.asset_id else None,
+        "notebook_id": str(version.notebook_id),
+        "version_num": version.version_num,
+        "manifest_schema_version": version.manifest_schema_version,
+        "content_hash": version.content_hash,
+        "status": version.status,
+        "created_by": str(version.created_by) if version.created_by else None,
+        "actor_type": version.actor_type,
+        "change_summary": version.change_summary,
+        "pinned_model_versions": version.pinned_model_versions_json or {},
+        "pinned_source_snapshots": version.pinned_source_snapshots_json or [],
+        "validation_result": version.validation_result_json or {},
+        "renderer_version": version.renderer_version,
+        "migration_state": version.migration_state,
+        "is_published_immutable": version.is_published_immutable,
+        "created_at": _dt(version.created_at),
+    }
+
+
+def _version_payload(version: Dashboard) -> dict[str, Any]:
+    payload = _version_summary_payload(version)
+    payload["manifest"] = version.manifest_json or {}
+    return payload
+
+
+def _audit_payload(event: DashboardAuditEvent) -> dict[str, Any]:
+    return {
+        "id": str(event.id),
+        "asset_id": str(event.asset_id) if event.asset_id else None,
+        "version_id": str(event.version_id) if event.version_id else None,
+        "run_id": str(event.run_id) if event.run_id else None,
+        "actor_type": event.actor_type,
+        "actor_id": event.actor_id,
+        "action": event.action,
+        "correlation_id": event.correlation_id,
+        "before_digest": event.before_digest,
+        "after_digest": event.after_digest,
+        "outcome": event.outcome,
+        "details": event.details_json or {},
+        "created_at": _dt(event.created_at),
+    }
+
+
+def _lineage_from_manifest(manifest: dict[str, Any] | None) -> dict[str, Any]:
+    manifest = manifest or {}
+    data_views = manifest.get("data_views") or []
+    return {
+        "dashboard_id": manifest.get("dashboard_id"),
+        "semantic_bindings": manifest.get("semantic_bindings") or [],
+        "data_views": [
+            {
+                "id": data_view.get("id"),
+                "kind": data_view.get("kind"),
+                "lineage": data_view.get("lineage") or data_view.get("saved_query", {}).get("lineage", []),
+                "evidence": data_view.get("evidence") or [],
+            }
+            for data_view in data_views
+        ],
+        "migration": manifest.get("migration") or {},
+    }
+
+
+@router.get("/dashboard-assets")
+async def list_dashboard_assets(
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    assets = await repo.list_assets(auth.tenant_id)
+    return success_response(
+        data={"items": [_asset_payload(asset) for asset in assets], "total": len(assets)},
+        message=f"Retrieved {len(assets)} dashboard asset(s)",
+    )
+
+
+@router.post("/dashboard-assets", status_code=status.HTTP_201_CREATED)
+async def create_dashboard_asset(
+    payload: DashboardAssetCreateRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    await _assert_notebook_access(session, payload.notebook_id, auth)
+    asset = await DashboardService().create_asset_draft(
+        session=session,
+        tenant_id=auth.tenant_id,
+        actor_id=auth.user_id,
+        manifest_payload=payload.manifest,
+        slug=payload.slug,
+        notebook_id=payload.notebook_id,
+        description=payload.description,
+        tags=payload.tags,
+        change_summary=payload.change_summary,
+        actor_type="human",
+    )
+    return success_response(data=_asset_payload(asset), message="Dashboard asset draft created")
+
+
+@router.get("/dashboard-assets/{asset_id}")
+async def get_dashboard_asset(
+    asset_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    asset = await _get_asset_or_404(repo, auth, asset_id)
+    versions = await repo.list_asset_versions(tenant_id=auth.tenant_id, asset_id=asset_id)
+    return success_response(
+        data={**_asset_payload(asset), "versions": [_version_summary_payload(version) for version in versions]},
+        message="Retrieved dashboard asset",
+    )
+
+
+@router.get("/dashboard-assets/{asset_id}/versions/{version_num}")
+async def get_dashboard_asset_version(
+    asset_id: UUID,
+    version_num: int,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    await _get_asset_or_404(repo, auth, asset_id)
+    version = await _get_version_or_404(repo, auth, asset_id, version_num)
+    return success_response(data=_version_payload(version), message="Retrieved dashboard version")
+
+
+@router.patch("/dashboard-assets/{asset_id}/draft")
+async def patch_dashboard_draft(
+    asset_id: UUID,
+    payload: DashboardDraftPatchRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    asset = await _get_asset_or_404(repo, auth, asset_id)
+    if asset.notebook_id:
+        await _assert_notebook_access(session, asset.notebook_id, auth)
+    if payload.json_patch is not None:
+        version = await DashboardService().apply_draft_patch(
+            session=session,
+            tenant_id=auth.tenant_id,
+            asset_id=asset_id,
+            actor_id=auth.user_id,
+            base_etag=payload.base_etag,
+            patch_operations=payload.json_patch,
+            change_summary=payload.change_summary,
+            actor_type="human",
+        )
+    elif payload.manifest is not None:
+        version = await DashboardService().patch_draft(
+            session=session,
+            tenant_id=auth.tenant_id,
+            asset_id=asset_id,
+            actor_id=auth.user_id,
+            manifest_payload=payload.manifest,
+            base_etag=payload.base_etag,
+            change_summary=payload.change_summary,
+            actor_type="human",
+        )
+    else:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="manifest or json_patch is required")
+    return success_response(data=_version_payload(version), message="Dashboard draft patched")
+
+
+@router.post("/dashboard-assets/{asset_id}/validate")
+async def validate_dashboard_asset(
+    asset_id: UUID,
+    payload: DashboardValidateRequest | None = None,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    asset = await _get_asset_or_404(repo, auth, asset_id)
+    manifest = payload.manifest if payload and payload.manifest is not None else None
+    if manifest is None:
+        if not asset.current_draft_version_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no editable draft")
+        draft = await repo.get_asset_version(
+            tenant_id=auth.tenant_id,
+            asset_id=asset_id,
+            version_id=asset.current_draft_version_id,
+        )
+        if not draft:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard draft not found")
+        manifest = draft.manifest_json or {}
+    validated_manifest = DashboardService.validate_manifest_payload(manifest)
+    validation = DashboardService.validation_summary(validated_manifest)
+    return success_response(data={"validation": validation, "manifest": validated_manifest}, message="Dashboard validated")
+
+
+@router.post("/dashboard-assets/{asset_id}/preview")
+async def preview_dashboard_asset(
+    asset_id: UUID,
+    payload: DashboardPreviewRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    run = await DashboardService().preview_dashboard(
+        session=session,
+        tenant_id=auth.tenant_id,
+        asset_id=asset_id,
+        actor_id=str(auth.user_id),
+        actor_type="human",
+        filters=payload.filters,
+        data_view_ids=payload.data_view_ids,
+        correlation_id=payload.correlation_id,
+    )
+    return success_response(data=run, message="Dashboard preview executed")
+
+
+@router.post("/dashboard-assets/{asset_id}/publish")
+async def publish_dashboard_asset(
+    asset_id: UUID,
+    payload: DashboardPublishRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    version = await DashboardService().publish(
+        session=session,
+        tenant_id=auth.tenant_id,
+        asset_id=asset_id,
+        actor_id=auth.user_id,
+        base_etag=payload.base_etag,
+        change_summary=payload.change_summary,
+        actor_type="human",
+    )
+    return success_response(data=_version_payload(version), message="Dashboard published")
+
+
+@router.post("/dashboard-assets/{asset_id}/reload")
+async def reload_dashboard_asset(
+    asset_id: UUID,
+    payload: DashboardReloadRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    asset = await _get_asset_or_404(repo, auth, asset_id)
+    if asset.notebook_id:
+        await _assert_notebook_access(session, asset.notebook_id, auth)
+    version, semantic_diff = await DashboardService().reload_dashboard(
+        session=session,
+        tenant_id=auth.tenant_id,
+        asset_id=asset_id,
+        actor_id=auth.user_id,
+        base_etag=payload.base_etag,
+        semantic_model_versions=payload.semantic_model_versions,
+        source_snapshot_ids=payload.source_snapshot_ids,
+        change_summary=payload.change_summary,
+        actor_type="human",
+    )
+    return success_response(
+        data={"draft": _version_payload(version), "semantic_diff": semantic_diff},
+        message="Dashboard reload draft created",
+    )
+
+
+@router.post("/dashboard-assets/{asset_id}/query")
+async def query_dashboard_asset(
+    asset_id: UUID,
+    payload: DashboardQueryRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    run = await DashboardService().query_dashboard(
+        session=session,
+        tenant_id=auth.tenant_id,
+        asset_id=asset_id,
+        actor_id=str(auth.user_id),
+        actor_type="human",
+        filters=payload.filters,
+        data_view_ids=payload.data_view_ids,
+        mode=payload.mode,
+        correlation_id=payload.correlation_id,
+        idempotency_key=payload.idempotency_key,
+    )
+    return success_response(data=run, message="Dashboard query executed")
+
+
+@router.get("/dashboard-assets/{asset_id}/state")
+async def get_dashboard_asset_state(
+    asset_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    asset = await _get_asset_or_404(repo, auth, asset_id)
+    versions = await repo.list_asset_versions(tenant_id=auth.tenant_id, asset_id=asset_id)
+    return success_response(
+        data={
+            "asset": _asset_payload(asset),
+            "versions": [_version_summary_payload(version) for version in versions],
+            "draft_version_id": str(asset.current_draft_version_id) if asset.current_draft_version_id else None,
+            "published_version_id": str(asset.published_version_id) if asset.published_version_id else None,
+        },
+        message="Retrieved dashboard state",
+    )
+
+
+@router.get("/dashboard-assets/{asset_id}/lineage")
+async def get_dashboard_asset_lineage(
+    asset_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    asset = await _get_asset_or_404(repo, auth, asset_id)
+    version = None
+    if asset.published_version_id:
+        version = await repo.get_asset_version(
+            tenant_id=auth.tenant_id,
+            asset_id=asset_id,
+            version_id=asset.published_version_id,
+        )
+    if version is None and asset.current_draft_version_id:
+        version = await repo.get_asset_version(
+            tenant_id=auth.tenant_id,
+            asset_id=asset_id,
+            version_id=asset.current_draft_version_id,
+        )
+    return success_response(
+        data={
+            "asset_id": str(asset.id),
+            "version_id": str(version.id) if version else None,
+            "lineage": _lineage_from_manifest(version.manifest_json if version else None),
+        },
+        message="Retrieved dashboard lineage",
+    )
+
+
+@router.get("/dashboard-assets/{asset_id}/audit")
+async def get_dashboard_asset_audit(
+    asset_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    repo = DashboardRepository(session)
+    await _get_asset_or_404(repo, auth, asset_id)
+    events = await repo.list_asset_audit_events(tenant_id=auth.tenant_id, asset_id=asset_id)
+    return success_response(
+        data={"items": [_audit_payload(event) for event in events], "total": len(events)},
+        message=f"Retrieved {len(events)} dashboard audit event(s)",
+    )
+
+
+@router.get("/dashboard-assets/{asset_id}/export/html")
+async def export_dashboard_asset_html(
+    asset_id: UUID,
+    version_num: int | None = None,
+    correlation_id: str | None = None,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    _require_non_viewer(auth)
+    html_content, filename = await DashboardService().export_dashboard_html(
+        session=session,
+        tenant_id=auth.tenant_id,
+        asset_id=asset_id,
+        actor_id=auth.user_id,
+        actor_type="human",
+        version_num=version_num,
+        correlation_id=correlation_id,
+    )
+    return Response(
+        content=html_content,
+        media_type="text/html; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/server/routers/dashboard.py
+++ b/server/routers/dashboard.py
@@ -76,7 +76,9 @@ def _require_non_viewer(auth: AuthContext) -> None:
 
 
 async def _assert_notebook_access(session: AsyncSession, notebook_id: UUID, auth: AuthContext) -> None:
-    notebook = await session.scalar(select(Notebook).where(Notebook.id == notebook_id, Notebook.tenant_id == auth.tenant_id))
+    notebook = await session.scalar(
+        select(Notebook).where(Notebook.id == notebook_id, Notebook.tenant_id == auth.tenant_id)
+    )
     if not notebook:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
     if not auth.has_scope(Scope.NOTEBOOK_READ) and str(notebook.created_by) != str(auth.user_id):
@@ -328,7 +330,9 @@ async def validate_dashboard_asset(
         manifest = draft.manifest_json or {}
     validated_manifest = DashboardService.validate_manifest_payload(manifest)
     validation = DashboardService.validation_summary(validated_manifest)
-    return success_response(data={"validation": validation, "manifest": validated_manifest}, message="Dashboard validated")
+    return success_response(
+        data={"validation": validation, "manifest": validated_manifest}, message="Dashboard validated"
+    )
 
 
 @router.post("/dashboard-assets/{asset_id}/preview")

--- a/server/routers/evaluation.py
+++ b/server/routers/evaluation.py
@@ -117,14 +117,10 @@ def _advisor_review_payload(review: dict[str, Any]) -> dict[str, Any]:
     regression_run = review.get("regression_run")
     return {
         "change_set": advisor_change_set_payload(review["change_set"]),
-        "advisor_suggestions": [
-            advisor_suggestion_payload(suggestion) for suggestion in review["advisor_suggestions"]
-        ],
+        "advisor_suggestions": [advisor_suggestion_payload(suggestion) for suggestion in review["advisor_suggestions"]],
         "verification_run": evaluation_run_payload(verification_run) if verification_run else None,
         "regression_run": evaluation_run_payload(regression_run) if regression_run else None,
-        "promotion_decisions": [
-            promotion_payload(promotion) for promotion in review["promotion_decisions"]
-        ],
+        "promotion_decisions": [promotion_payload(promotion) for promotion in review["promotion_decisions"]],
         "gate_summary": review["gate_summary"],
     }
 
@@ -169,7 +165,9 @@ def _parse_import_cases(payload: EvaluationCaseImportRequest) -> list[dict[str, 
             expected_contract = json.loads(expected_text)
             provenance = json.loads(provenance_text)
         except json.JSONDecodeError as exc:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV JSON field: {exc.msg}") from exc
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV JSON field: {exc.msg}"
+            ) from exc
         cases.append(
             {
                 "case_key": row.get("case_key") or "",
@@ -436,7 +434,10 @@ async def list_evaluation_advisor_change_sets(
     except ValueError as exc:
         raise _service_error(exc) from exc
     return success_response(
-        data={"items": [advisor_change_set_payload(change_set) for change_set in change_sets], "total": len(change_sets)},
+        data={
+            "items": [advisor_change_set_payload(change_set) for change_set in change_sets],
+            "total": len(change_sets),
+        },
         message="Advisor change sets listed",
     )
 
@@ -503,9 +504,7 @@ async def describe_evaluation_failures(
     failures = []
     for case_run, assessments in case_runs:
         failed_assessments = [
-            assessment
-            for assessment in assessments
-            if assessment.status != "passed" or assessment.hard_fail
+            assessment for assessment in assessments if assessment.status != "passed" or assessment.hard_fail
         ]
         if case_run.status != "passed" or failed_assessments:
             failures.append(evaluation_case_run_payload(case_run, assessments=failed_assessments))
@@ -770,7 +769,9 @@ async def create_advisor_change_set_from_skill_suggestion(
     session: AsyncSession = Depends(get_async_session),
 ):
     try:
-        change_set, suggestions, created = await EvaluationService(session).create_advisor_change_set_from_skill_suggestion(
+        change_set, suggestions, created = await EvaluationService(
+            session
+        ).create_advisor_change_set_from_skill_suggestion(
             tenant_id=auth.tenant_id,
             suggestion_id=suggestion_id,
             suite_version_id=payload.suite_version_id,

--- a/server/routers/evaluation.py
+++ b/server/routers/evaluation.py
@@ -1,0 +1,790 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext, require_scope
+from server.auth.scopes import Scope
+from server.db.session import get_async_session
+from server.schemas.standard_response import success_response
+from server.serializers.evaluation import (
+    advisor_change_set_payload,
+    advisor_suggestion_payload,
+    evaluation_artifact_payload,
+    evaluation_case_payload,
+    evaluation_case_run_payload,
+    evaluation_run_payload,
+    evaluation_suite_payload,
+    evaluation_suite_version_payload,
+    promotion_payload,
+)
+from server.services.evaluation import EvaluationService
+
+router = APIRouter()
+
+
+class EvaluationRouterModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class EvaluationPreflightRunRequest(EvaluationRouterModel):
+    suite_version_id: UUID
+    target_snapshot: dict[str, Any]
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=160)
+    actor_type: Literal["human", "agent", "service"] = "agent"
+    actor_id: str | None = Field(default=None, min_length=1, max_length=160)
+
+
+class EvaluationCreateSuiteRequest(EvaluationRouterModel):
+    slug: str = Field(min_length=1, max_length=160)
+    name: str = Field(min_length=1, max_length=255)
+    description: str = ""
+    target_kinds: list[str] = Field(min_length=1)
+    gate_policy: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvaluationCreateDraftVersionRequest(EvaluationRouterModel):
+    copy_from_version_id: UUID | None = None
+
+
+class EvaluationCaseDraftRequest(EvaluationRouterModel):
+    case_key: str = Field(min_length=1, max_length=160)
+    title: str | None = Field(default=None, max_length=255)
+    target_kinds: list[str] = Field(min_length=1)
+    operation: str = Field(default="answer_question", min_length=1, max_length=80)
+    question: str = Field(min_length=1)
+    expected_contract: dict[str, Any] = Field(default_factory=dict)
+    provenance: dict[str, Any] = Field(default_factory=lambda: {"source": "import"})
+    tags: list[str] = Field(default_factory=list)
+
+
+class EvaluationCaseImportRequest(EvaluationRouterModel):
+    format: Literal["json", "jsonl", "csv"] = "json"
+    cases: list[EvaluationCaseDraftRequest] | None = None
+    content: str | None = None
+
+
+class EvaluationRunLeaseRequest(EvaluationRouterModel):
+    worker_id: str = Field(min_length=1, max_length=160)
+    lease_seconds: int = Field(default=60, ge=1, le=3600)
+
+
+class EvaluationArtifactRequest(EvaluationRouterModel):
+    artifact_type: str = Field(min_length=1, max_length=80)
+    uri: str = Field(min_length=1)
+    content: Any
+
+
+class EvaluationCompleteRunRequest(EvaluationRouterModel):
+    worker_id: str = Field(min_length=1, max_length=160)
+    case_results: list[dict[str, Any]] = Field(min_length=1)
+
+
+class EvaluationFeedbackCaseDraftRequest(EvaluationRouterModel):
+    suite_version_id: UUID
+    question: str | None = Field(default=None, min_length=1)
+    tags: list[str] = Field(default_factory=list)
+
+
+class EvaluationSkillSuggestionAdvisorRequest(EvaluationRouterModel):
+    suite_version_id: UUID | None = None
+    affected_case_ids: list[UUID] = Field(default_factory=list)
+
+
+class EvaluationAdvisorGateRequest(EvaluationRouterModel):
+    target_snapshot: dict[str, Any]
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=160)
+
+
+def _service_error(exc: ValueError) -> HTTPException:
+    detail = str(exc)
+    if "not found" in detail:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+    if "leased by this worker" in detail or "case results do not match" in detail or "immutable" in detail:
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+def _advisor_review_payload(review: dict[str, Any]) -> dict[str, Any]:
+    verification_run = review.get("verification_run")
+    regression_run = review.get("regression_run")
+    return {
+        "change_set": advisor_change_set_payload(review["change_set"]),
+        "advisor_suggestions": [
+            advisor_suggestion_payload(suggestion) for suggestion in review["advisor_suggestions"]
+        ],
+        "verification_run": evaluation_run_payload(verification_run) if verification_run else None,
+        "regression_run": evaluation_run_payload(regression_run) if regression_run else None,
+        "promotion_decisions": [
+            promotion_payload(promotion) for promotion in review["promotion_decisions"]
+        ],
+        "gate_summary": review["gate_summary"],
+    }
+
+
+def _case_request_payload(payload: EvaluationCaseDraftRequest) -> dict[str, Any]:
+    return {
+        "case_key": payload.case_key,
+        "title": payload.title or payload.case_key,
+        "target_kinds": payload.target_kinds,
+        "operation": payload.operation,
+        "question": payload.question,
+        "expected_contract": payload.expected_contract,
+        "provenance": payload.provenance,
+        "tags": payload.tags,
+    }
+
+
+def _parse_import_cases(payload: EvaluationCaseImportRequest) -> list[dict[str, Any]]:
+    if payload.format == "json":
+        return [_case_request_payload(case) for case in payload.cases or []]
+    if not payload.content:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Import content is required")
+    if payload.format == "jsonl":
+        cases = []
+        for line_number, line in enumerate(payload.content.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                cases.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid JSONL at line {line_number}: {exc.msg}",
+                ) from exc
+        return cases
+    reader = csv.DictReader(io.StringIO(payload.content))
+    cases = []
+    for row in reader:
+        expected_text = row.get("expected_contract_json") or row.get("expected_contract") or "{}"
+        provenance_text = row.get("provenance_json") or row.get("provenance") or '{"source":"import"}'
+        try:
+            expected_contract = json.loads(expected_text)
+            provenance = json.loads(provenance_text)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid CSV JSON field: {exc.msg}") from exc
+        cases.append(
+            {
+                "case_key": row.get("case_key") or "",
+                "title": row.get("title") or row.get("case_key") or "",
+                "target_kinds": [item.strip() for item in (row.get("target_kinds") or "").split(";") if item.strip()],
+                "operation": row.get("operation") or "answer_question",
+                "question": row.get("question") or "",
+                "expected_contract": expected_contract,
+                "provenance": provenance,
+                "tags": [item.strip() for item in (row.get("tags") or "").split(";") if item.strip()],
+            }
+        )
+    return cases
+
+
+@router.get("/evaluation/suites")
+async def list_evaluation_suites(
+    query: str = "",
+    target_kind: str = "",
+    status_filter: str = Query(default="", alias="status"),
+    limit: int = 50,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    suites = await EvaluationService(session).list_suites(
+        tenant_id=auth.tenant_id,
+        query=query,
+        target_kind=target_kind,
+        status=status_filter,
+        limit=max(1, min(limit, 100)),
+    )
+    return success_response(
+        data={"items": [evaluation_suite_payload(suite) for suite in suites], "total": len(suites)},
+        message="Evaluation suites listed",
+    )
+
+
+@router.post("/evaluation/suites", status_code=status.HTTP_201_CREATED)
+async def create_evaluation_suite(
+    payload: EvaluationCreateSuiteRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        suite, version = await EvaluationService(session).create_suite_with_draft(
+            tenant_id=auth.tenant_id,
+            slug=payload.slug,
+            name=payload.name,
+            description=payload.description,
+            target_kinds=payload.target_kinds,
+            gate_policy=payload.gate_policy,
+            actor_id=auth.user_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={
+            "suite": evaluation_suite_payload(
+                suite,
+                versions=[version],
+                include_versions=True,
+                include_manifests=True,
+            )
+        },
+        message="Evaluation suite draft created",
+    )
+
+
+@router.get("/evaluation/suites/{suite_id}")
+async def describe_evaluation_suite(
+    suite_id: UUID,
+    include_manifests: bool = False,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        suite, versions = await EvaluationService(session).describe_suite(
+            tenant_id=auth.tenant_id,
+            suite_id=suite_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={
+            "suite": evaluation_suite_payload(
+                suite,
+                versions=versions,
+                include_versions=True,
+                include_manifests=include_manifests,
+            )
+        },
+        message="Evaluation suite described",
+    )
+
+
+@router.post("/evaluation/suites/{suite_id}/draft-version", status_code=status.HTTP_201_CREATED)
+async def create_evaluation_draft_suite_version(
+    suite_id: UUID,
+    payload: EvaluationCreateDraftVersionRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        version = await EvaluationService(session).create_draft_suite_version(
+            tenant_id=auth.tenant_id,
+            suite_id=suite_id,
+            actor_id=auth.user_id,
+            copy_from_version_id=payload.copy_from_version_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={"version": evaluation_suite_version_payload(version, include_manifest=True)},
+        message="Evaluation draft version created",
+    )
+
+
+@router.get("/evaluation/suite-versions/{suite_version_id}/cases")
+async def list_evaluation_cases(
+    suite_version_id: UUID,
+    include_expected_contract: bool = True,
+    limit: int = 100,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        cases = await EvaluationService(session).list_cases(
+            tenant_id=auth.tenant_id,
+            suite_version_id=suite_version_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    limit = max(1, min(limit, 500))
+    return success_response(
+        data={
+            "items": [
+                evaluation_case_payload(case, include_expected_contract=include_expected_contract)
+                for case in cases[:limit]
+            ],
+            "total": len(cases),
+            "has_more": len(cases) > limit,
+        },
+        message="Evaluation cases listed",
+    )
+
+
+@router.post("/evaluation/suite-versions/{suite_version_id}/cases", status_code=status.HTTP_201_CREATED)
+async def create_evaluation_case_draft(
+    suite_version_id: UUID,
+    payload: EvaluationCaseDraftRequest,
+    response: Response,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        case, created = await EvaluationService(session).create_case_draft(
+            tenant_id=auth.tenant_id,
+            suite_version_id=suite_version_id,
+            case_key=payload.case_key,
+            title=payload.title or payload.case_key,
+            target_kinds=payload.target_kinds,
+            operation=payload.operation,
+            question=payload.question,
+            expected_contract=payload.expected_contract,
+            provenance=payload.provenance,
+            tags=payload.tags,
+            actor_id=str(auth.user_id),
+            actor_type="human",
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    response.status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+    return success_response(
+        data={"case": evaluation_case_payload(case), "created": created},
+        message="Evaluation case draft created",
+    )
+
+
+@router.post("/evaluation/suite-versions/{suite_version_id}/cases/import", status_code=status.HTTP_201_CREATED)
+async def import_evaluation_case_drafts(
+    suite_version_id: UUID,
+    payload: EvaluationCaseImportRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        imported = await EvaluationService(session).import_case_drafts(
+            tenant_id=auth.tenant_id,
+            suite_version_id=suite_version_id,
+            cases=_parse_import_cases(payload),
+            actor_id=str(auth.user_id),
+            actor_type="human",
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    created = [evaluation_case_payload(case) for case in imported["created"]]
+    existing = [evaluation_case_payload(case) for case in imported["existing"]]
+    return success_response(
+        data={
+            "created": created,
+            "existing": existing,
+            "created_count": len(created),
+            "existing_count": len(existing),
+            "total": imported["total"],
+        },
+        message="Evaluation cases imported",
+    )
+
+
+@router.post("/evaluation/suite-versions/{suite_version_id}/publish")
+async def publish_evaluation_suite_version(
+    suite_version_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        version = await EvaluationService(session).publish_suite_version(
+            tenant_id=auth.tenant_id,
+            suite_version_id=suite_version_id,
+            actor_id=str(auth.user_id),
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={"version": evaluation_suite_version_payload(version, include_manifest=True)},
+        message="Evaluation suite version published",
+    )
+
+
+@router.get("/evaluation/suite-versions/{suite_version_id}/runs")
+async def list_evaluation_runs(
+    suite_version_id: UUID,
+    limit: int = 50,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        runs = await EvaluationService(session).list_runs(
+            tenant_id=auth.tenant_id,
+            suite_version_id=suite_version_id,
+            limit=max(1, min(limit, 100)),
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={"items": [evaluation_run_payload(run) for run in runs], "total": len(runs)},
+        message="Evaluation runs listed",
+    )
+
+
+@router.get("/evaluation/suite-versions/{suite_version_id}/advisor-change-sets")
+async def list_evaluation_advisor_change_sets(
+    suite_version_id: UUID,
+    limit: int = 50,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        change_sets = await EvaluationService(session).list_advisor_change_sets(
+            tenant_id=auth.tenant_id,
+            suite_version_id=suite_version_id,
+            limit=max(1, min(limit, 100)),
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={"items": [advisor_change_set_payload(change_set) for change_set in change_sets], "total": len(change_sets)},
+        message="Advisor change sets listed",
+    )
+
+
+@router.get("/evaluation/runs/compare")
+async def compare_evaluation_runs(
+    baseline_run_id: UUID,
+    candidate_run_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        comparison = await EvaluationService(session).compare_runs(
+            tenant_id=auth.tenant_id,
+            baseline_run_id=baseline_run_id,
+            candidate_run_id=candidate_run_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data={"comparison": comparison}, message="Evaluation runs compared")
+
+
+@router.get("/evaluation/runs/{run_id}")
+async def get_evaluation_run(
+    run_id: UUID,
+    include_case_results: bool = True,
+    limit: int = 100,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        run, case_runs = await EvaluationService(session).get_run_report(
+            tenant_id=auth.tenant_id,
+            run_id=run_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    limit = max(1, min(limit, 500))
+    data: dict[str, Any] = {"run": evaluation_run_payload(run)}
+    if include_case_results:
+        data["case_runs"] = [
+            evaluation_case_run_payload(case_run, assessments=assessments)
+            for case_run, assessments in case_runs[:limit]
+        ]
+        data["total_case_runs"] = len(case_runs)
+        data["has_more_case_runs"] = len(case_runs) > limit
+    return success_response(data=data, message="Evaluation run described")
+
+
+@router.get("/evaluation/runs/{run_id}/failures")
+async def describe_evaluation_failures(
+    run_id: UUID,
+    limit: int = 100,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        run, case_runs = await EvaluationService(session).get_run_report(
+            tenant_id=auth.tenant_id,
+            run_id=run_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    failures = []
+    for case_run, assessments in case_runs:
+        failed_assessments = [
+            assessment
+            for assessment in assessments
+            if assessment.status != "passed" or assessment.hard_fail
+        ]
+        if case_run.status != "passed" or failed_assessments:
+            failures.append(evaluation_case_run_payload(case_run, assessments=failed_assessments))
+    limit = max(1, min(limit, 500))
+    return success_response(
+        data={
+            "run": evaluation_run_payload(run),
+            "failures": failures[:limit],
+            "total": len(failures),
+            "has_more": len(failures) > limit,
+        },
+        message="Evaluation failures described",
+    )
+
+
+@router.post("/evaluation/runs/preflight", status_code=status.HTTP_202_ACCEPTED)
+async def create_evaluation_preflight_run(
+    payload: EvaluationPreflightRunRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        run = await EvaluationService(session).create_preflight_run(
+            tenant_id=auth.tenant_id,
+            suite_version_id=payload.suite_version_id,
+            target_snapshot_payload=payload.target_snapshot,
+            actor_id=payload.actor_id or str(auth.user_id),
+            idempotency_key=payload.idempotency_key,
+            actor_type=payload.actor_type,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=evaluation_run_payload(run), message="Evaluation preflight run created")
+
+
+@router.post("/evaluation/runs/claim")
+async def claim_evaluation_run(
+    payload: EvaluationRunLeaseRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    run = await EvaluationService(session).claim_next_run(
+        tenant_id=auth.tenant_id,
+        worker_id=payload.worker_id,
+        lease_seconds=payload.lease_seconds,
+    )
+    return success_response(data=evaluation_run_payload(run) if run else None, message="Evaluation run claim checked")
+
+
+@router.post("/evaluation/runs/{run_id}/heartbeat")
+async def heartbeat_evaluation_run(
+    run_id: UUID,
+    payload: EvaluationRunLeaseRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        run = await EvaluationService(session).heartbeat_run(
+            tenant_id=auth.tenant_id,
+            run_id=run_id,
+            worker_id=payload.worker_id,
+            lease_seconds=payload.lease_seconds,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=evaluation_run_payload(run), message="Evaluation run heartbeat recorded")
+
+
+@router.post("/evaluation/runs/{run_id}/stop")
+async def request_evaluation_run_stop(
+    run_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        run = await EvaluationService(session).request_run_stop(
+            tenant_id=auth.tenant_id,
+            run_id=run_id,
+            actor_id=str(auth.user_id),
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=evaluation_run_payload(run), message="Evaluation run stop requested")
+
+
+@router.post("/evaluation/runs/{run_id}/artifacts", status_code=status.HTTP_201_CREATED)
+async def record_evaluation_run_artifact(
+    run_id: UUID,
+    payload: EvaluationArtifactRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        artifact = await EvaluationService(session).record_run_artifact(
+            tenant_id=auth.tenant_id,
+            run_id=run_id,
+            artifact_type=payload.artifact_type,
+            uri=payload.uri,
+            content=payload.content,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=evaluation_artifact_payload(artifact), message="Evaluation run artifact recorded")
+
+
+@router.post("/evaluation/runs/{run_id}/complete")
+async def complete_evaluation_run(
+    run_id: UUID,
+    payload: EvaluationCompleteRunRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        run = await EvaluationService(session).complete_run_with_case_results(
+            tenant_id=auth.tenant_id,
+            run_id=run_id,
+            worker_id=payload.worker_id,
+            case_results=payload.case_results,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=evaluation_run_payload(run), message="Evaluation run completed")
+
+
+@router.post("/evaluation/advisor-change-sets/{change_set_id}/promotion-decision")
+async def decide_evaluation_promotion(
+    change_set_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        promotion = await EvaluationService(session).decide_promotion(
+            tenant_id=auth.tenant_id,
+            change_set_id=change_set_id,
+            actor_id=str(auth.user_id),
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=promotion_payload(promotion), message="Evaluation promotion decision recorded")
+
+
+@router.get("/evaluation/advisor-change-sets/{change_set_id}/review")
+async def review_evaluation_advisor_change_set(
+    change_set_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        review = await EvaluationService(session).get_advisor_review(
+            tenant_id=auth.tenant_id,
+            change_set_id=change_set_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=_advisor_review_payload(review), message="Advisor change set reviewed")
+
+
+@router.post("/evaluation/advisor-change-sets/{change_set_id}/verification", status_code=status.HTTP_202_ACCEPTED)
+async def run_evaluation_advisor_verification(
+    change_set_id: UUID,
+    payload: EvaluationAdvisorGateRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        change_set, run = await EvaluationService(session).create_advisor_gate_run(
+            tenant_id=auth.tenant_id,
+            change_set_id=change_set_id,
+            gate_kind="verification",
+            target_snapshot_payload=payload.target_snapshot,
+            actor_id=str(auth.user_id),
+            idempotency_key=payload.idempotency_key,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={"change_set": advisor_change_set_payload(change_set), "run": evaluation_run_payload(run)},
+        message="Advisor verification run queued",
+    )
+
+
+@router.post("/evaluation/advisor-change-sets/{change_set_id}/regression", status_code=status.HTTP_202_ACCEPTED)
+async def run_evaluation_advisor_regression(
+    change_set_id: UUID,
+    payload: EvaluationAdvisorGateRequest,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        change_set, run = await EvaluationService(session).create_advisor_gate_run(
+            tenant_id=auth.tenant_id,
+            change_set_id=change_set_id,
+            gate_kind="regression",
+            target_snapshot_payload=payload.target_snapshot,
+            actor_id=str(auth.user_id),
+            idempotency_key=payload.idempotency_key,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={"change_set": advisor_change_set_payload(change_set), "run": evaluation_run_payload(run)},
+        message="Advisor regression run queued",
+    )
+
+
+@router.post("/evaluation/advisor-change-sets/{change_set_id}/apply")
+async def apply_evaluation_advisor_change_set(
+    change_set_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        promotion = await EvaluationService(session).decide_promotion(
+            tenant_id=auth.tenant_id,
+            change_set_id=change_set_id,
+            actor_id=str(auth.user_id),
+        )
+        review = await EvaluationService(session).get_advisor_review(
+            tenant_id=auth.tenant_id,
+            change_set_id=change_set_id,
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(
+        data={"promotion": promotion_payload(promotion), "review": _advisor_review_payload(review)},
+        message="Advisor apply decision recorded",
+    )
+
+
+@router.post("/evaluation/feedback/conversation-evaluations/{evaluation_id}/case-draft")
+async def create_case_draft_from_conversation_evaluation(
+    evaluation_id: UUID,
+    payload: EvaluationFeedbackCaseDraftRequest,
+    response: Response,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        case, created = await EvaluationService(session).promote_conversation_evaluation_to_case_draft(
+            tenant_id=auth.tenant_id,
+            evaluation_id=evaluation_id,
+            suite_version_id=payload.suite_version_id,
+            question=payload.question,
+            tags=payload.tags,
+            actor_id=str(auth.user_id),
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    response.status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+    return success_response(
+        data={"case": evaluation_case_payload(case), "created": created},
+        message="Evaluation case draft created from feedback",
+    )
+
+
+@router.post("/evaluation/skill-suggestions/{suggestion_id}/advisor-change-set")
+async def create_advisor_change_set_from_skill_suggestion(
+    suggestion_id: UUID,
+    payload: EvaluationSkillSuggestionAdvisorRequest,
+    response: Response,
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        change_set, suggestions, created = await EvaluationService(session).create_advisor_change_set_from_skill_suggestion(
+            tenant_id=auth.tenant_id,
+            suggestion_id=suggestion_id,
+            suite_version_id=payload.suite_version_id,
+            affected_case_ids=payload.affected_case_ids,
+            actor_id=str(auth.user_id),
+        )
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    response.status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+    return success_response(
+        data={
+            "change_set": advisor_change_set_payload(change_set),
+            "advisor_suggestions": [advisor_suggestion_payload(suggestion) for suggestion in suggestions],
+            "created": created,
+        },
+        message="Advisor change set created from skill suggestion",
+    )

--- a/server/routers/exports.py
+++ b/server/routers/exports.py
@@ -4,20 +4,28 @@ from fastapi.responses import JSONResponse, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from server.auth.dependencies import AuthContext, require_scope
+from server.auth.object_authorizer import NotebookAction, authorize_notebook_action
 from server.auth.scopes import Scope
 from server.db.session import get_async_session
 from server.schemas.notebook_export import ShareNotebookJsonRequest
 from server.schemas.standard_response import success_response
 from server.services.export_service import CompiledHtmlExportService
-from server.services.notebook import NotebookService
 from server.services.notebook_export_service import NotebookExportService
 from server.services.settings import SettingsService
+from server.services.sharing import SharingService
 from server.utils.config_loader import get_waitlist_config
 from server.utils.custom_logger import get_logger
 from server.utils.deployment import is_feature_enabled
+from server.utils.error_sanitizer import sanitize_error_message, sanitize_text
 
 router = APIRouter()
 logger = get_logger(__name__)
+
+
+def _log_worker_error(response: httpx.Response | object) -> None:
+    status_code = getattr(response, "status_code", "unknown")
+    body = sanitize_text(str(getattr(response, "text", "")))
+    logger.error(f"Worker returned error: {status_code} - {body}")
 
 
 def get_worker_url() -> str:
@@ -57,9 +65,12 @@ async def export_pdf(
 
     from server.services.pdf_service import PDFService, PDFServiceError
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.EXPORT,
+    )
 
     try:
         from uuid import UUID
@@ -74,7 +85,7 @@ async def export_pdf(
 
     except PDFServiceError as e:
         logger.error(
-            f"Failed to generate PDF: {str(e)}",
+            f"Failed to generate PDF: {sanitize_error_message(e)}",
             posthog_context={
                 "function": "export_pdf",
                 "notebook_id": notebook_id,
@@ -82,22 +93,24 @@ async def export_pdf(
             },
         )
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to generate PDF: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate PDF: {sanitize_error_message(e)}",
         )
     except ValueError as e:
         logger.error(
-            f"Invalid notebook ID: {str(e)}",
+            f"Invalid notebook ID: {sanitize_error_message(e)}",
             posthog_context={"function": "export_pdf", "notebook_id": notebook_id},
         )
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
     except Exception as e:
         logger.error(
-            f"Error generating PDF: {str(e)}",
+            f"Error generating PDF: {sanitize_error_message(e)}",
             exc_info=True,
             posthog_context={"function": "export_pdf", "notebook_id": notebook_id, "version": version},
         )
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to generate PDF: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate PDF: {sanitize_error_message(e)}",
         )
 
 
@@ -116,10 +129,12 @@ async def export_compiled_html(
     - Works without a backend API
     - Can be opened in any browser
     """
-    # Verify notebook exists
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.EXPORT,
+    )
 
     try:
         # Generate compiled HTML with embedded data
@@ -136,7 +151,7 @@ async def export_compiled_html(
 
     except ValueError as e:
         logger.error(
-            f"Failed to generate compiled HTML: {str(e)}",
+            f"Failed to generate compiled HTML: {sanitize_error_message(e)}",
             posthog_context={
                 "function": "export_compiled_html",
                 "notebook_id": notebook_id,
@@ -147,11 +162,12 @@ async def export_compiled_html(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:
         logger.error(
-            f"Error generating compiled HTML: {str(e)}",
+            f"Error generating compiled HTML: {sanitize_error_message(e)}",
             posthog_context={"function": "export_compiled_html", "notebook_id": notebook_id, "version": version},
         )
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to generate compiled HTML: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate compiled HTML: {sanitize_error_message(e)}",
         )
 
 
@@ -161,7 +177,7 @@ async def share_notebook(
     version: int | None = None,
     password: str | None = None,
     update_password: bool = False,
-    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
     session: AsyncSession = Depends(get_async_session),
 ):
     """
@@ -178,9 +194,12 @@ async def share_notebook(
     if not api_key_setting:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.SHARE_MANAGE,
+    )
 
     try:
         worker_url = get_worker_url()
@@ -212,10 +231,20 @@ async def share_notebook(
             )
 
         if response.status_code != 200:
-            logger.error(f"Worker returned error: {response.status_code} - {response.text}")
+            _log_worker_error(response)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create share link")
 
         data = response.json()
+        await SharingService(session).ensure_notebook_worker_grant(
+            tenant_id=auth.tenant_id,
+            actor_id=auth.user_id,
+            notebook_id=notebook_id,
+            legacy_surface="html_notebook_share",
+            legacy_id=notebook_id,
+            has_password=bool(data.get("has_password", bool(password and password.strip()))),
+            password=password.strip() if password and password.strip() else None,
+            metadata={"version": version, "share_url": f"https://www.byaan.ai/share/{notebook_id}"},
+        )
         is_update = not data.get("is_new", True)
         return success_response(
             data={
@@ -227,7 +256,7 @@ async def share_notebook(
         )
 
     except httpx.ConnectError as e:
-        logger.error(f"Error sharing notebook: {str(e)}")
+        logger.error(f"Error sharing notebook: {sanitize_error_message(e)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to connect to sharing service. Please check your network connection.",
@@ -235,9 +264,10 @@ async def share_notebook(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error sharing notebook: {str(e)}")
+        logger.error(f"Error sharing notebook: {sanitize_error_message(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to share notebook: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to share notebook: {sanitize_error_message(e)}",
         ) from e
 
 
@@ -253,9 +283,12 @@ async def get_notebook_share(
     if not api_key_setting:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.SHARE_MANAGE,
+    )
 
     try:
         worker_url = get_worker_url()
@@ -271,7 +304,7 @@ async def get_notebook_share(
             return success_response(data={"share": None}, message="No share exists")
 
         if response.status_code != 200:
-            logger.error(f"Worker returned error: {response.status_code} - {response.text}")
+            _log_worker_error(response)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to get share")
 
         data = response.json()
@@ -281,13 +314,12 @@ async def get_notebook_share(
             "created_at": data.get("created_at"),
             "updated_at": data.get("updated_at"),
             "has_password": data.get("has_password", False),
-            "password": data.get("password"),
         }
 
         return success_response(data={"share": share}, message="Share retrieved")
 
     except httpx.ConnectError as e:
-        logger.error(f"Error getting share: {str(e)}")
+        logger.error(f"Error getting share: {sanitize_error_message(e)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to connect to sharing service.",
@@ -295,16 +327,17 @@ async def get_notebook_share(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error getting share: {str(e)}")
+        logger.error(f"Error getting share: {sanitize_error_message(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to get share: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get share: {sanitize_error_message(e)}",
         ) from e
 
 
 @router.delete("/notebooks/{notebook_id}/share")
 async def delete_share(
     notebook_id: str,
-    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
     session: AsyncSession = Depends(get_async_session),
 ):
     """Delete the share for a notebook (single share per notebook, uses notebook_id as share_id)."""
@@ -313,9 +346,12 @@ async def delete_share(
     if not api_key_setting:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.SHARE_MANAGE,
+    )
 
     try:
         worker_url = get_worker_url()
@@ -330,13 +366,20 @@ async def delete_share(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
 
         if response.status_code != 200:
-            logger.error(f"Worker returned error: {response.status_code} - {response.text}")
+            _log_worker_error(response)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete share")
 
+        await SharingService(session).revoke_legacy_grant(
+            tenant_id=auth.tenant_id,
+            legacy_surface="html_notebook_share",
+            legacy_id=notebook_id,
+            actor_id=auth.user_id,
+            reason="worker html notebook share deleted",
+        )
         return success_response(data=None, message="Share deleted")
 
     except httpx.ConnectError as e:
-        logger.error(f"Error deleting share: {str(e)}")
+        logger.error(f"Error deleting share: {sanitize_error_message(e)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to connect to sharing service.",
@@ -344,9 +387,10 @@ async def delete_share(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting share: {str(e)}")
+        logger.error(f"Error deleting share: {sanitize_error_message(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to delete share: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to delete share: {sanitize_error_message(e)}",
         ) from e
 
 
@@ -372,9 +416,12 @@ async def export_notebook_json(
 
     The exported JSON can be shared manually or imported into another Byaan instance.
     """
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.EXPORT,
+    )
 
     try:
         export_data = await NotebookExportService.export_notebook(session, notebook_id)
@@ -390,7 +437,7 @@ async def export_notebook_json(
 
     except ValueError as e:
         logger.error(
-            f"Failed to export notebook JSON: {str(e)}",
+            f"Failed to export notebook JSON: {sanitize_error_message(e)}",
             posthog_context={
                 "function": "export_notebook_json",
                 "notebook_id": notebook_id,
@@ -400,11 +447,12 @@ async def export_notebook_json(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except Exception as e:
         logger.error(
-            f"Error exporting notebook JSON: {str(e)}",
+            f"Error exporting notebook JSON: {sanitize_error_message(e)}",
             posthog_context={"function": "export_notebook_json", "notebook_id": notebook_id},
         )
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to export notebook: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to export notebook: {sanitize_error_message(e)}",
         )
 
 
@@ -412,7 +460,7 @@ async def export_notebook_json(
 async def share_notebook_json(
     notebook_id: str,
     request: ShareNotebookJsonRequest | None = None,
-    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
     session: AsyncSession = Depends(get_async_session),
 ):
     """
@@ -433,9 +481,12 @@ async def share_notebook_json(
     if not api_key_setting:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.SHARE_MANAGE,
+    )
 
     try:
         # Export notebook to JSON format
@@ -461,17 +512,27 @@ async def share_notebook_json(
             )
 
         if response.status_code != 200:
-            logger.error(f"Worker returned error: {response.status_code} - {response.text}")
+            _log_worker_error(response)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create share link")
 
         data = response.json()
+        await SharingService(session).ensure_notebook_worker_grant(
+            tenant_id=auth.tenant_id,
+            actor_id=auth.user_id,
+            notebook_id=notebook_id,
+            legacy_surface="json_notebook_share",
+            legacy_id=str(data["id"]),
+            has_password=bool(request and request.password and request.password.strip()),
+            password=request.password.strip() if request and request.password and request.password.strip() else None,
+            metadata={"share_id": str(data["id"])},
+        )
         return success_response(
             data={"share_id": data["id"]},
             message="Notebook shared successfully",
         )
 
     except httpx.ConnectError as e:
-        logger.error(f"Error sharing notebook JSON: {str(e)}")
+        logger.error(f"Error sharing notebook JSON: {sanitize_error_message(e)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to connect to sharing service. Please check your network connection.",
@@ -479,16 +540,17 @@ async def share_notebook_json(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error sharing notebook JSON: {str(e)}")
+        logger.error(f"Error sharing notebook JSON: {sanitize_error_message(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to share notebook: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to share notebook: {sanitize_error_message(e)}",
         ) from e
 
 
 @router.get("/notebooks/{notebook_id}/shares/notebook")
 async def list_notebook_json_shares(
     notebook_id: str,
-    auth: AuthContext = Depends(require_scope(Scope.NOTEBOOK_READ_OWN)),
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
     session: AsyncSession = Depends(get_async_session),
 ):
     """List all JSON shares for a notebook."""
@@ -497,9 +559,12 @@ async def list_notebook_json_shares(
     if not api_key_setting:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.SHARE_MANAGE,
+    )
 
     try:
         worker_url = get_worker_url()
@@ -511,7 +576,7 @@ async def list_notebook_json_shares(
             )
 
         if response.status_code != 200:
-            logger.error(f"Worker returned error: {response.status_code} - {response.text}")
+            _log_worker_error(response)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list shares")
 
         data = response.json()
@@ -521,7 +586,6 @@ async def list_notebook_json_shares(
                 "id": share["id"],
                 "created_at": share["created_at"],
                 "has_password": share.get("has_password", False),
-                "password": share.get("password"),
             }
             for share in data.get("shares", [])
         ]
@@ -529,7 +593,7 @@ async def list_notebook_json_shares(
         return success_response(data={"shares": shares}, message="Shares retrieved")
 
     except httpx.ConnectError as e:
-        logger.error(f"Error listing JSON shares: {str(e)}")
+        logger.error(f"Error listing JSON shares: {sanitize_error_message(e)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to connect to sharing service.",
@@ -537,9 +601,10 @@ async def list_notebook_json_shares(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error listing JSON shares: {str(e)}")
+        logger.error(f"Error listing JSON shares: {sanitize_error_message(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to list shares: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list shares: {sanitize_error_message(e)}",
         ) from e
 
 
@@ -548,7 +613,7 @@ async def update_notebook_json_share_password(
     notebook_id: str,
     share_id: str,
     password: str | None = None,
-    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
     session: AsyncSession = Depends(get_async_session),
 ):
     """Update or remove password for a notebook JSON share."""
@@ -557,9 +622,12 @@ async def update_notebook_json_share_password(
     if not api_key_setting:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.SHARE_MANAGE,
+    )
 
     try:
         worker_url = get_worker_url()
@@ -575,7 +643,7 @@ async def update_notebook_json_share_password(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
 
         if response.status_code != 200:
-            logger.error(f"Worker returned error: {response.status_code} - {response.text}")
+            _log_worker_error(response)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update password")
 
         data = response.json()
@@ -585,7 +653,7 @@ async def update_notebook_json_share_password(
         )
 
     except httpx.ConnectError as e:
-        logger.error(f"Error updating share password: {str(e)}")
+        logger.error(f"Error updating share password: {sanitize_error_message(e)}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Unable to connect to sharing service.",
@@ -593,9 +661,10 @@ async def update_notebook_json_share_password(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error updating share password: {str(e)}")
+        logger.error(f"Error updating share password: {sanitize_error_message(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to update password: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update password: {sanitize_error_message(e)}",
         ) from e
 
 
@@ -603,7 +672,7 @@ async def update_notebook_json_share_password(
 async def delete_notebook_json_share(
     notebook_id: str,
     share_id: str,
-    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_EXPORT)),
+    auth: AuthContext = Depends(require_scope(Scope.DASHBOARD_SHARE)),
     session: AsyncSession = Depends(get_async_session),
 ):
     """Delete a JSON share."""
@@ -612,9 +681,12 @@ async def delete_notebook_json_share(
     if not api_key_setting:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    notebook = await NotebookService.get_notebook(session, notebook_id)
-    if notebook is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notebook not found")
+    await authorize_notebook_action(
+        session=session,
+        auth=auth,
+        notebook_id=notebook_id,
+        action=NotebookAction.SHARE_MANAGE,
+    )
 
     try:
         worker_url = get_worker_url()
@@ -629,9 +701,16 @@ async def delete_notebook_json_share(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
 
         if response.status_code != 200:
-            logger.error(f"Worker returned error: {response.status_code} - {response.text}")
+            _log_worker_error(response)
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete share")
 
+        await SharingService(session).revoke_legacy_grant(
+            tenant_id=auth.tenant_id,
+            legacy_surface="json_notebook_share",
+            legacy_id=share_id,
+            actor_id=auth.user_id,
+            reason="worker json notebook share deleted",
+        )
         return success_response(data=None, message="Share deleted")
 
     except httpx.ConnectError as e:

--- a/server/routers/semantic_models.py
+++ b/server/routers/semantic_models.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext, require_any_scope, require_scope
+from server.auth.scopes import Scope
+from server.db.session import get_async_session
+from server.schemas.semantic_models import SemanticModelCreate, SemanticModelPatch
+from server.schemas.standard_response import StandardResponse, success_response
+from server.services.semantic_model_service import SemanticModelService
+
+router = APIRouter()
+
+
+def _bad_request_or_not_found(error: ValueError) -> HTTPException:
+    message = str(error)
+    code = status.HTTP_404_NOT_FOUND if "not found" in message.lower() else status.HTTP_400_BAD_REQUEST
+    return HTTPException(status_code=code, detail=message)
+
+
+@router.post("/data-models", response_model=StandardResponse[dict], status_code=status.HTTP_201_CREATED)
+async def create_data_model(
+    payload: SemanticModelCreate,
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_CREATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        model = await SemanticModelService.create_model(
+            session=session,
+            tenant_id=auth.tenant_id,
+            user_id=auth.user_id,
+            payload=payload,
+        )
+        return success_response(data=SemanticModelService.model_to_payload(model), message="Data Model created")
+    except ValueError as error:
+        raise _bad_request_or_not_found(error)
+
+
+@router.get("/data-models", response_model=StandardResponse[dict])
+async def list_data_models(
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    items = await SemanticModelService.list_models(session=session, tenant_id=auth.tenant_id)
+    return success_response(data={"items": items, "total": len(items)}, message="Retrieved Data Models")
+
+
+@router.get("/data-models/{model_slug}", response_model=StandardResponse[dict])
+async def get_data_model(
+    model_slug: str,
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    model = await SemanticModelService.get_model(session=session, tenant_id=auth.tenant_id, slug=model_slug)
+    if model is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data Model not found")
+    return success_response(data=SemanticModelService.model_to_payload(model), message="Retrieved Data Model")
+
+
+@router.patch("/data-models/{model_slug}", response_model=StandardResponse[dict])
+async def update_data_model(
+    model_slug: str,
+    payload: SemanticModelPatch,
+    auth: AuthContext = Depends(require_any_scope(Scope.DATASET_UPDATE, Scope.DATASET_UPDATE_OWN)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        model = await SemanticModelService.update_model(
+            session=session,
+            tenant_id=auth.tenant_id,
+            slug=model_slug,
+            user_id=auth.user_id,
+            payload=payload,
+        )
+    except RuntimeError as error:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error))
+    except ValueError as error:
+        raise _bad_request_or_not_found(error)
+    if model is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data Model not found")
+    return success_response(data=SemanticModelService.model_to_payload(model), message="Data Model updated")
+
+
+@router.post("/data-models/{model_slug}/validate", response_model=StandardResponse[dict])
+async def validate_data_model(
+    model_slug: str,
+    auth: AuthContext = Depends(require_any_scope(Scope.DATASET_UPDATE, Scope.DATASET_UPDATE_OWN)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    model = await SemanticModelService.validate_model(
+        session=session,
+        tenant_id=auth.tenant_id,
+        slug=model_slug,
+        user_id=auth.user_id,
+    )
+    if model is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data Model not found")
+    return success_response(
+        data=SemanticModelService.model_to_payload(model), message="Data Model validation is partial"
+    )
+
+
+@router.post("/data-models/{model_slug}/publish", response_model=StandardResponse[dict])
+async def publish_data_model(
+    model_slug: str,
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_UPDATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        model = await SemanticModelService.publish_model(session=session, tenant_id=auth.tenant_id, slug=model_slug)
+    except RuntimeError as error:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error))
+    if model is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data Model not found")
+    return success_response(data=SemanticModelService.model_to_payload(model), message="Data Model published")
+
+
+@router.post("/data-models/{model_slug}/mcp/query_metric", response_model=StandardResponse[dict])
+async def query_data_model_metric(
+    model_slug: str,
+    auth: AuthContext = Depends(require_scope(Scope.QUERY_EXECUTE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        model = await SemanticModelService.query_metric(session=session, tenant_id=auth.tenant_id, slug=model_slug)
+    except RuntimeError as error:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error))
+    if model is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data Model not found")
+    return success_response(data=SemanticModelService.model_to_payload(model), message="Semantic metric query executed")
+
+
+@router.get("/semantic-models", response_model=StandardResponse[dict])
+async def list_semantic_models(
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    items = await SemanticModelService.list_models(session=session, tenant_id=auth.tenant_id)
+    return success_response(data={"items": items, "total": len(items)}, message="Retrieved semantic models")
+
+
+@router.get("/semantic-models/{model_slug}", response_model=StandardResponse[dict])
+async def get_semantic_model(
+    model_slug: str,
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    model = await SemanticModelService.get_model(session=session, tenant_id=auth.tenant_id, slug=model_slug)
+    if model is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Semantic model not found")
+    return success_response(data=SemanticModelService.model_to_payload(model), message="Retrieved semantic model")

--- a/server/routers/sharing.py
+++ b/server/routers/sharing.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext, require_scope
+from server.auth.scopes import Scope
+from server.db.session import get_async_session
+from server.schemas.standard_response import success_response
+from server.serializers.sharing import sharing_grant_evidence_payload, sharing_grant_payload
+from server.services.sharing import SharingService
+
+router = APIRouter()
+
+
+def _service_error(exc: ValueError) -> HTTPException:
+    detail = str(exc)
+    if "not found" in detail:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+@router.get("/sharing/grants")
+async def list_sharing_grants(
+    object_type: str | None = None,
+    object_id: UUID | None = None,
+    legacy_surface: str | None = None,
+    status_filter: str | None = Query(default=None, alias="status"),
+    limit: int = 50,
+    auth: AuthContext = Depends(require_scope(Scope.SHARING_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    grants = await SharingService(session).list_grants(
+        tenant_id=auth.tenant_id,
+        object_type=object_type,
+        object_id=object_id,
+        legacy_surface=legacy_surface,
+        status=status_filter,
+        limit=limit,
+    )
+    return success_response(
+        data={"items": [sharing_grant_payload(grant) for grant in grants], "total": len(grants)},
+        message="Sharing grants listed",
+    )
+
+
+@router.get("/sharing/grants/{grant_id}")
+async def describe_sharing_grant(
+    grant_id: UUID,
+    auth: AuthContext = Depends(require_scope(Scope.SHARING_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        evidence = await SharingService(session).grant_evidence(tenant_id=auth.tenant_id, grant_id=grant_id)
+    except ValueError as exc:
+        raise _service_error(exc) from exc
+    return success_response(data=sharing_grant_evidence_payload(evidence), message="Sharing grant described")

--- a/server/routers/source_connections.py
+++ b/server/routers/source_connections.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext, require_any_scope, require_scope
+from server.auth.scopes import Scope
+from server.db.session import get_async_session
+from server.schemas.source_connections import SourceConnectionCreate
+from server.schemas.standard_response import StandardResponse, success_response
+from server.services.source_connections import SourceConnectionService
+
+router = APIRouter()
+source_connection_service = SourceConnectionService()
+
+
+def _http_error(error: ValueError) -> HTTPException:
+    message = str(error)
+    code = status.HTTP_404_NOT_FOUND if "not found" in message.lower() else status.HTTP_400_BAD_REQUEST
+    return HTTPException(status_code=code, detail=message)
+
+
+@router.get("/connector-definitions", response_model=StandardResponse[dict])
+async def list_connector_definitions(
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+):
+    return success_response(
+        data=source_connection_service.list_connector_definitions(),
+        message="Retrieved connector definitions",
+    )
+
+
+@router.post("/source-connections", response_model=StandardResponse[dict], status_code=status.HTTP_201_CREATED)
+async def create_source_connection(
+    payload: SourceConnectionCreate,
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_CREATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        connection = await source_connection_service.create_connection(
+            session=session,
+            tenant_id=auth.tenant_id,
+            user_id=auth.user_id,
+            payload=payload,
+        )
+        return success_response(
+            data=source_connection_service.connection_payload(connection),
+            message="Source connection created",
+        )
+    except ValueError as error:
+        raise _http_error(error)
+
+
+@router.get("/source-connections", response_model=StandardResponse[dict])
+async def list_source_connections(
+    provider: str | None = Query(default=None),
+    auth: AuthContext = Depends(require_scope(Scope.CONNECTION_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    connections = await source_connection_service.list_connections(
+        session=session,
+        tenant_id=auth.tenant_id,
+        provider=provider,
+        user_id=auth.user_id,
+        include_all=auth.is_admin,
+    )
+    items = [source_connection_service.connection_payload(connection) for connection in connections]
+    return success_response(data={"items": items, "total": len(items)}, message="Retrieved source connections")
+
+
+@router.delete("/source-connections/{connection_id}", response_model=StandardResponse[dict])
+async def delete_source_connection(
+    connection_id: str,
+    auth: AuthContext = Depends(require_any_scope(Scope.CONNECTION_DELETE, Scope.CONNECTION_DELETE_OWN)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    ok, resource_count = await source_connection_service.delete_connection(
+        session=session,
+        tenant_id=auth.tenant_id,
+        connection_id=connection_id,
+        user_id=auth.user_id,
+        include_all=auth.has_scope(Scope.CONNECTION_DELETE),
+    )
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Source connection not found")
+    return success_response(
+        data={"deleted": True, "affected_resource_count": resource_count},
+        message="Source connection disconnected",
+    )

--- a/server/routers/source_resources.py
+++ b/server/routers/source_resources.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.auth.dependencies import AuthContext, require_any_scope, require_scope
+from server.auth.scopes import Scope
+from server.db.session import get_async_session
+from server.schemas.source_resources import SourceResourceCreate, SourceResourceRead, SourceResourceSyncRequest
+from server.schemas.standard_response import StandardResponse, success_response
+from server.services.source_resources import SourceResourceService
+
+router = APIRouter()
+source_resource_service = SourceResourceService()
+
+
+def _bad_request_or_not_found(error: ValueError) -> HTTPException:
+    message = str(error)
+    code = status.HTTP_404_NOT_FOUND if "not found" in message.lower() else status.HTTP_400_BAD_REQUEST
+    return HTTPException(status_code=code, detail=message)
+
+
+@router.post(
+    "/source-resources",
+    response_model=StandardResponse[SourceResourceRead],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_source_resource(
+    payload: SourceResourceCreate,
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_CREATE)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        data = await source_resource_service.create_resource(
+            session=session,
+            tenant_id=auth.tenant_id,
+            user_id=auth.user_id,
+            payload=payload,
+            include_all_connections=auth.is_admin,
+        )
+        return success_response(data=data, message="Source resource created")
+    except ValueError as error:
+        raise _bad_request_or_not_found(error)
+
+
+@router.get("/source-resources", response_model=StandardResponse[dict])
+async def list_source_resources(
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    items = await source_resource_service.list_resources(session=session, tenant_id=auth.tenant_id)
+    return success_response(data={"items": items, "total": len(items)}, message="Retrieved source resources")
+
+
+@router.get("/source-resources/{resource_id}", response_model=StandardResponse[SourceResourceRead])
+async def get_source_resource(
+    resource_id: str,
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    resource = await source_resource_service.get_resource(
+        session=session,
+        tenant_id=auth.tenant_id,
+        resource_id=resource_id,
+    )
+    if resource is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Source resource not found")
+    data = await source_resource_service.resource_payload(session=session, resource=resource)
+    return success_response(data=data, message="Retrieved source resource")
+
+
+@router.get("/source-resources/{resource_id}/snapshots", response_model=StandardResponse[dict])
+async def list_source_resource_snapshots(
+    resource_id: str,
+    auth: AuthContext = Depends(require_scope(Scope.DATASET_READ)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        data = await source_resource_service.list_snapshots(
+            session=session,
+            tenant_id=auth.tenant_id,
+            resource_id=resource_id,
+        )
+        return success_response(data=data, message="Retrieved source resource snapshots")
+    except ValueError as error:
+        raise _bad_request_or_not_found(error)
+
+
+@router.post("/source-resources/{resource_id}/sync", response_model=StandardResponse[SourceResourceRead])
+async def sync_source_resource(
+    resource_id: str,
+    payload: SourceResourceSyncRequest,
+    auth: AuthContext = Depends(require_any_scope(Scope.DATASET_UPDATE, Scope.DATASET_UPDATE_OWN)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    try:
+        data = await source_resource_service.sync_resource(
+            session=session,
+            tenant_id=auth.tenant_id,
+            resource_id=resource_id,
+            payload=payload,
+            user_id=auth.user_id,
+            include_all=auth.has_scope(Scope.DATASET_UPDATE),
+        )
+        return success_response(data=data, message="Source resource sync accepted")
+    except ValueError as error:
+        raise _bad_request_or_not_found(error)
+    except PermissionError as error:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(error))
+
+
+@router.delete("/source-resources/{resource_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_source_resource(
+    resource_id: str,
+    auth: AuthContext = Depends(require_any_scope(Scope.DATASET_DELETE, Scope.DATASET_DELETE_OWN)),
+    session: AsyncSession = Depends(get_async_session),
+):
+    resource = await source_resource_service.get_resource(
+        session=session,
+        tenant_id=auth.tenant_id,
+        resource_id=resource_id,
+    )
+    if resource is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Source resource not found")
+    if not auth.has_scope(Scope.DATASET_DELETE):
+        if resource.owner_id is None or str(resource.owner_id) != str(auth.user_id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only delete source resources you created",
+            )
+    await source_resource_service.delete_resource(
+        session=session,
+        tenant_id=auth.tenant_id,
+        resource_id=resource_id,
+    )

--- a/server/schemas/dashboard.py
+++ b/server/schemas/dashboard.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+DashboardManifestSchemaVersion = Literal["dashboard.manifest.v1"]
+DashboardRunContractVersion = Literal["dashboard.run.v1"]
+
+DashboardActorType = Literal["human", "agent", "service"]
+DashboardDataViewKind = Literal["semantic_metric", "saved_query", "context_search"]
+DashboardTileType = Literal["kpi", "line", "bar", "area", "table", "text", "evidence", "status"]
+DashboardRunMode = Literal["live", "pinned_snapshot"]
+DashboardSensitivity = Literal["public", "internal", "confidential", "restricted"]
+DashboardFreshnessStatus = Literal["fresh", "stale", "unknown", "partial", "blocked"]
+DashboardMigrationState = Literal["new_structured", "legacy_unstructured", "candidate", "needs_review", "reviewed"]
+DashboardFilterType = Literal["string", "number", "integer", "boolean", "date", "datetime", "enum", "date_range"]
+DashboardFilterOperator = Literal["eq", "ne", "gt", "lt", "gte", "lte", "in", "between", "contains", "like"]
+DashboardViewStatus = Literal[
+    "pending",
+    "running",
+    "success",
+    "empty",
+    "partial",
+    "stale",
+    "permission_denied",
+    "error",
+    "blocked",
+]
+DashboardScope = Literal[
+    "dashboard:read",
+    "dashboard:query",
+    "dashboard:create",
+    "dashboard:edit",
+    "dashboard:publish",
+    "dashboard:share",
+    "dashboard:export",
+]
+
+
+class DashboardStrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class DashboardOutputField(DashboardStrictModel):
+    name: str = Field(min_length=1)
+    data_type: str = Field(min_length=1)
+    description: str = ""
+    unit: str | None = None
+    nullable: bool = True
+    sensitivity: DashboardSensitivity = "internal"
+
+
+class DashboardEvidenceLocator(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    kind: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    locator: dict[str, Any] = Field(default_factory=dict)
+    confidence: float | None = Field(default=None, ge=0, le=1)
+
+
+class DashboardLineageRef(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    kind: Literal["dashboard", "tile", "data_view", "metric", "saved_query", "semantic_model", "source_snapshot"]
+    name: str = Field(min_length=1)
+    ref: str = Field(min_length=1)
+    version: str | None = None
+
+
+class DashboardFreshnessPolicy(DashboardStrictModel):
+    mode: Literal["live", "cache_first", "pinned_snapshot"] = "live"
+    max_age_seconds: int = Field(default=3600, ge=0)
+    allow_stale: bool = True
+    require_as_of: bool = True
+
+
+class DashboardAccessPolicy(DashboardStrictModel):
+    required_scopes: list[DashboardScope] = Field(default_factory=lambda: ["dashboard:read", "dashboard:query"])
+    row_policy_refs: list[str] = Field(default_factory=list)
+    column_policy_refs: list[str] = Field(default_factory=list)
+    redaction_policy_refs: list[str] = Field(default_factory=list)
+
+
+class DashboardSemanticBinding(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    model_slug: str = Field(min_length=1)
+    model_version: str = Field(min_length=1)
+    source_snapshot_ids: list[str] = Field(default_factory=list)
+    allowed_metrics: list[str] = Field(default_factory=list)
+    allowed_dimensions: list[str] = Field(default_factory=list)
+    readiness: Literal["published", "blocked"] = "published"
+
+    @model_validator(mode="after")
+    def require_published_binding(self) -> DashboardSemanticBinding:
+        if self.readiness != "published":
+            raise ValueError("dashboard semantic bindings must pin published model versions")
+        return self
+
+
+class DashboardSavedQueryBinding(DashboardStrictModel):
+    query_id: str = Field(min_length=1)
+    compatibility_reason: str = Field(min_length=1)
+    filter_contract: dict[str, Any] = Field(default_factory=dict)
+    lineage: list[DashboardLineageRef] = Field(default_factory=list)
+
+
+class DashboardSemanticMetricBinding(DashboardStrictModel):
+    semantic_binding_id: str = Field(min_length=1)
+    metric: str = Field(min_length=1)
+    dimensions: list[str] = Field(default_factory=list)
+    grain: str | None = None
+    sort: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DashboardContextSearchBinding(DashboardStrictModel):
+    source_binding_id: str = Field(min_length=1)
+    query_template: str = Field(min_length=1)
+    evidence_required: bool = True
+
+
+class DashboardDataView(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    kind: DashboardDataViewKind
+    question: str = Field(min_length=1)
+    output_schema: list[DashboardOutputField] = Field(default_factory=list)
+    filter_fields: list[str] = Field(default_factory=list)
+    sensitivity: DashboardSensitivity = "internal"
+    row_limit: int = Field(default=500, ge=1, le=5000)
+    byte_limit: int = Field(default=1_000_000, ge=1024, le=10_000_000)
+    timeout_seconds: int = Field(default=30, ge=1, le=300)
+    freshness_policy: DashboardFreshnessPolicy = Field(default_factory=DashboardFreshnessPolicy)
+    evidence: list[DashboardEvidenceLocator] = Field(default_factory=list)
+    lineage: list[DashboardLineageRef] = Field(default_factory=list)
+    semantic_metric: DashboardSemanticMetricBinding | None = None
+    saved_query: DashboardSavedQueryBinding | None = None
+    context_search: DashboardContextSearchBinding | None = None
+
+    @model_validator(mode="after")
+    def require_kind_binding(self) -> DashboardDataView:
+        bindings = {
+            "semantic_metric": self.semantic_metric,
+            "saved_query": self.saved_query,
+            "context_search": self.context_search,
+        }
+        if bindings[self.kind] is None:
+            raise ValueError(f"{self.kind} data views require a matching binding payload")
+        unexpected = [kind for kind, value in bindings.items() if kind != self.kind and value is not None]
+        if unexpected:
+            raise ValueError(f"{self.kind} data views cannot include {', '.join(unexpected)} bindings")
+        return self
+
+
+class DashboardFilter(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    source: Literal["semantic_field", "saved_query_contract"]
+    field: str = Field(min_length=1)
+    filter_type: DashboardFilterType
+    operators: list[DashboardFilterOperator] = Field(min_length=1)
+    affected_data_view_ids: list[str] = Field(default_factory=list)
+    default_value: Any = None
+    required: bool = False
+    domain: list[Any] | None = None
+    timezone: str | None = None
+
+
+class DashboardTileAccessibleFallback(DashboardStrictModel):
+    summary: str = ""
+    table_fields: list[str] = Field(default_factory=list)
+
+
+class DashboardTile(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    tile_type: DashboardTileType
+    business_question: str = Field(min_length=1)
+    data_view_id: str | None = None
+    encoding: dict[str, Any] = Field(default_factory=dict)
+    formatting: dict[str, Any] = Field(default_factory=dict)
+    interactions: list[dict[str, Any]] = Field(default_factory=list)
+    accessible_fallback: DashboardTileAccessibleFallback = Field(default_factory=DashboardTileAccessibleFallback)
+
+    @model_validator(mode="after")
+    def require_data_view_for_data_tiles(self) -> DashboardTile:
+        if self.tile_type != "text" and not self.data_view_id:
+            raise ValueError(f"{self.tile_type} tiles require data_view_id")
+        return self
+
+
+class DashboardLayoutSection(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    title: str = ""
+    tile_ids: list[str] = Field(default_factory=list)
+
+
+class DashboardLayout(DashboardStrictModel):
+    sections: list[DashboardLayoutSection] = Field(default_factory=list)
+
+
+class DashboardAction(DashboardStrictModel):
+    id: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    action_type: Literal["drill", "export", "share", "reload", "publish"]
+    required_scope: DashboardScope
+    enabled: bool = True
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class DashboardProvenance(DashboardStrictModel):
+    created_by_actor_type: DashboardActorType
+    created_by: str = Field(min_length=1)
+    source: Literal["human", "agent", "migration", "import"]
+    evidence_refs: list[str] = Field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class DashboardMigration(DashboardStrictModel):
+    state: DashboardMigrationState = "new_structured"
+    legacy_dashboard_id: str | None = None
+    legacy_notebook_id: str | None = None
+    blockers: list[str] = Field(default_factory=list)
+    reviewed_by: str | None = None
+    reviewed_at: datetime | None = None
+
+
+class DashboardManifest(DashboardStrictModel):
+    schema_version: DashboardManifestSchemaVersion
+    dashboard_id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    description: str = ""
+    audience: list[str]
+    semantic_bindings: list[DashboardSemanticBinding]
+    data_views: list[DashboardDataView]
+    filters: list[DashboardFilter]
+    layout: DashboardLayout
+    tiles: list[DashboardTile]
+    actions: list[DashboardAction]
+    freshness_policy: DashboardFreshnessPolicy
+    access_policy: DashboardAccessPolicy
+    provenance: DashboardProvenance
+    migration: DashboardMigration
+
+    @model_validator(mode="after")
+    def validate_manifest_references(self) -> DashboardManifest:
+        data_view_ids = _unique_ids("data_views", [data_view.id for data_view in self.data_views])
+        tile_ids = _unique_ids("tiles", [tile.id for tile in self.tiles])
+        binding_ids = _unique_ids("semantic_bindings", [binding.id for binding in self.semantic_bindings])
+        _unique_ids("filters", [dashboard_filter.id for dashboard_filter in self.filters])
+
+        for data_view in self.data_views:
+            if data_view.semantic_metric and data_view.semantic_metric.semantic_binding_id not in binding_ids:
+                raise ValueError(f"data view {data_view.id} references unknown semantic binding")
+
+        for dashboard_filter in self.filters:
+            unknown_views = set(dashboard_filter.affected_data_view_ids) - data_view_ids
+            if unknown_views:
+                raise ValueError(f"filter {dashboard_filter.id} references unknown data views")
+
+        for tile in self.tiles:
+            if tile.data_view_id and tile.data_view_id not in data_view_ids:
+                raise ValueError(f"tile {tile.id} references unknown data view")
+
+        for section in self.layout.sections:
+            unknown_tiles = set(section.tile_ids) - tile_ids
+            if unknown_tiles:
+                raise ValueError(f"layout section {section.id} references unknown tiles")
+
+        return self
+
+
+class DashboardRunError(DashboardStrictModel):
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    retryable: bool = False
+    policy_reason: str | None = None
+
+
+class DashboardPagination(DashboardStrictModel):
+    cursor: str | None = None
+    has_more: bool = False
+    limit: int = Field(default=500, ge=1, le=5000)
+
+
+class DashboardRunViewResult(DashboardStrictModel):
+    data_view_id: str = Field(min_length=1)
+    status: DashboardViewStatus
+    result: list[dict[str, Any]] | dict[str, Any] | None = None
+    schema_: list[DashboardOutputField] = Field(default_factory=list, alias="schema")
+    row_count: int = Field(default=0, ge=0)
+    cached: bool = False
+    stale: bool = False
+    as_of: datetime | None = None
+    warnings: list[str] = Field(default_factory=list)
+    error: DashboardRunError | None = None
+    evidence: list[DashboardEvidenceLocator] = Field(default_factory=list)
+    lineage: list[DashboardLineageRef] = Field(default_factory=list)
+    pagination: DashboardPagination = Field(default_factory=DashboardPagination)
+    result_artifact_id: str | None = None
+
+
+class DashboardRun(DashboardStrictModel):
+    contract_version: DashboardRunContractVersion
+    run_id: str = Field(min_length=1)
+    dashboard_id: str = Field(min_length=1)
+    dashboard_version_id: str = Field(min_length=1)
+    actor_type: DashboardActorType
+    actor_id: str = Field(min_length=1)
+    correlation_id: str | None = None
+    session_id: str | None = None
+    idempotency_key: str | None = None
+    mode: DashboardRunMode = "live"
+    normalized_filters: dict[str, Any] = Field(default_factory=dict)
+    filter_digest: str = Field(min_length=1)
+    pinned_versions: dict[str, Any] = Field(default_factory=dict)
+    execution_plan_digest: str = Field(min_length=1)
+    started_at: datetime
+    completed_at: datetime | None = None
+    overall_freshness: DashboardFreshnessStatus = "unknown"
+    views: list[DashboardRunViewResult] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    errors: list[DashboardRunError] = Field(default_factory=list)
+    pagination: DashboardPagination = Field(default_factory=DashboardPagination)
+
+    @model_validator(mode="after")
+    def require_snapshot_artifacts(self) -> DashboardRun:
+        if self.mode != "pinned_snapshot":
+            return self
+        missing_artifacts = [
+            view.data_view_id
+            for view in self.views
+            if view.status not in {"blocked", "permission_denied", "error"} and not view.result_artifact_id
+        ]
+        if missing_artifacts:
+            raise ValueError("pinned_snapshot runs require immutable result_artifact_id for successful views")
+        return self
+
+
+def _unique_ids(collection_name: str, ids: list[str]) -> set[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for item_id in ids:
+        if item_id in seen:
+            duplicates.add(item_id)
+        seen.add(item_id)
+    if duplicates:
+        raise ValueError(f"{collection_name} contains duplicate ids: {', '.join(sorted(duplicates))}")
+    return seen

--- a/server/schemas/evaluation.py
+++ b/server/schemas/evaluation.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+import sqlglot
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+EvaluationCaseContractVersion = Literal["evaluation.case.v1"]
+EvaluationSuiteVersionContractVersion = Literal["evaluation.suite_version.v1"]
+EvaluationTargetSnapshotContractVersion = Literal["evaluation.target_snapshot.v1"]
+
+EvaluationTargetKind = Literal["connector", "semantic_model", "agent_answer", "dashboard", "policy", "end_to_end"]
+EvaluationOperation = Literal[
+    "answer_question",
+    "execute_sql",
+    "query_dashboard",
+    "apply_policy",
+    "end_to_end_task",
+]
+EvaluationActorType = Literal["human", "agent", "service"]
+EvaluationResultMode = Literal["ordered_rows", "multiset", "scalar", "invariants_only"]
+
+
+class EvaluationStrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class EvaluationSemanticIntent(EvaluationStrictModel):
+    metric: str | None = None
+    dimensions: list[str] = Field(default_factory=list)
+    grain: str | None = None
+    timezone: str | None = None
+    description: str = ""
+
+
+class EvaluationGroundTruthSQL(EvaluationStrictModel):
+    sql: str = Field(min_length=1)
+    dialect: str = "duckdb"
+    must_reference: list[str] = Field(default_factory=list)
+    must_not_reference: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_readonly_sql(self) -> EvaluationGroundTruthSQL:
+        try:
+            expressions = sqlglot.parse(self.sql, read=self.dialect)
+        except Exception as exc:  # pragma: no cover - exact parser errors vary by sqlglot version
+            raise ValueError(f"ground truth SQL could not be parsed: {exc}") from exc
+        if len(expressions) != 1:
+            raise ValueError("ground truth SQL must contain exactly one read-only statement")
+        expression = expressions[0]
+        if expression is None or expression.key not in {"select", "with", "union"}:
+            raise ValueError("ground truth SQL must be read-only")
+        return self
+
+
+class EvaluationExpectedField(EvaluationStrictModel):
+    name: str = Field(min_length=1)
+    data_type: str = Field(min_length=1)
+    unit: str | None = None
+    nullable: bool = True
+    logical_type: str | None = None
+
+
+class EvaluationNormalizedResult(EvaluationStrictModel):
+    mode: EvaluationResultMode = "multiset"
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+    invariants: dict[str, Any] = Field(default_factory=dict)
+    canonical_hash: str | None = None
+    large_result_chunk_hashes: list[str] = Field(default_factory=list)
+
+
+class EvaluationTolerance(EvaluationStrictModel):
+    absolute: float | None = Field(default=None, ge=0)
+    relative: float | None = Field(default=None, ge=0)
+    per_field: dict[str, dict[str, float]] = Field(default_factory=dict)
+
+
+class EvaluationAnswerExpectation(EvaluationStrictModel):
+    must_include_any: list[str] = Field(default_factory=list)
+    must_include_all: list[str] = Field(default_factory=list)
+    must_not_include: list[str] = Field(default_factory=list)
+    refusal_allowed: bool = False
+    clarification_allowed: bool = False
+
+
+class EvaluationEvidenceExpectation(EvaluationStrictModel):
+    required: bool = True
+    lineage_refs: list[str] = Field(default_factory=list)
+    min_confidence: float | None = Field(default=None, ge=0, le=1)
+
+
+class EvaluationPolicyExpectation(EvaluationStrictModel):
+    required_scopes: list[str] = Field(default_factory=list)
+    forbidden_fields: list[str] = Field(default_factory=list)
+    expected_decision: Literal["allow", "deny", "redact"] | None = None
+    security_hard_fail: bool = True
+
+
+class EvaluationDashboardExpectation(EvaluationStrictModel):
+    manifest_id: str | None = None
+    run_contract_version: Literal["dashboard.run.v1"] = "dashboard.run.v1"
+    required_data_view_ids: list[str] = Field(default_factory=list)
+
+
+class EvaluationHumanMCPParityExpectation(EvaluationStrictModel):
+    required: bool = False
+    compare_fields: list[str] = Field(default_factory=list)
+
+
+class EvaluationExpectedContract(EvaluationStrictModel):
+    semantic_intent: EvaluationSemanticIntent = Field(default_factory=EvaluationSemanticIntent)
+    ground_truth_sql: EvaluationGroundTruthSQL | None = None
+    expected_schema: list[EvaluationExpectedField] = Field(default_factory=list)
+    normalized_result: EvaluationNormalizedResult = Field(default_factory=EvaluationNormalizedResult)
+    tolerance: EvaluationTolerance = Field(default_factory=EvaluationTolerance)
+    answer: EvaluationAnswerExpectation = Field(default_factory=EvaluationAnswerExpectation)
+    evidence: EvaluationEvidenceExpectation = Field(default_factory=EvaluationEvidenceExpectation)
+    policy: EvaluationPolicyExpectation = Field(default_factory=EvaluationPolicyExpectation)
+    dashboard: EvaluationDashboardExpectation = Field(default_factory=EvaluationDashboardExpectation)
+    human_mcp_parity: EvaluationHumanMCPParityExpectation = Field(
+        default_factory=EvaluationHumanMCPParityExpectation
+    )
+
+
+class EvaluationCaseProvenance(EvaluationStrictModel):
+    source: Literal["human_feedback", "manual", "legacy_conversation_evaluation", "import", "advisor"]
+    feedback_id: str | None = None
+    trace_id: str | None = None
+    principal: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime | None = None
+
+
+class EvaluationCaseContract(EvaluationStrictModel):
+    contract_version: EvaluationCaseContractVersion
+    case_id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    target_kinds: list[EvaluationTargetKind] = Field(min_length=1)
+    operation: EvaluationOperation
+    question: str = Field(min_length=1)
+    expected: EvaluationExpectedContract
+    tags: list[str] = Field(default_factory=list)
+    provenance: EvaluationCaseProvenance
+
+
+class EvaluationGatePolicy(EvaluationStrictModel):
+    version: str = "gate-policy.v1"
+    security_hard_fail: bool = True
+    min_overall_pass_rate: float = Field(default=1.0, ge=0, le=1)
+    max_new_regressions: int = Field(default=0, ge=0)
+    require_manual_review_for: list[str] = Field(default_factory=list)
+
+
+class EvaluationSuiteVersionManifest(EvaluationStrictModel):
+    contract_version: EvaluationSuiteVersionContractVersion
+    suite_id: str = Field(min_length=1)
+    version: int = Field(ge=1)
+    cases: list[EvaluationCaseContract]
+    gate_policy: EvaluationGatePolicy
+    owner: str | None = None
+    description: str = ""
+
+
+class EvaluationAppPin(EvaluationStrictModel):
+    git_sha: str | None = None
+    image_digest: str | None = None
+    migration_revision: str | None = None
+
+
+class EvaluationConnectorPin(EvaluationStrictModel):
+    version: str | None = None
+    connection_id: str | None = None
+
+
+class EvaluationSourcePin(EvaluationStrictModel):
+    snapshot_id: str | None = None
+    snapshot_hash: str | None = None
+
+
+class EvaluationSemanticModelPin(EvaluationStrictModel):
+    version_id: str | None = None
+    version_hash: str | None = None
+
+
+class EvaluationDashboardPin(EvaluationStrictModel):
+    version_id: str | None = None
+    manifest_hash: str | None = None
+    renderer_version: str | None = None
+
+
+class EvaluationPromptPin(EvaluationStrictModel):
+    version: str | None = None
+    prompt_hash: str | None = None
+
+
+class EvaluationLLMPin(EvaluationStrictModel):
+    provider: str | None = None
+    model: str | None = None
+    params_hash: str | None = None
+
+
+class EvaluationPrincipalPin(EvaluationStrictModel):
+    tenant_id: str = Field(min_length=1)
+    actor_type: EvaluationActorType
+    actor_id: str = Field(min_length=1)
+    scopes: list[str] = Field(default_factory=list)
+    rls: dict[str, Any] = Field(default_factory=dict)
+    cls: list[str] = Field(default_factory=list)
+
+
+class EvaluationDatasetPin(EvaluationStrictModel):
+    snapshot_id: str | None = None
+    snapshot_hash: str | None = None
+
+
+class EvaluationTimeFixture(EvaluationStrictModel):
+    now: str | None = None
+    timezone: str = "UTC"
+
+
+class EvaluationTargetSnapshot(EvaluationStrictModel):
+    contract_version: EvaluationTargetSnapshotContractVersion
+    target_kind: EvaluationTargetKind
+    target_ref: str = Field(min_length=1)
+    app: EvaluationAppPin
+    connector: EvaluationConnectorPin = Field(default_factory=EvaluationConnectorPin)
+    source: EvaluationSourcePin = Field(default_factory=EvaluationSourcePin)
+    semantic_model: EvaluationSemanticModelPin = Field(default_factory=EvaluationSemanticModelPin)
+    dashboard: EvaluationDashboardPin = Field(default_factory=EvaluationDashboardPin)
+    prompt: EvaluationPromptPin = Field(default_factory=EvaluationPromptPin)
+    tool_registry_hash: str | None = None
+    skill_registry_hash: str | None = None
+    llm: EvaluationLLMPin = Field(default_factory=EvaluationLLMPin)
+    principal: EvaluationPrincipalPin
+    dataset: EvaluationDatasetPin = Field(default_factory=EvaluationDatasetPin)
+    feature_flags: dict[str, Any]
+    time_fixture: EvaluationTimeFixture
+
+    def required_pin_blockers(self) -> list[str]:
+        blockers: list[str] = []
+        required_paths = [
+            ("app.git_sha", self.app.git_sha),
+            ("app.image_digest", self.app.image_digest),
+            ("app.migration_revision", self.app.migration_revision),
+            ("source.snapshot_hash", self.source.snapshot_hash),
+            ("dataset.snapshot_hash", self.dataset.snapshot_hash),
+            ("time_fixture.now", self.time_fixture.now),
+        ]
+        if self.target_kind in {"semantic_model", "agent_answer", "dashboard", "end_to_end"}:
+            required_paths.append(("semantic_model.version_hash", self.semantic_model.version_hash))
+        if self.target_kind in {"dashboard", "end_to_end"}:
+            required_paths.extend(
+                [
+                    ("dashboard.version_id", self.dashboard.version_id),
+                    ("dashboard.manifest_hash", self.dashboard.manifest_hash),
+                    ("dashboard.renderer_version", self.dashboard.renderer_version),
+                ]
+            )
+        if self.target_kind in {"agent_answer", "end_to_end"}:
+            required_paths.extend(
+                [
+                    ("prompt.version", self.prompt.version),
+                    ("tool_registry_hash", self.tool_registry_hash),
+                    ("skill_registry_hash", self.skill_registry_hash),
+                    ("llm.params_hash", self.llm.params_hash),
+                ]
+            )
+        for path, value in required_paths:
+            if value in (None, "", [], {}):
+                blockers.append(path)
+        return blockers

--- a/server/schemas/evaluation.py
+++ b/server/schemas/evaluation.py
@@ -118,9 +118,7 @@ class EvaluationExpectedContract(EvaluationStrictModel):
     evidence: EvaluationEvidenceExpectation = Field(default_factory=EvaluationEvidenceExpectation)
     policy: EvaluationPolicyExpectation = Field(default_factory=EvaluationPolicyExpectation)
     dashboard: EvaluationDashboardExpectation = Field(default_factory=EvaluationDashboardExpectation)
-    human_mcp_parity: EvaluationHumanMCPParityExpectation = Field(
-        default_factory=EvaluationHumanMCPParityExpectation
-    )
+    human_mcp_parity: EvaluationHumanMCPParityExpectation = Field(default_factory=EvaluationHumanMCPParityExpectation)
 
 
 class EvaluationCaseProvenance(EvaluationStrictModel):

--- a/server/schemas/semantic_models.py
+++ b/server/schemas/semantic_models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SemanticModelCreate(BaseModel):
+    slug: str | None = None
+    name: str
+    domain: str = ""
+    owner: str = ""
+    description: str = ""
+    datasource_id: str | None = None
+    datasource_name: str | None = None
+    datasource_kind: str = "source"
+    manifest: dict[str, Any] = Field(default_factory=dict)
+    source_resource_ids: list[UUID] = Field(default_factory=list)
+    source_snapshot_ids: list[UUID] = Field(default_factory=list)
+    consumer_summary: dict[str, Any] = Field(default_factory=dict)
+
+
+class SemanticModelPatch(BaseModel):
+    expected_revision: int | None = None
+    expectedRevision: int | None = None
+    name: str | None = None
+    domain: str | None = None
+    owner: str | None = None
+    description: str | None = None
+    datasource_id: str | None = None
+    datasource_name: str | None = None
+    datasource_kind: str | None = None
+    manifest: dict[str, Any] | None = None
+    source_resource_ids: list[UUID] | None = None
+    source_snapshot_ids: list[UUID] | None = None
+    consumer_summary: dict[str, Any] | None = None
+
+    def revision_guard(self) -> int | None:
+        return self.expected_revision if self.expected_revision is not None else self.expectedRevision

--- a/server/schemas/source_connections.py
+++ b/server/schemas/source_connections.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+SourceProvider = Literal["local_files", "web", "feishu", "sql_databases", "volcengine_tos", "databricks"]
+SourceAuthMode = Literal["oauth", "access_key", "connection_string", "none"]
+
+
+class ConnectorDefinitionRead(BaseModel):
+    id: str
+    provider: str
+    category: str
+    family: str
+    display_name: str
+    icon: str
+    auth_mode: str
+    capabilities: list[str]
+    limitations: list[str] = Field(default_factory=list)
+    required_scopes: list[str] = Field(default_factory=list)
+    config_schema: dict[str, Any]
+    resource_picker_schema: dict[str, Any]
+    resource_picker_type: str = "none"
+    supported_resource_types: list[str]
+    availability: str
+    status: str
+    readiness_gates: list[dict[str, str]] = Field(default_factory=list)
+    modeling_modes: list[str] = Field(default_factory=list)
+    description: str = ""
+    entry_kind: str = "connector_backed"
+
+
+class SourceConnectionCreate(BaseModel):
+    provider: SourceProvider
+    auth_mode: SourceAuthMode
+    display_name: str
+    credentials: dict[str, Any] = Field(default_factory=dict)
+    external_account_id: str | None = None
+    capabilities: dict[str, Any] = Field(default_factory=dict)
+
+
+class SourceConnectionRead(BaseModel):
+    id: UUID
+    provider: str
+    auth_mode: str
+    external_account_id: str | None = None
+    display_name: str
+    status: str
+    capabilities: dict[str, Any]
+    token_expires_at: datetime | None = None
+    created_by: UUID | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/server/schemas/source_resources.py
+++ b/server/schemas/source_resources.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+SourceResourceType = Literal[
+    "file",
+    "pdf",
+    "web",
+    "feishu_doc",
+    "feishu_wiki",
+    "feishu_sheet",
+    "feishu_base",
+    "tos_bucket",
+    "tos_prefix",
+    "tos_object",
+    "database_catalog",
+    "database_schema",
+    "database_table",
+    "databricks_catalog",
+    "databricks_schema",
+    "databricks_table",
+]
+SourceResourceStatus = Literal[
+    "pending",
+    "beta",
+    "syncing",
+    "understanding",
+    "authorization_required",
+    "reauthorization_required",
+    "blocked",
+    "source_unavailable",
+    "permission_lost",
+    "needs_confirmation",
+    "ready",
+    "failed",
+]
+
+
+class SourceResourceCreate(BaseModel):
+    resource_type: SourceResourceType
+    name: str
+    external_id: str | None = None
+    source_url: str | None = None
+    parent_external_id: str | None = None
+    source_connection_id: UUID | None = None
+    connection_id: UUID | None = None
+    visibility: str = "workspace"
+    sync_mode: Literal["manual", "scheduled"] = "manual"
+    selection_config: dict[str, Any] = Field(default_factory=dict)
+    sync_config: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    content: str | None = Field(
+        default=None,
+        description="Optional caller-supplied content used to record a governed snapshot. No external connector runtime is invoked.",
+    )
+    external_revision: str | None = None
+    parser_version: str | None = None
+    raw_storage_uri: str | None = None
+
+
+class SourceResourceSyncRequest(BaseModel):
+    content: str | None = None
+    external_revision: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    parser_version: str | None = None
+    raw_storage_uri: str | None = None
+
+
+class SourceSnapshotRead(BaseModel):
+    id: UUID
+    resource_id: UUID
+    external_revision: str | None = None
+    content_hash: str
+    raw_storage_uri: str
+    captured_at: datetime
+    parser_version: str | None = None
+    metadata_json: dict[str, Any] | None = None
+    status: str
+    error_json: dict[str, Any] | None = None
+
+
+class SourceResourceRead(BaseModel):
+    id: UUID
+    connection_id: UUID | None = None
+    source_connection_id: UUID | None = None
+    source_connection: dict[str, Any] | None = None
+    resource_type: str
+    name: str
+    external_id: str | None = None
+    source_url: str | None = None
+    parent_external_id: str | None = None
+    selection_config_json: dict[str, Any] | None = None
+    visibility: str
+    sync_mode: str
+    sync_config_json: dict[str, Any] | None = None
+    status: SourceResourceStatus
+    latest_snapshot_id: UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+    latest_snapshot: SourceSnapshotRead | None = None

--- a/server/serializers/evaluation.py
+++ b/server/serializers/evaluation.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from server.models.evaluation import (
+    AdvisorChangeSet,
+    AdvisorSuggestion,
+    EvaluationArtifact,
+    EvaluationAssessment,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    PromotionDecision,
+)
+from server.utils.error_sanitizer import sanitize_error_payload
+
+
+def _dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def evaluation_suite_payload(
+    suite: EvaluationSuite,
+    *,
+    versions: list[EvaluationSuiteVersion] | None = None,
+    include_versions: bool = False,
+    include_manifests: bool = False,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": str(suite.id),
+        "tenant_id": str(suite.tenant_id),
+        "slug": suite.slug,
+        "name": suite.name,
+        "description": suite.description,
+        "owner_id": str(suite.owner_id) if suite.owner_id else None,
+        "target_kinds": suite.target_kinds_json or [],
+        "lifecycle": suite.lifecycle,
+        "current_draft_version_id": str(suite.current_draft_version_id) if suite.current_draft_version_id else None,
+        "published_version_id": str(suite.published_version_id) if suite.published_version_id else None,
+        "created_at": _dt(suite.created_at),
+        "updated_at": _dt(suite.updated_at),
+    }
+    if include_versions:
+        payload["versions"] = [
+            evaluation_suite_version_payload(version, include_manifest=include_manifests)
+            for version in versions or []
+        ]
+    return payload
+
+
+def evaluation_suite_version_payload(
+    version: EvaluationSuiteVersion,
+    *,
+    include_manifest: bool = False,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": str(version.id),
+        "tenant_id": str(version.tenant_id),
+        "suite_id": str(version.suite_id),
+        "version_num": version.version_num,
+        "status": version.status,
+        "contract_version": version.contract_version,
+        "case_count": version.case_count,
+        "content_hash": version.content_hash,
+        "gate_policy": sanitize_error_payload(version.gate_policy_json or {}),
+        "created_by": str(version.created_by) if version.created_by else None,
+        "published_at": _dt(version.published_at),
+        "created_at": _dt(version.created_at),
+    }
+    if include_manifest:
+        payload["manifest"] = sanitize_error_payload(version.manifest_json or {})
+    return payload
+
+
+def evaluation_run_payload(run: EvaluationRun) -> dict[str, Any]:
+    return {
+        "id": str(run.id),
+        "tenant_id": str(run.tenant_id),
+        "suite_version_id": str(run.suite_version_id),
+        "target_snapshot_id": str(run.target_snapshot_id),
+        "status": run.status,
+        "actor_type": run.actor_type,
+        "actor_id": run.actor_id,
+        "baseline_run_id": str(run.baseline_run_id) if run.baseline_run_id else None,
+        "candidate_label": run.candidate_label,
+        "idempotency_key": run.idempotency_key,
+        "attempt": run.attempt,
+        "lease_holder": run.lease_holder,
+        "lease_expires_at": _dt(run.lease_expires_at),
+        "heartbeat_at": _dt(run.heartbeat_at),
+        "stop_requested": run.stop_requested,
+        "preflight_blockers": run.preflight_blockers_json or [],
+        "summary": sanitize_error_payload(run.summary_json or {}),
+        "started_at": _dt(run.started_at),
+        "completed_at": _dt(run.completed_at),
+        "created_at": _dt(run.created_at),
+    }
+
+
+def evaluation_case_payload(
+    case: EvaluationCase,
+    *,
+    include_expected_contract: bool = True,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": str(case.id),
+        "tenant_id": str(case.tenant_id),
+        "suite_version_id": str(case.suite_version_id),
+        "case_key": case.case_key,
+        "title": case.title,
+        "target_kinds": case.target_kinds_json or [],
+        "operation": case.operation,
+        "question": case.question,
+        "provenance": sanitize_error_payload(case.provenance_json or {}),
+        "tags": case.tags_json or [],
+        "content_hash": case.content_hash,
+        "immutable": case.immutable,
+        "has_ground_truth_sql": bool((case.expected_contract_json or {}).get("ground_truth_sql")),
+        "created_at": _dt(case.created_at),
+    }
+    if include_expected_contract:
+        payload["expected_contract"] = sanitize_error_payload(case.expected_contract_json or {})
+    return payload
+
+
+def evaluation_case_run_payload(
+    case_run: EvaluationCaseRun,
+    *,
+    assessments: list[EvaluationAssessment] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": str(case_run.id),
+        "tenant_id": str(case_run.tenant_id),
+        "run_id": str(case_run.run_id),
+        "case_id": str(case_run.case_id),
+        "status": case_run.status,
+        "attempt": case_run.attempt,
+        "input_digest": case_run.input_digest,
+        "output_digest": case_run.output_digest,
+        "result": sanitize_error_payload(case_run.result_json or {}),
+        "error": sanitize_error_payload(case_run.error_json or {}),
+        "immutable": case_run.immutable,
+        "started_at": _dt(case_run.started_at),
+        "completed_at": _dt(case_run.completed_at),
+        "created_at": _dt(case_run.created_at),
+        "assessments": [evaluation_assessment_payload(assessment) for assessment in assessments or []],
+    }
+
+
+def evaluation_assessment_payload(assessment: EvaluationAssessment) -> dict[str, Any]:
+    return {
+        "id": str(assessment.id),
+        "tenant_id": str(assessment.tenant_id),
+        "case_run_id": str(assessment.case_run_id),
+        "category": assessment.category,
+        "status": assessment.status,
+        "score": assessment.score,
+        "hard_fail": assessment.hard_fail,
+        "details": sanitize_error_payload(assessment.details_json or {}),
+        "immutable": assessment.immutable,
+        "created_at": _dt(assessment.created_at),
+    }
+
+
+def evaluation_artifact_payload(artifact: EvaluationArtifact) -> dict[str, Any]:
+    return {
+        "id": str(artifact.id),
+        "tenant_id": str(artifact.tenant_id),
+        "run_id": str(artifact.run_id) if artifact.run_id else None,
+        "case_run_id": str(artifact.case_run_id) if artifact.case_run_id else None,
+        "artifact_type": artifact.artifact_type,
+        "uri": artifact.uri,
+        "content_hash": artifact.content_hash,
+        "metadata": sanitize_error_payload(artifact.metadata_json or {}),
+        "immutable": artifact.immutable,
+        "created_at": _dt(artifact.created_at),
+    }
+
+
+def promotion_payload(promotion: PromotionDecision) -> dict[str, Any]:
+    return {
+        "id": str(promotion.id),
+        "tenant_id": str(promotion.tenant_id),
+        "change_set_id": str(promotion.change_set_id) if promotion.change_set_id else None,
+        "verification_run_id": str(promotion.verification_run_id) if promotion.verification_run_id else None,
+        "regression_run_id": str(promotion.regression_run_id) if promotion.regression_run_id else None,
+        "decision": promotion.decision,
+        "decided_by": str(promotion.decided_by) if promotion.decided_by else None,
+        "rationale": promotion.rationale,
+        "audit": sanitize_error_payload(promotion.audit_json or {}),
+        "created_at": _dt(promotion.created_at),
+    }
+
+
+def advisor_change_set_payload(change_set: AdvisorChangeSet) -> dict[str, Any]:
+    return {
+        "id": str(change_set.id),
+        "tenant_id": str(change_set.tenant_id),
+        "suite_version_id": str(change_set.suite_version_id) if change_set.suite_version_id else None,
+        "target_ref": change_set.target_ref,
+        "base_version_ref": change_set.base_version_ref,
+        "base_etag": change_set.base_etag,
+        "status": change_set.status,
+        "evidence": sanitize_error_payload(change_set.evidence_json or {}),
+        "verification_run_id": str(change_set.verification_run_id) if change_set.verification_run_id else None,
+        "regression_run_id": str(change_set.regression_run_id) if change_set.regression_run_id else None,
+        "created_by": change_set.created_by,
+        "created_at": _dt(change_set.created_at),
+    }
+
+
+def advisor_suggestion_payload(suggestion: AdvisorSuggestion) -> dict[str, Any]:
+    return {
+        "id": str(suggestion.id),
+        "tenant_id": str(suggestion.tenant_id),
+        "change_set_id": str(suggestion.change_set_id),
+        "suggestion_type": suggestion.suggestion_type,
+        "patch": sanitize_error_payload(suggestion.patch_json or {}),
+        "affected_case_ids": suggestion.affected_case_ids_json or [],
+        "status": suggestion.status,
+        "created_at": _dt(suggestion.created_at),
+    }

--- a/server/serializers/evaluation.py
+++ b/server/serializers/evaluation.py
@@ -45,8 +45,7 @@ def evaluation_suite_payload(
     }
     if include_versions:
         payload["versions"] = [
-            evaluation_suite_version_payload(version, include_manifest=include_manifests)
-            for version in versions or []
+            evaluation_suite_version_payload(version, include_manifest=include_manifests) for version in versions or []
         ]
     return payload
 

--- a/server/serializers/sharing.py
+++ b/server/serializers/sharing.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from server.models.sharing import SharingAuditEvent, SharingCompatibilityLink, SharingGrant
+from server.utils.error_sanitizer import sanitize_error_payload
+
+
+def _dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def sharing_grant_payload(grant: SharingGrant) -> dict[str, Any]:
+    return {
+        "id": str(grant.id),
+        "tenant_id": str(grant.tenant_id),
+        "object_type": grant.object_type,
+        "object_id": str(grant.object_id),
+        "object_version_id": str(grant.object_version_id) if grant.object_version_id else None,
+        "object_version_digest": grant.object_version_digest,
+        "mode": grant.mode,
+        "channel": grant.channel,
+        "audience": grant.audience,
+        "status": grant.status,
+        "created_by": str(grant.created_by) if grant.created_by else None,
+        "expires_at": _dt(grant.expires_at),
+        "revoked_at": _dt(grant.revoked_at),
+        "revoked_by": str(grant.revoked_by) if grant.revoked_by else None,
+        "revocation_reason": grant.revocation_reason,
+        "metadata": sanitize_error_payload(grant.metadata_json or {}),
+        "created_at": _dt(grant.created_at),
+        "updated_at": _dt(grant.updated_at),
+    }
+
+
+def sharing_compatibility_link_payload(link: SharingCompatibilityLink) -> dict[str, Any]:
+    return {
+        "id": str(link.id),
+        "grant_id": str(link.grant_id),
+        "legacy_surface": link.legacy_surface,
+        "legacy_id": link.legacy_id,
+        "metadata": sanitize_error_payload(link.metadata_json or {}),
+        "created_at": _dt(link.created_at),
+    }
+
+
+def sharing_audit_event_payload(event: SharingAuditEvent) -> dict[str, Any]:
+    return {
+        "id": str(event.id),
+        "grant_id": str(event.grant_id) if event.grant_id else None,
+        "viewer_session_id": str(event.viewer_session_id) if event.viewer_session_id else None,
+        "object_type": event.object_type,
+        "object_id": str(event.object_id) if event.object_id else None,
+        "object_version_id": str(event.object_version_id) if event.object_version_id else None,
+        "actor_type": event.actor_type,
+        "actor_id": event.actor_id,
+        "action": event.action,
+        "outcome": event.outcome,
+        "details": sanitize_error_payload(event.details_json or {}),
+        "created_at": _dt(event.created_at),
+    }
+
+
+def sharing_grant_evidence_payload(evidence: dict[str, Any]) -> dict[str, Any]:
+    secret_counts = list(evidence.get("secret_counts") or [])
+    has_secret = any(item.get("status") == "active" and int(item.get("count") or 0) > 0 for item in secret_counts)
+    return {
+        "grant": sharing_grant_payload(evidence["grant"]),
+        "compatibility_links": [
+            sharing_compatibility_link_payload(link) for link in evidence.get("compatibility_links") or []
+        ],
+        "has_secret": has_secret,
+        "secret_counts": secret_counts,
+        "active_viewer_session_count": int(evidence.get("active_viewer_session_count") or 0),
+        "audit_events": [sharing_audit_event_payload(event) for event in evidence.get("audit_events") or []],
+    }

--- a/server/services/connector_catalog.py
+++ b/server/services/connector_catalog.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+ConnectorAvailability = Literal["beta", "planned"]
+ConnectorAuthMode = Literal["oauth", "access_key", "connection_string", "none"]
+ConnectorEntryKind = Literal["connector_backed", "embedded_flow", "roadmap"]
+ConnectorReadinessGateStatus = Literal["partial", "missing", "not_applicable"]
+ConnectorResourcePickerType = Literal[
+    "none",
+    "file_import",
+    "url_import",
+    "oauth_drive_picker",
+    "object_storage_browser",
+    "database_schema_picker",
+    "warehouse_catalog_picker",
+    "roadmap_only",
+]
+
+COMMERCIAL_READINESS_GATES: tuple[tuple[str, str], ...] = (
+    ("tenant_isolated_auth", "Tenant-isolated authorization and encrypted credentials"),
+    ("resource_picker", "Resource picker or explicit import contract"),
+    ("already_added_state", "Already-added state"),
+    ("immutable_snapshot", "Immutable snapshot with external revision and content hash"),
+    ("raw_artifact_uri", "Raw artifact URI outside the control database"),
+    ("parser_warnings", "Parser version and parser warnings"),
+    ("context_index_status", "Context indexing status through KnowledgeProvider"),
+    ("recoverable_errors", "Permission, reauthorization, source unavailable, and retryable failure states"),
+    ("source_detail", "Source detail with snapshots, parsed assets, evidence, lineage, and consumers"),
+    ("lifecycle_actions", "Clear delete, revoke, and reindex behavior"),
+)
+
+
+def _readiness_gates(
+    *,
+    status: ConnectorReadinessGateStatus,
+    detail: str,
+    overrides: dict[str, tuple[ConnectorReadinessGateStatus, str]] | None = None,
+) -> tuple[dict[str, str], ...]:
+    overrides = overrides or {}
+    gates: list[dict[str, str]] = []
+    for key, label in COMMERCIAL_READINESS_GATES:
+        gate_status, gate_detail = overrides.get(key, (status, detail))
+        gates.append({"key": key, "label": label, "status": gate_status, "detail": gate_detail})
+    return tuple(gates)
+
+
+BETA_GATES = _readiness_gates(
+    status="partial",
+    detail="Official landing includes the Source control-plane contract. Runtime connector execution, production credentials, and full provenance are not certified in this batch.",
+)
+WAREHOUSE_BETA_GATES = _readiness_gates(
+    status="partial",
+    detail="Official landing includes schema/profile Source representation only. Warehouse data remains external and semantic modeling stays beta.",
+    overrides={
+        "immutable_snapshot": (
+            "not_applicable",
+            "Warehouse Sources track schema/profile freshness instead of raw data snapshots.",
+        ),
+        "raw_artifact_uri": (
+            "not_applicable",
+            "Warehouse Sources do not copy raw table data into Byaan object storage.",
+        ),
+        "context_index_status": (
+            "not_applicable",
+            "Warehouse Sources feed future semantic modeling from schema/profile evidence.",
+        ),
+    },
+)
+PLANNED_GATES = _readiness_gates(
+    status="missing",
+    detail="Required before this roadmap entry can become a supported connector.",
+)
+
+
+@dataclass(frozen=True)
+class ConnectorDefinition:
+    id: str
+    category: str
+    display_name: str
+    icon: str
+    auth_mode: ConnectorAuthMode
+    capabilities: tuple[str, ...]
+    config_schema: dict[str, Any]
+    resource_picker_schema: dict[str, Any]
+    supported_resource_types: tuple[str, ...]
+    availability: ConnectorAvailability
+    description: str = ""
+    limitations: tuple[str, ...] = ()
+    required_scopes: tuple[str, ...] = ()
+    resource_picker_type: ConnectorResourcePickerType = "none"
+    modeling_modes: tuple[str, ...] = ()
+    readiness_gates: tuple[dict[str, str], ...] = ()
+    entry_kind: ConnectorEntryKind = "connector_backed"
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "provider": self.id,
+            "category": self.category,
+            "family": _family_for_category(self.category),
+            "display_name": self.display_name,
+            "icon": self.icon,
+            "auth_mode": self.auth_mode,
+            "capabilities": list(self.capabilities),
+            "limitations": list(self.limitations),
+            "required_scopes": list(self.required_scopes),
+            "config_schema": self.config_schema,
+            "resource_picker_schema": self.resource_picker_schema,
+            "resource_picker_type": self.resource_picker_type,
+            "supported_resource_types": list(self.supported_resource_types),
+            "availability": self.availability,
+            "status": self.availability,
+            "readiness_gates": list(self.readiness_gates),
+            "modeling_modes": list(self.modeling_modes),
+            "description": self.description,
+            "entry_kind": self.entry_kind,
+        }
+
+
+def _field(name: str, field_type: str, *, required: bool = True, secret: bool = False) -> dict[str, Any]:
+    return {"name": name, "type": field_type, "required": required, "secret": secret}
+
+
+def _family_for_category(category: str) -> str:
+    if category == "documents":
+        return "business_docs"
+    if category == "data_lake":
+        return "warehouses"
+    if category in {"messages", "search"}:
+        return "api"
+    return category
+
+
+def _planned(
+    *,
+    id: str,
+    category: str,
+    display_name: str,
+    icon: str,
+    auth_mode: ConnectorAuthMode,
+    capabilities: tuple[str, ...] = (),
+    planned_adapter: str | None = None,
+) -> ConnectorDefinition:
+    return ConnectorDefinition(
+        id=id,
+        category=category,
+        display_name=display_name,
+        icon=icon,
+        auth_mode=auth_mode,
+        capabilities=capabilities,
+        config_schema={"fields": []},
+        resource_picker_schema={"planned_adapter": planned_adapter} if planned_adapter else {},
+        supported_resource_types=(),
+        availability="planned",
+        limitations=("Roadmap entry only; no runtime connector contract has been certified in the official repo.",),
+        resource_picker_type="roadmap_only",
+        modeling_modes=(),
+        readiness_gates=PLANNED_GATES,
+        entry_kind="roadmap",
+    )
+
+
+CONNECTOR_CATALOG: tuple[ConnectorDefinition, ...] = (
+    ConnectorDefinition(
+        id="local_files",
+        category="files",
+        display_name="Files as Source",
+        icon="file",
+        auth_mode="none",
+        capabilities=("file_import", "snapshot_metadata", "parser_artifact_contract"),
+        config_schema={"embedded_flow": "files_source_upload", "fields": []},
+        resource_picker_schema={"supported_extensions": ["pdf", "csv", "xlsx", "xlsm", "docx", "pptx"]},
+        supported_resource_types=("file", "pdf"),
+        availability="beta",
+        description="Register uploaded files as governed Sources with immutable snapshot metadata.",
+        limitations=(
+            "This landing records Source metadata only; parser workers and KnowledgeProvider indexing are partial.",
+        ),
+        resource_picker_type="file_import",
+        modeling_modes=("context_assisted", "projection"),
+        readiness_gates=BETA_GATES,
+        entry_kind="embedded_flow",
+    ),
+    ConnectorDefinition(
+        id="web",
+        category="web",
+        display_name="Web page",
+        icon="web",
+        auth_mode="none",
+        capabilities=("url_import", "snapshot_metadata", "crawl_policy_contract"),
+        config_schema={"embedded_flow": "web_source_capture", "fields": []},
+        resource_picker_schema={"supports_single_url": True, "supports_public_http": True, "ssrf_protection": True},
+        supported_resource_types=("web",),
+        availability="beta",
+        description="Register public web pages as governed Sources.",
+        limitations=("No crawler/runtime fetch is included in this official landing batch.",),
+        resource_picker_type="url_import",
+        modeling_modes=("context_assisted",),
+        readiness_gates=BETA_GATES,
+        entry_kind="embedded_flow",
+    ),
+    ConnectorDefinition(
+        id="feishu",
+        category="documents",
+        display_name="飞书文档 / Wiki / Sheets / Base",
+        icon="feishu",
+        auth_mode="oauth",
+        capabilities=("oauth_contract", "resource_browse_contract", "snapshot_metadata"),
+        config_schema={"fields": []},
+        resource_picker_schema={"scopes": ["recent", "drive", "wiki", "search"], "supports_multi_select": True},
+        supported_resource_types=("feishu_doc", "feishu_wiki", "feishu_sheet", "feishu_base"),
+        availability="beta",
+        description="Control-plane contract for Feishu/Lark Sources.",
+        limitations=("OAuth runtime, admin app setup, and live Drive picker are not landed in this batch.",),
+        required_scopes=("space:document:retrieve", "docx:document:readonly", "wiki:wiki:readonly"),
+        resource_picker_type="oauth_drive_picker",
+        modeling_modes=("context_assisted", "projection"),
+        readiness_gates=BETA_GATES,
+    ),
+    ConnectorDefinition(
+        id="sql_databases",
+        category="databases",
+        display_name="SQL databases",
+        icon="database",
+        auth_mode="connection_string",
+        capabilities=("schema_profile_contract", "semantic_model_handoff_contract"),
+        config_schema={
+            "embedded_flow": "database_connection",
+            "providers": ["sqlite", "postgres", "mysql"],
+            "fields": [],
+        },
+        resource_picker_schema={"picker": "database_schema_picker"},
+        supported_resource_types=("database_catalog", "database_schema", "database_table"),
+        availability="beta",
+        description="Represent existing SQL database connections as governed Sources.",
+        limitations=("Semantic model generation remains beta and requires reviewed schema/profile evidence.",),
+        resource_picker_type="database_schema_picker",
+        modeling_modes=("relational",),
+        readiness_gates=WAREHOUSE_BETA_GATES,
+        entry_kind="embedded_flow",
+    ),
+    ConnectorDefinition(
+        id="volcengine_tos",
+        category="object_storage",
+        display_name="火山引擎 TOS",
+        icon="tos",
+        auth_mode="access_key",
+        capabilities=("object_storage_contract", "bucket_browse_contract", "snapshot_metadata"),
+        config_schema={
+            "fields": [
+                _field("endpoint", "url"),
+                _field("region", "string"),
+                _field("access_key_id", "string", secret=True),
+                _field("secret_access_key", "string", secret=True),
+                _field("session_token", "string", required=False, secret=True),
+                _field("default_bucket", "string", required=False),
+                _field("default_prefix", "string", required=False),
+            ]
+        },
+        resource_picker_schema={"hierarchy": ["bucket", "prefix", "object"], "supports_multi_select": True},
+        supported_resource_types=("tos_bucket", "tos_prefix", "tos_object"),
+        availability="beta",
+        description="Control-plane contract for TOS object storage Sources.",
+        limitations=("No live TOS browse/sync adapter is included in this official landing batch.",),
+        required_scopes=("tos:ListBucket", "tos:GetObject"),
+        resource_picker_type="object_storage_browser",
+        modeling_modes=("projection", "context_assisted"),
+        readiness_gates=BETA_GATES,
+    ),
+    ConnectorDefinition(
+        id="databricks",
+        category="data_lake",
+        display_name="Databricks",
+        icon="databricks",
+        auth_mode="oauth",
+        capabilities=("warehouse_catalog_contract", "schema_profile_contract", "semantic_model_handoff_contract"),
+        config_schema={"embedded_flow": "databricks_oauth_catalog", "fields": []},
+        resource_picker_schema={"supports_catalogs": True, "supports_schemas": True, "supports_multi_select": True},
+        supported_resource_types=("databricks_catalog", "databricks_schema", "databricks_table"),
+        availability="beta",
+        description="Represent Databricks warehouse metadata as governed Sources.",
+        limitations=("Requires existing Databricks OAuth setup; semantic modeling remains beta.",),
+        resource_picker_type="warehouse_catalog_picker",
+        modeling_modes=("warehouse",),
+        readiness_gates=WAREHOUSE_BETA_GATES,
+        entry_kind="embedded_flow",
+    ),
+    _planned(
+        id="aliyun_oss",
+        category="object_storage",
+        display_name="阿里云 OSS",
+        icon="oss",
+        auth_mode="access_key",
+        capabilities=("object_storage_contract",),
+        planned_adapter="object_storage",
+    ),
+    _planned(
+        id="tencent_cos",
+        category="object_storage",
+        display_name="腾讯云 COS",
+        icon="cos",
+        auth_mode="access_key",
+        capabilities=("object_storage_contract",),
+        planned_adapter="object_storage",
+    ),
+    _planned(
+        id="huawei_obs",
+        category="object_storage",
+        display_name="华为云 OBS",
+        icon="obs",
+        auth_mode="access_key",
+        capabilities=("object_storage_contract",),
+        planned_adapter="object_storage",
+    ),
+    _planned(
+        id="minio_s3",
+        category="object_storage",
+        display_name="MinIO / S3 Compatible",
+        icon="s3",
+        auth_mode="access_key",
+        capabilities=("object_storage_contract",),
+        planned_adapter="object_storage",
+    ),
+    _planned(
+        id="dingtalk_docs",
+        category="documents",
+        display_name="钉钉文档 / 表格 / 宜搭",
+        icon="dingtalk",
+        auth_mode="oauth",
+        capabilities=("oauth_picker_contract",),
+        planned_adapter="oauth_picker",
+    ),
+    _planned(
+        id="tencent_docs",
+        category="documents",
+        display_name="腾讯文档",
+        icon="tencent-docs",
+        auth_mode="oauth",
+        capabilities=("oauth_picker_contract",),
+        planned_adapter="oauth_picker",
+    ),
+    _planned(
+        id="oceanbase",
+        category="databases",
+        display_name="OceanBase",
+        icon="database",
+        auth_mode="connection_string",
+        capabilities=("mysql_protocol_planned",),
+    ),
+    _planned(
+        id="clickhouse",
+        category="databases",
+        display_name="ClickHouse",
+        icon="database",
+        auth_mode="connection_string",
+        capabilities=("sql_dialect_planned",),
+    ),
+    _planned(
+        id="volcengine_las",
+        category="data_lake",
+        display_name="火山引擎 LAS",
+        icon="lake",
+        auth_mode="access_key",
+    ),
+    _planned(id="kafka", category="messages", display_name="Kafka", icon="message", auth_mode="connection_string"),
+    _planned(
+        id="elasticsearch",
+        category="search",
+        display_name="Elasticsearch / OpenSearch",
+        icon="search",
+        auth_mode="connection_string",
+    ),
+)
+
+
+def list_connector_definitions() -> list[dict[str, Any]]:
+    return [definition.to_payload() for definition in CONNECTOR_CATALOG]
+
+
+def get_connector_definition(provider: str) -> ConnectorDefinition | None:
+    return next((item for item in CONNECTOR_CATALOG if item.id == provider), None)
+
+
+def connector_catalog_summary() -> dict[str, int | str]:
+    counts = {"ready": 0, "beta": 0, "planned": 0, "blocked": 0}
+    for definition in CONNECTOR_CATALOG:
+        if definition.availability == "beta":
+            counts["beta"] += 1
+        elif definition.availability == "planned":
+            counts["planned"] += 1
+    return {**counts, "overall_status": "PARTIAL"}

--- a/server/services/dashboard.py
+++ b/server/services/dashboard.py
@@ -1,0 +1,1548 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from html import escape
+from typing import Any
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.dashboard import Dashboard, DashboardAsset, DashboardAuditEvent, DashboardRun
+from server.repositories.dashboard import DashboardRepository
+from server.schemas.dashboard import DashboardManifest
+from server.schemas.query import QueryFilter as SavedQueryFilter
+from server.services.query_service import QueryService
+from server.utils.custom_logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class DashboardService:
+    """Governed Dashboard lifecycle service shared by REST and MCP wrappers."""
+
+    PATCHABLE_MANIFEST_PATHS = {
+        "title",
+        "description",
+        "audience",
+        "semantic_bindings",
+        "data_views",
+        "filters",
+        "layout",
+        "tiles",
+        "actions",
+        "freshness_policy",
+        "access_policy",
+        "migration",
+    }
+
+    @staticmethod
+    def canonical_json(payload: dict[str, Any]) -> str:
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+    @staticmethod
+    def digest_payload(payload: dict[str, Any]) -> str:
+        return "sha256:" + hashlib.sha256(DashboardService.canonical_json(payload).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def validate_manifest_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        manifest = DashboardManifest.model_validate(payload)
+        return manifest.model_dump(mode="json", by_alias=True)
+
+    @staticmethod
+    def apply_manifest_patch(manifest_payload: dict[str, Any], patch_operations: list[dict[str, Any]]) -> dict[str, Any]:
+        manifest = json.loads(DashboardService.canonical_json(manifest_payload))
+        for operation in patch_operations:
+            op = operation.get("op")
+            path = operation.get("path")
+            if op not in {"add", "replace", "remove"} or not isinstance(path, str):
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported dashboard patch operation")
+            target = DashboardService._manifest_patch_target(path)
+            if target not in DashboardService.PATCHABLE_MANIFEST_PATHS:
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Dashboard patch path is not allowed")
+            manifest = DashboardService._apply_patch_operation(manifest, op, path, operation.get("value"))
+        return DashboardService.validate_manifest_payload(manifest)
+
+    @staticmethod
+    def assert_manifest_update_allowed(current_manifest: dict[str, Any], next_manifest: dict[str, Any]) -> None:
+        current = DashboardService.validate_manifest_payload(current_manifest)
+        proposed = DashboardService.validate_manifest_payload(next_manifest)
+        changed_keys = {key for key in set(current) | set(proposed) if current.get(key) != proposed.get(key)}
+        blocked_keys = changed_keys - DashboardService.PATCHABLE_MANIFEST_PATHS
+        if blocked_keys:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "dashboard_manifest_patch_forbidden",
+                    "message": "Dashboard full-manifest draft update changed non-patchable top-level keys",
+                    "blocked_keys": sorted(blocked_keys),
+                    "allowed_keys": sorted(DashboardService.PATCHABLE_MANIFEST_PATHS),
+                },
+            )
+
+    @staticmethod
+    def _manifest_patch_target(path: str) -> str:
+        if not path.startswith("/"):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path must be absolute")
+        parts = [part for part in path.split("/") if part]
+        if not parts:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Dashboard manifest root patch is not allowed")
+        return parts[0].replace("~1", "/").replace("~0", "~")
+
+    @staticmethod
+    def _apply_patch_operation(payload: dict[str, Any], op: str, path: str, value: Any = None) -> dict[str, Any]:
+        parts = [part.replace("~1", "/").replace("~0", "~") for part in path.split("/") if part]
+        parent: Any = payload
+        for part in parts[:-1]:
+            if isinstance(parent, list):
+                parent = parent[int(part)]
+            elif isinstance(parent, dict) and part in parent:
+                parent = parent[part]
+            else:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
+
+        leaf = parts[-1]
+        if isinstance(parent, list):
+            index = len(parent) if leaf == "-" else int(leaf)
+            if op == "remove":
+                parent.pop(index)
+            elif op == "add":
+                parent.insert(index, value)
+            else:
+                parent[index] = value
+        elif isinstance(parent, dict):
+            if op == "remove":
+                if leaf not in parent:
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
+                parent.pop(leaf)
+            elif op in {"add", "replace"}:
+                if op == "replace" and leaf not in parent:
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
+                parent[leaf] = value
+        else:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
+        return payload
+
+    async def create_asset_draft(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        actor_id: UUID,
+        manifest_payload: dict[str, Any],
+        slug: str,
+        notebook_id: UUID | None = None,
+        description: str = "",
+        tags: list[str] | None = None,
+        change_summary: str = "Create structured dashboard draft",
+        actor_type: str = "human",
+    ) -> DashboardAsset:
+        if notebook_id is None:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="notebook_id is required for P0 drafts")
+
+        repo = DashboardRepository(session)
+        existing = await repo.get_asset_by_slug(tenant_id, slug)
+        if existing:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard asset slug already exists")
+
+        manifest = self.validate_manifest_payload(manifest_payload)
+        content_hash = self.digest_payload(manifest)
+        now_etag = self.digest_payload({"manifest": content_hash, "slug": slug, "actor": str(actor_id)})
+        asset = DashboardAsset(
+            tenant_id=tenant_id,
+            notebook_id=notebook_id,
+            slug=slug,
+            name=manifest["title"],
+            description=description or manifest.get("description", ""),
+            owner_id=actor_id,
+            tags_json=tags or [],
+            lifecycle="draft",
+            access_policy_json=manifest["access_policy"],
+            freshness_policy_json=manifest["freshness_policy"],
+            etag=now_etag,
+        )
+        session.add(asset)
+        await session.flush()
+
+        version = Dashboard(
+            tenant_id=tenant_id,
+            notebook_id=notebook_id,
+            asset_id=asset.id,
+            version_num=1,
+            html_content="",
+            manifest_schema_version=manifest["schema_version"],
+            manifest_json=manifest,
+            content_hash=content_hash,
+            status="draft",
+            created_by=actor_id,
+            actor_type=actor_type,
+            change_summary=change_summary,
+            pinned_model_versions_json=self._manifest_model_versions(manifest),
+            pinned_source_snapshots_json=self._manifest_source_snapshots(manifest),
+            validation_result_json=self.validation_summary(manifest),
+            migration_state=manifest["migration"]["state"],
+            is_published_immutable=False,
+        )
+        session.add(version)
+        await session.flush()
+
+        asset.current_draft_version_id = version.id
+        await self._audit(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=version.id,
+            actor_type=actor_type,
+            actor_id=str(actor_id),
+            action="dashboard.draft.create",
+            outcome="success",
+            after_digest=content_hash,
+        )
+        await session.commit()
+        await session.refresh(asset)
+        return asset
+
+    async def apply_draft_patch(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        actor_id: UUID,
+        base_etag: str,
+        patch_operations: list[dict[str, Any]],
+        change_summary: str,
+        actor_type: str = "human",
+    ) -> Dashboard:
+        repo = DashboardRepository(session)
+        asset = await repo.get_asset(asset_id, tenant_id)
+        if not asset:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+        if not asset.current_draft_version_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no editable draft")
+        draft = await repo.get_asset_version(
+            tenant_id=tenant_id,
+            asset_id=asset_id,
+            version_id=asset.current_draft_version_id,
+        )
+        if not draft or not draft.manifest_json:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard draft not found")
+        manifest = self.apply_manifest_patch(draft.manifest_json, patch_operations)
+        return await self.patch_draft(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset_id,
+            actor_id=actor_id,
+            manifest_payload=manifest,
+            base_etag=base_etag,
+            change_summary=change_summary,
+            actor_type=actor_type,
+        )
+
+    async def patch_draft(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        actor_id: UUID,
+        manifest_payload: dict[str, Any],
+        base_etag: str,
+        change_summary: str,
+        actor_type: str = "human",
+    ) -> Dashboard:
+        repo = DashboardRepository(session)
+        asset = await repo.get_asset(asset_id, tenant_id)
+        if not asset:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+        if asset.etag != base_etag:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "etag_conflict", "current_etag": asset.etag},
+            )
+        if not asset.current_draft_version_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no editable draft")
+
+        current_draft = await repo.get_asset_version(
+            tenant_id=tenant_id,
+            asset_id=asset_id,
+            version_id=asset.current_draft_version_id,
+        )
+        if not current_draft:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard draft not found")
+
+        if current_draft.manifest_json:
+            self.assert_manifest_update_allowed(current_draft.manifest_json, manifest_payload)
+
+        manifest = self.validate_manifest_payload(manifest_payload)
+        content_hash = self.digest_payload(manifest)
+        next_version = await repo.get_asset_next_version_num(asset_id)
+        version = Dashboard(
+            tenant_id=tenant_id,
+            notebook_id=current_draft.notebook_id,
+            asset_id=asset.id,
+            version_num=next_version,
+            html_content=current_draft.html_content,
+            manifest_schema_version=manifest["schema_version"],
+            manifest_json=manifest,
+            content_hash=content_hash,
+            status="draft",
+            created_by=actor_id,
+            actor_type=actor_type,
+            change_summary=change_summary,
+            pinned_model_versions_json=self._manifest_model_versions(manifest),
+            pinned_source_snapshots_json=self._manifest_source_snapshots(manifest),
+            validation_result_json=self.validation_summary(manifest),
+            migration_state=manifest["migration"]["state"],
+            is_published_immutable=False,
+        )
+        session.add(version)
+        await session.flush()
+
+        asset.current_draft_version_id = version.id
+        asset.name = manifest["title"]
+        asset.description = manifest.get("description", asset.description)
+        asset.access_policy_json = manifest["access_policy"]
+        asset.freshness_policy_json = manifest["freshness_policy"]
+        asset.etag = self.digest_payload({"manifest": content_hash, "base_etag": base_etag, "version": next_version})
+        await self._audit(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=version.id,
+            actor_type=actor_type,
+            actor_id=str(actor_id),
+            action="dashboard.draft.patch",
+            outcome="success",
+            before_digest=current_draft.content_hash,
+            after_digest=content_hash,
+        )
+        await session.commit()
+        await session.refresh(version)
+        return version
+
+    async def publish(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        actor_id: UUID,
+        base_etag: str,
+        change_summary: str,
+        actor_type: str = "human",
+    ) -> Dashboard:
+        repo = DashboardRepository(session)
+        asset = await repo.get_asset(asset_id, tenant_id)
+        if not asset:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+        if asset.etag != base_etag:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "etag_conflict", "current_etag": asset.etag},
+            )
+        if not asset.current_draft_version_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no validated draft")
+
+        draft = await repo.get_asset_version(
+            tenant_id=tenant_id,
+            asset_id=asset_id,
+            version_id=asset.current_draft_version_id,
+        )
+        if not draft or not draft.manifest_json:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard draft not found")
+
+        manifest = self.validate_manifest_payload(draft.manifest_json)
+        validation = self.validation_summary(manifest)
+        if validation["blockers"]:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail={"code": "validation_blocked", **validation})
+
+        draft.status = "published"
+        draft.change_summary = change_summary
+        draft.is_published_immutable = True
+        draft.validation_result_json = validation
+        asset.published_version_id = draft.id
+        asset.lifecycle = "published"
+        asset.etag = self.digest_payload({"published": str(draft.id), "content_hash": draft.content_hash})
+        await self._audit(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=draft.id,
+            actor_type=actor_type,
+            actor_id=str(actor_id),
+            action="dashboard.publish",
+            outcome="success",
+            after_digest=draft.content_hash,
+        )
+        await session.commit()
+        await session.refresh(draft)
+        return draft
+
+    async def reload_dashboard(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        actor_id: UUID,
+        base_etag: str,
+        change_summary: str,
+        semantic_model_versions: dict[str, str] | None = None,
+        source_snapshot_ids: list[str] | None = None,
+        actor_type: str = "human",
+    ) -> tuple[Dashboard, dict[str, Any]]:
+        repo = DashboardRepository(session)
+        asset = await repo.get_asset(asset_id, tenant_id)
+        if not asset:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+        if asset.etag != base_etag:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "etag_conflict", "current_etag": asset.etag},
+            )
+        if not asset.published_version_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no published version to reload")
+
+        published = await repo.get_asset_version(
+            tenant_id=tenant_id,
+            asset_id=asset_id,
+            version_id=asset.published_version_id,
+        )
+        if not published or not published.manifest_json:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Published dashboard version not found")
+
+        manifest = json.loads(self.canonical_json(published.manifest_json))
+        semantic_diff = self._apply_reload_targets(
+            manifest=manifest,
+            base_version=published,
+            semantic_model_versions=semantic_model_versions or {},
+            source_snapshot_ids=source_snapshot_ids,
+        )
+        manifest.setdefault("provenance", {})["updated_at"] = datetime.utcnow().isoformat()
+        manifest.setdefault("migration", {})["state"] = "needs_review"
+        manifest = self.validate_manifest_payload(manifest)
+        validation = self.validation_summary(manifest)
+        semantic_diff["blockers"] = validation["blockers"]
+        semantic_diff["warnings"] = [*semantic_diff["warnings"], *validation["warnings"]]
+
+        content_hash = self.digest_payload(manifest)
+        next_version = await repo.get_asset_next_version_num(asset_id)
+        version = Dashboard(
+            tenant_id=tenant_id,
+            notebook_id=published.notebook_id,
+            asset_id=asset.id,
+            version_num=next_version,
+            html_content=published.html_content,
+            manifest_schema_version=manifest["schema_version"],
+            manifest_json=manifest,
+            content_hash=content_hash,
+            status="draft",
+            created_by=actor_id,
+            actor_type=actor_type,
+            change_summary=change_summary,
+            pinned_model_versions_json=self._manifest_model_versions(manifest),
+            pinned_source_snapshots_json=self._manifest_source_snapshots(manifest),
+            validation_result_json={**validation, "semantic_diff": semantic_diff},
+            migration_state=manifest["migration"]["state"],
+            is_published_immutable=False,
+        )
+        session.add(version)
+        await session.flush()
+
+        semantic_diff["draft_version_id"] = str(version.id)
+        semantic_diff["draft_version_num"] = version.version_num
+        version.validation_result_json = {**validation, "semantic_diff": semantic_diff}
+        asset.current_draft_version_id = version.id
+        asset.lifecycle = "in_review"
+        asset.etag = self.digest_payload({"reload": str(version.id), "base_etag": base_etag, "content_hash": content_hash})
+        asset.health_summary_json = {
+            **(asset.health_summary_json or {}),
+            "freshness": "unknown",
+            "last_reload_draft_version_id": str(version.id),
+            "last_reload_base_version_id": str(published.id),
+            "semantic_diff": semantic_diff,
+        }
+        await self._audit(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=version.id,
+            actor_type=actor_type,
+            actor_id=str(actor_id),
+            action="dashboard.reload",
+            outcome="blocked" if validation["blockers"] else "success",
+            before_digest=published.content_hash,
+            after_digest=content_hash,
+            details={"semantic_diff": semantic_diff},
+        )
+        await session.commit()
+        await session.refresh(version)
+        return version, semantic_diff
+
+    async def export_dashboard_html(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        actor_id: UUID,
+        actor_type: str = "human",
+        version_num: int | None = None,
+        correlation_id: str | None = None,
+    ) -> tuple[str, str]:
+        repo = DashboardRepository(session)
+        asset = await repo.get_asset(asset_id, tenant_id)
+        if not asset:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+
+        if version_num is not None:
+            version = await repo.get_asset_version_by_num(
+                tenant_id=tenant_id,
+                asset_id=asset_id,
+                version_num=version_num,
+            )
+        elif asset.published_version_id:
+            version = await repo.get_asset_version(
+                tenant_id=tenant_id,
+                asset_id=asset_id,
+                version_id=asset.published_version_id,
+            )
+        else:
+            version = None
+        if not version:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard version not found")
+        if version.status == "draft":
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Draft dashboards must be published before export")
+
+        if not version.manifest_json:
+            if not version.html_content:
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard version has no exportable content")
+            html_content = version.html_content
+            artifact_kind = "legacy_html"
+        else:
+            manifest = self.validate_manifest_payload(version.manifest_json)
+            html_content = self._render_structured_export_html(asset, version, manifest)
+            artifact_kind = "structured_manifest_html"
+
+        await self._audit(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=version.id,
+            actor_type=actor_type,
+            actor_id=str(actor_id),
+            action="dashboard.export",
+            outcome="success",
+            correlation_id=correlation_id,
+            after_digest=version.content_hash,
+            details={"version_num": version.version_num, "artifact_kind": artifact_kind},
+        )
+        await session.commit()
+        filename = f"{asset.slug or asset.id}-v{version.version_num}.html"
+        return html_content, filename
+
+    async def query_dashboard(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        actor_id: str,
+        actor_type: str,
+        filters: dict[str, Any] | None = None,
+        data_view_ids: list[str] | None = None,
+        mode: str = "live",
+        correlation_id: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        if mode != "live":
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="pinned_snapshot artifacts are not available")
+
+        repo = DashboardRepository(session)
+        asset = await repo.get_asset(asset_id, tenant_id)
+        if not asset:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+        if not asset.published_version_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no published version")
+
+        version = await repo.get_asset_version(
+            tenant_id=tenant_id,
+            asset_id=asset_id,
+            version_id=asset.published_version_id,
+        )
+        if not version or not version.manifest_json:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Published dashboard version not found")
+
+        manifest = self.validate_manifest_payload(version.manifest_json)
+        selected_data_views = self._select_data_views(manifest, data_view_ids)
+        normalized_filters = self._normalize_filters(manifest, selected_data_views, filters or {})
+        policy_blockers = self._manifest_policy_blockers(manifest)
+        filter_digest = self.digest_payload(normalized_filters)
+        execution_plan_digest = self.digest_payload(
+            {
+                "dashboard_version_id": str(version.id),
+                "data_view_ids": [view["id"] for view in selected_data_views],
+                "pinned_versions": {
+                    "semantic_models": version.pinned_model_versions_json,
+                    "source_snapshots": version.pinned_source_snapshots_json,
+                },
+            }
+        )
+        started_at = datetime.utcnow()
+        if policy_blockers:
+            view_results = [
+                self._permission_denied_view_result(data_view=data_view, policy_blockers=policy_blockers)
+                for data_view in selected_data_views
+            ]
+        else:
+            view_results = []
+            for data_view in selected_data_views:
+                view_results.append(
+                    await self._execute_data_view(
+                        session=session,
+                        tenant_id=tenant_id,
+                        actor_id=actor_id,
+                        manifest=manifest,
+                        data_view=data_view,
+                        normalized_filters=normalized_filters,
+                    )
+                )
+
+        completed_at = datetime.utcnow()
+        overall_freshness = self._overall_freshness(view_results)
+        run_payload = {
+            "contract_version": "dashboard.run.v1",
+            "run_id": str(uuid4()),
+            "dashboard_id": str(asset.id),
+            "dashboard_version_id": str(version.id),
+            "actor_type": actor_type,
+            "actor_id": actor_id,
+            "correlation_id": correlation_id,
+            "idempotency_key": idempotency_key,
+            "mode": mode,
+            "normalized_filters": normalized_filters,
+            "filter_digest": filter_digest,
+            "pinned_versions": {
+                "semantic_models": version.pinned_model_versions_json,
+                "source_snapshots": version.pinned_source_snapshots_json,
+            },
+            "execution_plan_digest": execution_plan_digest,
+            "started_at": started_at.isoformat(),
+            "completed_at": completed_at.isoformat(),
+            "overall_freshness": overall_freshness,
+            "views": view_results,
+            "warnings": self._run_warnings(view_results),
+            "errors": [view["error"] for view in view_results if view.get("error")],
+        }
+        run = DashboardRun(
+            id=UUID(run_payload["run_id"]),
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=version.id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            mode=mode,
+            normalized_filters_json=normalized_filters,
+            filter_digest=filter_digest,
+            pinned_versions_json=run_payload["pinned_versions"],
+            execution_plan_digest=execution_plan_digest,
+            overall_freshness=overall_freshness,
+            result_manifest_json=run_payload,
+            warnings_json=run_payload["warnings"],
+            errors_json=run_payload["errors"],
+            started_at=started_at,
+            completed_at=completed_at,
+        )
+        session.add(run)
+        await self._audit(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=version.id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action="dashboard.query",
+            outcome=self._run_outcome(view_results),
+            correlation_id=correlation_id,
+            details={"run_id": str(run.id), "data_view_ids": [view["data_view_id"] for view in view_results]},
+        )
+        await session.commit()
+        return run_payload
+
+    async def preview_dashboard(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        actor_id: str,
+        actor_type: str,
+        filters: dict[str, Any] | None = None,
+        data_view_ids: list[str] | None = None,
+        correlation_id: str | None = None,
+    ) -> dict[str, Any]:
+        repo = DashboardRepository(session)
+        asset = await repo.get_asset(asset_id, tenant_id)
+        if not asset:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard asset not found")
+        if not asset.current_draft_version_id:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no editable draft")
+
+        version = await repo.get_asset_version(
+            tenant_id=tenant_id,
+            asset_id=asset_id,
+            version_id=asset.current_draft_version_id,
+        )
+        if not version or not version.manifest_json:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard draft not found")
+
+        manifest = self.validate_manifest_payload(version.manifest_json)
+        selected_data_views = self._select_data_views(manifest, data_view_ids)
+        normalized_filters = self._normalize_filters(manifest, selected_data_views, filters or {})
+        policy_blockers = self._manifest_policy_blockers(manifest)
+        filter_digest = self.digest_payload(normalized_filters)
+        execution_plan_digest = self.digest_payload(
+            {
+                "dashboard_version_id": str(version.id),
+                "data_view_ids": [view["id"] for view in selected_data_views],
+                "preview": True,
+            }
+        )
+        started_at = datetime.utcnow()
+        if policy_blockers:
+            view_results = [
+                self._permission_denied_view_result(data_view=data_view, policy_blockers=policy_blockers)
+                for data_view in selected_data_views
+            ]
+        else:
+            view_results = [
+                await self._execute_data_view(
+                    session=session,
+                    tenant_id=tenant_id,
+                    actor_id=actor_id,
+                    manifest=manifest,
+                    data_view=data_view,
+                    normalized_filters=normalized_filters,
+                )
+                for data_view in selected_data_views
+            ]
+        completed_at = datetime.utcnow()
+        run_payload = {
+            "contract_version": "dashboard.run.v1",
+            "run_id": str(uuid4()),
+            "dashboard_id": str(asset.id),
+            "dashboard_version_id": str(version.id),
+            "actor_type": actor_type,
+            "actor_id": actor_id,
+            "correlation_id": correlation_id,
+            "mode": "live",
+            "preview": True,
+            "normalized_filters": normalized_filters,
+            "filter_digest": filter_digest,
+            "pinned_versions": {
+                "semantic_models": version.pinned_model_versions_json,
+                "source_snapshots": version.pinned_source_snapshots_json,
+            },
+            "execution_plan_digest": execution_plan_digest,
+            "started_at": started_at.isoformat(),
+            "completed_at": completed_at.isoformat(),
+            "overall_freshness": self._overall_freshness(view_results),
+            "views": view_results,
+            "warnings": self._run_warnings(view_results),
+            "errors": [view["error"] for view in view_results if view.get("error")],
+        }
+        await self._audit(
+            session=session,
+            tenant_id=tenant_id,
+            asset_id=asset.id,
+            version_id=version.id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action="dashboard.preview",
+            outcome=self._run_outcome(view_results),
+            correlation_id=correlation_id,
+            details={"run_id": run_payload["run_id"], "data_view_ids": [view["data_view_id"] for view in view_results]},
+        )
+        await session.commit()
+        return run_payload
+
+    @staticmethod
+    def validation_summary(manifest: dict[str, Any]) -> dict[str, Any]:
+        blockers: list[str] = []
+        warnings: list[str] = []
+        if not manifest.get("data_views"):
+            blockers.append("manifest must contain at least one data view")
+        if not manifest.get("tiles"):
+            blockers.append("manifest must contain at least one tile")
+        if manifest.get("migration", {}).get("state") == "legacy_unstructured":
+            blockers.append("legacy_unstructured dashboards cannot publish structured versions")
+        if any(binding.get("readiness") != "published" for binding in manifest.get("semantic_bindings", [])):
+            blockers.append("all semantic bindings must pin published model versions")
+        saved_query_views = [
+            data_view["id"] for data_view in manifest.get("data_views", []) if data_view.get("kind") == "saved_query"
+        ]
+        if saved_query_views:
+            warnings.append(f"saved_query compatibility views require lineage review: {', '.join(saved_query_views)}")
+        return {"valid": not blockers, "blockers": blockers, "warnings": warnings, "validated_at": datetime.utcnow().isoformat()}
+
+    def _select_data_views(self, manifest: dict[str, Any], data_view_ids: list[str] | None) -> list[dict[str, Any]]:
+        views_by_id = {data_view["id"]: data_view for data_view in manifest.get("data_views", [])}
+        if not data_view_ids:
+            return list(views_by_id.values())
+        missing = [data_view_id for data_view_id in data_view_ids if data_view_id not in views_by_id]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="One or more data views are not available for this dashboard",
+            )
+        return [views_by_id[data_view_id] for data_view_id in data_view_ids]
+
+    def _normalize_filters(
+        self,
+        manifest: dict[str, Any],
+        selected_data_views: list[dict[str, Any]],
+        filters: dict[str, Any],
+    ) -> dict[str, Any]:
+        selected_ids = {data_view["id"] for data_view in selected_data_views}
+        selected_filter_fields: set[str] = set()
+        for data_view in selected_data_views:
+            selected_filter_fields.update(str(field) for field in data_view.get("filter_fields") or [])
+        allowed_filters = [
+            dashboard_filter
+            for dashboard_filter in manifest.get("filters", [])
+            if self._filter_applies_to_selected_views(dashboard_filter, selected_ids)
+            and dashboard_filter.get("field") in selected_filter_fields
+        ]
+        filters_by_key: dict[str, dict[str, Any]] = {}
+        for dashboard_filter in allowed_filters:
+            filters_by_key[str(dashboard_filter["id"])] = dashboard_filter
+            filters_by_key[str(dashboard_filter["field"])] = dashboard_filter
+        unknown_filters = sorted(str(filter_id) for filter_id in filters if filter_id not in filters_by_key)
+        if unknown_filters:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="One or more filters are not available for this dashboard data view",
+            )
+
+        normalized: dict[str, Any] = {}
+        for dashboard_filter in allowed_filters:
+            value_present, raw_value = self._filter_value(dashboard_filter, filters)
+            if self._has_conflicting_filter_values(dashboard_filter, filters):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="One or more dashboard filters have invalid values",
+                )
+            if not value_present:
+                default_value = dashboard_filter.get("default_value")
+                if default_value is not None:
+                    normalized[str(dashboard_filter["field"])] = self._validate_filter_value(dashboard_filter, default_value)
+                    continue
+                if dashboard_filter.get("required"):
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="One or more required dashboard filters are missing",
+                    )
+                continue
+            normalized[str(dashboard_filter["field"])] = self._validate_filter_value(dashboard_filter, raw_value)
+        return {key: normalized[key] for key in sorted(normalized)}
+
+    @staticmethod
+    def _filter_applies_to_selected_views(dashboard_filter: dict[str, Any], selected_ids: set[str]) -> bool:
+        affected_ids = set(dashboard_filter.get("affected_data_view_ids") or [])
+        return not affected_ids or bool(selected_ids.intersection(affected_ids))
+
+    @staticmethod
+    def _filter_value(dashboard_filter: dict[str, Any], filters: dict[str, Any]) -> tuple[bool, Any]:
+        filter_id = str(dashboard_filter["id"])
+        field = str(dashboard_filter["field"])
+        if filter_id in filters:
+            return True, filters[filter_id]
+        if field in filters:
+            return True, filters[field]
+        return False, None
+
+    @staticmethod
+    def _has_conflicting_filter_values(dashboard_filter: dict[str, Any], filters: dict[str, Any]) -> bool:
+        filter_id = str(dashboard_filter["id"])
+        field = str(dashboard_filter["field"])
+        return filter_id != field and filter_id in filters and field in filters and filters[filter_id] != filters[field]
+
+    def _validate_filter_value(self, dashboard_filter: dict[str, Any], value: Any) -> Any:
+        filter_type = str(dashboard_filter.get("filter_type") or "")
+        if self._is_empty_filter_value(value):
+            if dashboard_filter.get("required"):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="One or more required dashboard filters are missing",
+                )
+            return value
+
+        if not self._filter_value_matches_type(filter_type, value):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="One or more dashboard filters have invalid values",
+            )
+        domain = dashboard_filter.get("domain")
+        if domain is not None:
+            values = value if isinstance(value, list) else [value]
+            if any(item not in domain for item in values):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="One or more dashboard filters have invalid values",
+                )
+        return value
+
+    @staticmethod
+    def _is_empty_filter_value(value: Any) -> bool:
+        return value is None or value == "" or value == []
+
+    @staticmethod
+    def _filter_value_matches_type(filter_type: str, value: Any) -> bool:
+        if filter_type in {"string", "date", "datetime"}:
+            return isinstance(value, str)
+        if filter_type == "enum":
+            if isinstance(value, list):
+                return all(isinstance(item, (str, int, float, bool)) for item in value)
+            return isinstance(value, (str, int, float, bool))
+        if filter_type == "boolean":
+            return isinstance(value, bool)
+        if filter_type == "integer":
+            return isinstance(value, int) and not isinstance(value, bool)
+        if filter_type == "number":
+            return isinstance(value, int | float) and not isinstance(value, bool)
+        if filter_type == "date_range":
+            return isinstance(value, dict) and set(value).issubset({"start", "end"}) and bool(value)
+        return True
+
+    @staticmethod
+    def _manifest_policy_blockers(manifest: dict[str, Any]) -> dict[str, list[str]]:
+        access_policy = manifest.get("access_policy") or {}
+        blockers = {
+            "row_policy_refs": sorted(str(ref) for ref in access_policy.get("row_policy_refs") or []),
+            "column_policy_refs": sorted(str(ref) for ref in access_policy.get("column_policy_refs") or []),
+            "redaction_policy_refs": sorted(str(ref) for ref in access_policy.get("redaction_policy_refs") or []),
+        }
+        return {kind: refs for kind, refs in blockers.items() if refs}
+
+    @staticmethod
+    def _permission_denied_view_result(
+        *,
+        data_view: dict[str, Any],
+        policy_blockers: dict[str, list[str]],
+    ) -> dict[str, Any]:
+        policy_reason = "; ".join(f"{kind}={','.join(refs)}" for kind, refs in policy_blockers.items())
+        return {
+            "data_view_id": data_view["id"],
+            "status": "permission_denied",
+            "result": None,
+            "schema": data_view.get("output_schema", []),
+            "row_count": 0,
+            "cached": False,
+            "stale": False,
+            "warnings": ["Dashboard access policy refs are not resolved for this execution context"],
+            "error": {
+                "code": "policy_not_enforced",
+                "message": "Dashboard data view execution is blocked by unresolved access policy refs",
+                "retryable": False,
+                "policy_reason": policy_reason,
+            },
+            "evidence": data_view.get("evidence", []),
+            "lineage": data_view.get("lineage") or data_view.get("saved_query", {}).get("lineage", []),
+        }
+
+    async def _execute_data_view(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        actor_id: str,
+        manifest: dict[str, Any],
+        data_view: dict[str, Any],
+        normalized_filters: dict[str, Any],
+    ) -> dict[str, Any]:
+        if data_view["kind"] == "saved_query":
+            return await self._execute_saved_query_view(
+                session=session,
+                data_view=data_view,
+                normalized_filters=normalized_filters,
+            )
+        if data_view["kind"] == "semantic_metric":
+            return await self._execute_semantic_metric_view(
+                session=session,
+                tenant_id=tenant_id,
+                actor_id=actor_id,
+                manifest=manifest,
+                data_view=data_view,
+                normalized_filters=normalized_filters,
+            )
+        if data_view["kind"] == "context_search":
+            return await self._execute_context_search_view(
+                session=session,
+                tenant_id=tenant_id,
+                data_view=data_view,
+                normalized_filters=normalized_filters,
+            )
+        return self._blocked_view_result(
+            data_view=data_view,
+            code="unsupported_data_view_kind",
+            message="Dashboard data view kind is not supported",
+        )
+
+    async def _execute_saved_query_view(
+        self,
+        *,
+        session: AsyncSession,
+        data_view: dict[str, Any],
+        normalized_filters: dict[str, Any],
+    ) -> dict[str, Any]:
+        saved_query = data_view["saved_query"]
+        filter_payload = self._filters_for_data_view(data_view, normalized_filters)
+        result = await QueryService.execute_saved_query(
+            session,
+            saved_query["query_id"],
+            filters=filter_payload,
+        )
+        success = bool(result.get("success"))
+        rows = result.get("data") if success else None
+        bounded_rows, row_count, pagination, bound_warnings = self._bounded_result(data_view, rows)
+        as_of = result.get("as_of") or result.get("cached_at") or datetime.utcnow().isoformat()
+        stale = bool(result.get("stale", False)) or self._is_data_view_stale(data_view, as_of)
+        status_value = "success" if success and row_count > 0 else "empty" if success else "error"
+        if success and stale:
+            status_value = "stale"
+        view_result = {
+            "data_view_id": data_view["id"],
+            "status": status_value,
+            "result": bounded_rows,
+            "schema": data_view.get("output_schema", []),
+            "row_count": row_count,
+            "cached": bool(result.get("cached", False)),
+            "stale": stale,
+            "as_of": as_of,
+            "warnings": [f"saved_query compatibility binding: {saved_query['compatibility_reason']}", *bound_warnings],
+            "evidence": data_view.get("evidence", []),
+            "lineage": data_view.get("lineage") or saved_query.get("lineage", []),
+            "pagination": pagination,
+        }
+        if not success:
+            view_result["error"] = {
+                "code": "saved_query_failed",
+                "message": "Dashboard data view execution failed",
+                "retryable": True,
+            }
+        return view_result
+
+    async def _execute_semantic_metric_view(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        actor_id: str,
+        manifest: dict[str, Any],
+        data_view: dict[str, Any],
+        normalized_filters: dict[str, Any],
+    ) -> dict[str, Any]:
+        semantic_metric = data_view["semantic_metric"]
+        binding = self._semantic_binding(manifest, semantic_metric["semantic_binding_id"])
+        if binding is None:
+            return self._blocked_view_result(
+                data_view=data_view,
+                code="semantic_binding_missing",
+                message="Dashboard semantic binding is not available for this data view",
+            )
+
+        policy_denial = self._semantic_binding_denial(binding, semantic_metric)
+        if policy_denial:
+            return self._blocked_view_result(
+                data_view=data_view,
+                status_value="permission_denied",
+                code="semantic_binding_not_allowed",
+                message="Dashboard semantic binding does not allow this metric or dimension",
+                policy_reason=policy_denial,
+            )
+        return self._blocked_view_result(
+            data_view=data_view,
+            code="semantic_metric_partial",
+            message="Semantic metric execution is deferred until the official Modeling domain lands",
+            retryable=False,
+        )
+
+    async def _execute_context_search_view(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        data_view: dict[str, Any],
+        normalized_filters: dict[str, Any],
+    ) -> dict[str, Any]:
+        binding = data_view["context_search"]
+        resource_id = self._optional_uuid(binding["source_binding_id"])
+        if resource_id is None:
+            return self._blocked_view_result(
+                data_view=data_view,
+                code="context_binding_invalid",
+                message="Context search data view must bind to a source resource id",
+            )
+
+        return self._blocked_view_result(
+            data_view=data_view,
+            code="context_search_partial",
+            message="Context search execution is deferred until the official Source Resource domain lands",
+            retryable=False,
+        )
+
+    @staticmethod
+    def _filters_for_data_view(data_view: dict[str, Any], normalized_filters: dict[str, Any]) -> list[SavedQueryFilter] | None:
+        filter_fields = set(data_view.get("filter_fields") or [])
+        if not filter_fields:
+            return None
+        filters: list[SavedQueryFilter] = []
+        for field in sorted(filter_fields):
+            if field in normalized_filters:
+                filters.append(SavedQueryFilter(field=field, operator="eq", value=normalized_filters[field]))
+        return filters or None
+
+    @staticmethod
+    def _filters_for_semantic_view(data_view: dict[str, Any], normalized_filters: dict[str, Any]) -> dict[str, Any]:
+        filter_fields = set(data_view.get("filter_fields") or [])
+        return {field: normalized_filters[field] for field in sorted(filter_fields) if field in normalized_filters}
+
+    @staticmethod
+    def _semantic_binding(manifest: dict[str, Any], binding_id: str) -> dict[str, Any] | None:
+        return next(
+            (binding for binding in manifest.get("semantic_bindings", []) if binding.get("id") == binding_id),
+            None,
+        )
+
+    @staticmethod
+    def _semantic_binding_denial(binding: dict[str, Any], semantic_metric: dict[str, Any]) -> str:
+        denied: list[str] = []
+        allowed_metrics = set(binding.get("allowed_metrics") or [])
+        if allowed_metrics and semantic_metric.get("metric") not in allowed_metrics:
+            denied.append("metric_not_allowlisted")
+        allowed_dimensions = set(binding.get("allowed_dimensions") or [])
+        denied_dimensions = [
+            dimension for dimension in semantic_metric.get("dimensions", []) if allowed_dimensions and dimension not in allowed_dimensions
+        ]
+        if denied_dimensions:
+            denied.append(f"dimensions_not_allowlisted={','.join(sorted(denied_dimensions))}")
+        return "; ".join(denied)
+
+    @staticmethod
+    def _bounded_result(data_view: dict[str, Any], rows: Any) -> tuple[Any, int, dict[str, Any], list[str]]:
+        row_limit = int(data_view.get("row_limit") or 500)
+        byte_limit = int(data_view.get("byte_limit") or 1_000_000)
+        warnings: list[str] = []
+        has_more = False
+        if isinstance(rows, list):
+            bounded = rows[:row_limit]
+            has_more = len(rows) > row_limit
+            if has_more:
+                warnings.append("Dashboard data view result was truncated to the manifest row limit")
+            byte_truncated = False
+            while bounded and len(json.dumps(bounded, ensure_ascii=False, default=str).encode("utf-8")) > byte_limit:
+                bounded = bounded[:-1]
+                has_more = True
+                byte_truncated = True
+            if byte_truncated:
+                warnings.append("Dashboard data view result was truncated to the manifest byte limit")
+            return bounded, len(bounded), {"cursor": None, "has_more": has_more, "limit": row_limit}, warnings
+        if isinstance(rows, dict):
+            encoded_size = len(json.dumps(rows, ensure_ascii=False, default=str).encode("utf-8"))
+            if encoded_size > byte_limit:
+                warnings.append("Dashboard data view result exceeded the manifest byte limit")
+                return None, 0, {"cursor": None, "has_more": True, "limit": row_limit}, warnings
+            return rows, 1, {"cursor": None, "has_more": False, "limit": row_limit}, warnings
+        return rows, 0, {"cursor": None, "has_more": False, "limit": row_limit}, warnings
+
+    @staticmethod
+    def _is_data_view_stale(data_view: dict[str, Any], as_of: Any) -> bool:
+        freshness_policy = data_view.get("freshness_policy") or {}
+        if not freshness_policy.get("allow_stale", True):
+            return False
+        max_age_seconds = freshness_policy.get("max_age_seconds")
+        if max_age_seconds is None:
+            return False
+        try:
+            as_of_text = str(as_of).replace("Z", "+00:00")
+            as_of_dt = datetime.fromisoformat(as_of_text).replace(tzinfo=None)
+            return (datetime.utcnow() - as_of_dt).total_seconds() > int(max_age_seconds)
+        except (TypeError, ValueError):
+            return False
+
+    @staticmethod
+    def _blocked_view_result(
+        *,
+        data_view: dict[str, Any],
+        code: str,
+        message: str,
+        status_value: str = "blocked",
+        retryable: bool = False,
+        policy_reason: str | None = None,
+    ) -> dict[str, Any]:
+        error: dict[str, Any] = {"code": code, "message": message, "retryable": retryable}
+        if policy_reason:
+            error["policy_reason"] = policy_reason
+        return {
+            "data_view_id": data_view["id"],
+            "status": status_value,
+            "result": None,
+            "schema": data_view.get("output_schema", []),
+            "row_count": 0,
+            "cached": False,
+            "stale": False,
+            "warnings": [message],
+            "error": error,
+            "evidence": data_view.get("evidence", []),
+            "lineage": data_view.get("lineage", []),
+        }
+
+    @staticmethod
+    def _optional_uuid(value: str | UUID | None) -> UUID | None:
+        if isinstance(value, UUID):
+            return value
+        try:
+            return UUID(str(value))
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _coerce_warnings(value: Any) -> list[str]:
+        if not value:
+            return []
+        if isinstance(value, list):
+            return [str(item) for item in value if item]
+        return [str(value)]
+
+    @staticmethod
+    def _semantic_metric_evidence(
+        data_view: dict[str, Any],
+        binding: dict[str, Any],
+        semantic_metric: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        return [
+            *data_view.get("evidence", []),
+            {
+                "id": f"{data_view['id']}:metric-definition",
+                "kind": "semantic_metric",
+                "title": f"Metric definition for {semantic_metric['metric']}",
+                "locator": {
+                    "model_slug": binding["model_slug"],
+                    "model_version": binding["model_version"],
+                    "metric": semantic_metric["metric"],
+                },
+                "confidence": 1,
+            },
+        ]
+
+    @staticmethod
+    def _semantic_metric_lineage(
+        data_view: dict[str, Any],
+        binding: dict[str, Any],
+        semantic_metric: dict[str, Any],
+        result: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        lineage = [
+            *data_view.get("lineage", []),
+            {
+                "id": f"{data_view['id']}:metric",
+                "kind": "metric",
+                "name": semantic_metric["metric"],
+                "ref": f"{binding['model_slug']}.{semantic_metric['metric']}",
+                "version": binding["model_version"],
+            },
+            {
+                "id": f"{data_view['id']}:semantic-model",
+                "kind": "semantic_model",
+                "name": binding["model_slug"],
+                "ref": binding["model_slug"],
+                "version": binding["model_version"],
+            },
+        ]
+        for snapshot_id in binding.get("source_snapshot_ids") or []:
+            lineage.append(
+                {
+                    "id": f"{data_view['id']}:source:{snapshot_id}",
+                    "kind": "source_snapshot",
+                    "name": str(snapshot_id),
+                    "ref": str(snapshot_id),
+                    "version": None,
+                }
+            )
+        for item in result.get("lineage") or []:
+            if isinstance(item, dict) and item.get("id"):
+                lineage.append(
+                    {
+                        "id": str(item.get("id")),
+                        "kind": str(item.get("kind") or "metric"),
+                        "name": str(item.get("name") or item.get("id")),
+                        "ref": str(item.get("ref") or item.get("id")),
+                        "version": str(item.get("version")) if item.get("version") is not None else None,
+                    }
+                )
+        return lineage
+
+    @staticmethod
+    def _render_context_query(query_template: str, normalized_filters: dict[str, Any]) -> str:
+        query = query_template
+        for key, value in normalized_filters.items():
+            query = query.replace("{" + key + "}", str(value))
+        return query
+
+    @staticmethod
+    def _context_search_row(item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "evidence_id": str(item.get("id") or ""),
+            "text": str(item.get("text") or ""),
+            "title_path": item.get("title_path") or [],
+            "locator": item.get("locator_json") or {},
+            "snapshot_id": str(item.get("snapshot_id") or ""),
+            "confidence": item.get("confidence"),
+        }
+
+    @staticmethod
+    def _context_evidence_locator(item: dict[str, Any]) -> dict[str, Any]:
+        title_path = item.get("title_path") or []
+        title = " / ".join(str(part) for part in title_path if part) or "Context evidence"
+        return {
+            "id": str(item.get("id") or ""),
+            "kind": str(item.get("fragment_type") or "context_search"),
+            "title": title,
+            "locator": item.get("locator_json") or {},
+            "confidence": DashboardService._confidence_float(item.get("confidence")),
+        }
+
+    @staticmethod
+    def _confidence_float(value: Any) -> float | None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _overall_freshness(view_results: list[dict[str, Any]]) -> str:
+        if any(view.get("status") in {"error", "blocked", "permission_denied"} for view in view_results):
+            return "partial" if any(view.get("status") in {"success", "empty", "stale"} for view in view_results) else "blocked"
+        if any(view.get("stale") for view in view_results):
+            return "stale"
+        return "fresh"
+
+    @staticmethod
+    def _run_warnings(view_results: list[dict[str, Any]]) -> list[str]:
+        warnings: list[str] = []
+        for view in view_results:
+            warnings.extend(str(warning) for warning in view.get("warnings", []))
+        return warnings
+
+    @staticmethod
+    def _run_outcome(view_results: list[dict[str, Any]]) -> str:
+        if not any(view.get("error") for view in view_results):
+            return "success"
+        if all(view.get("status") in {"blocked", "permission_denied", "error"} for view in view_results):
+            return "blocked"
+        return "partial"
+
+    @staticmethod
+    def _manifest_model_versions(manifest: dict[str, Any]) -> dict[str, str]:
+        return {
+            binding["model_slug"]: binding["model_version"]
+            for binding in manifest.get("semantic_bindings", [])
+            if binding.get("model_slug") and binding.get("model_version")
+        }
+
+    @staticmethod
+    def _manifest_source_snapshots(manifest: dict[str, Any]) -> list[str]:
+        snapshots: list[str] = []
+        for binding in manifest.get("semantic_bindings", []):
+            snapshots.extend(str(snapshot_id) for snapshot_id in binding.get("source_snapshot_ids", []))
+        return sorted(set(snapshots))
+
+    def _apply_reload_targets(
+        self,
+        *,
+        manifest: dict[str, Any],
+        base_version: Dashboard,
+        semantic_model_versions: dict[str, str],
+        source_snapshot_ids: list[str] | None,
+    ) -> dict[str, Any]:
+        diff: dict[str, Any] = {
+            "base_version_id": str(base_version.id),
+            "base_version_num": base_version.version_num,
+            "draft_version_id": None,
+            "draft_version_num": None,
+            "model_version_changes": [],
+            "source_snapshot_changes": [],
+            "filter_changes": [],
+            "tile_changes": [],
+            "policy_changes": [],
+            "warnings": [],
+            "blockers": [],
+        }
+        for binding in manifest.get("semantic_bindings", []):
+            requested_model_version = semantic_model_versions.get(binding["id"]) or semantic_model_versions.get(
+                binding["model_slug"]
+            )
+            if requested_model_version and requested_model_version != binding["model_version"]:
+                diff["model_version_changes"].append(
+                    {
+                        "binding_id": binding["id"],
+                        "model_slug": binding["model_slug"],
+                        "from": binding["model_version"],
+                        "to": requested_model_version,
+                    }
+                )
+                binding["model_version"] = requested_model_version
+
+            if source_snapshot_ids is not None:
+                next_snapshots = sorted(set(source_snapshot_ids))
+                current_snapshots = sorted(set(binding.get("source_snapshot_ids", [])))
+                if next_snapshots != current_snapshots:
+                    diff["source_snapshot_changes"].append(
+                        {
+                            "binding_id": binding["id"],
+                            "model_slug": binding["model_slug"],
+                            "from": current_snapshots,
+                            "to": next_snapshots,
+                        }
+                    )
+                    binding["source_snapshot_ids"] = next_snapshots
+
+        if not diff["model_version_changes"] and not diff["source_snapshot_changes"]:
+            diff["warnings"].append(
+                "No semantic model or source snapshot changes were supplied; reload draft captures the current published baseline for review."
+            )
+        return diff
+
+    @staticmethod
+    def _render_structured_export_html(asset: DashboardAsset, version: Dashboard, manifest: dict[str, Any]) -> str:
+        title = escape(manifest.get("title") or asset.name)
+        description = escape(manifest.get("description") or asset.description or "")
+        bindings = "".join(
+            "<li>"
+            f"<strong>{escape(binding.get('model_slug', 'model'))}</strong> "
+            f"version {escape(binding.get('model_version', 'unknown'))}"
+            f"<span>{escape(', '.join(binding.get('source_snapshot_ids', [])) or 'no source snapshot')}</span>"
+            "</li>"
+            for binding in manifest.get("semantic_bindings", [])
+        )
+        filters = "".join(
+            "<li>"
+            f"{escape(dashboard_filter.get('label', dashboard_filter.get('id', 'filter')))}"
+            f"<span>{escape(dashboard_filter.get('field', ''))} / {escape(dashboard_filter.get('filter_type', ''))}</span>"
+            "</li>"
+            for dashboard_filter in manifest.get("filters", [])
+        )
+        data_views_by_id = {data_view.get("id"): data_view for data_view in manifest.get("data_views", [])}
+        tiles = "".join(
+            DashboardService._render_export_tile(tile, data_views_by_id.get(tile.get("data_view_id")))
+            for tile in manifest.get("tiles", [])
+        )
+        manifest_json = escape(json.dumps(manifest, sort_keys=True, ensure_ascii=False))
+        return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{title}</title>
+  <style>
+    body {{ margin: 0; font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0d0f11; color: #eef2f3; }}
+    main {{ max-width: 1180px; margin: 0 auto; padding: 32px; }}
+    header {{ border-bottom: 1px solid #293037; padding-bottom: 20px; margin-bottom: 20px; }}
+    h1 {{ margin: 0 0 8px; font-size: 28px; }}
+    h2 {{ font-size: 14px; text-transform: uppercase; color: #9aa4ac; }}
+    p, li, td, th {{ color: #cdd3d8; }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; }}
+    .panel {{ border: 1px solid #293037; border-radius: 8px; background: #14181c; padding: 16px; }}
+    .tile h3 {{ margin: 0 0 8px; font-size: 16px; }}
+    .meta {{ display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }}
+    .pill {{ border: 1px solid #3a444d; border-radius: 999px; padding: 4px 8px; color: #cdd3d8; font-size: 12px; }}
+    li span {{ display: block; color: #818c95; font-size: 12px; margin-top: 4px; }}
+    code {{ white-space: pre-wrap; word-break: break-word; color: #d6dde2; }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      <div class="meta">
+        <span class="pill">dashboard.manifest.v1</span>
+        <span class="pill">version {version.version_num}</span>
+        <span class="pill">{escape(version.status)}</span>
+        <span class="pill">{escape(version.content_hash or "no hash")}</span>
+      </div>
+    </header>
+    <section class="grid">
+      <div class="panel"><h2>Semantic Bindings</h2><ul>{bindings or "<li>No bindings</li>"}</ul></div>
+      <div class="panel"><h2>Filters</h2><ul>{filters or "<li>No global filters</li>"}</ul></div>
+    </section>
+    <section>
+      <h2>Tiles</h2>
+      <div class="grid">{tiles or '<div class="panel">No tiles</div>'}</div>
+    </section>
+    <section class="panel">
+      <h2>Canonical Manifest</h2>
+      <script type="application/json" id="dashboard-manifest">{manifest_json}</script>
+      <code>{manifest_json}</code>
+    </section>
+  </main>
+</body>
+</html>"""
+
+    @staticmethod
+    def _render_export_tile(tile: dict[str, Any], data_view: dict[str, Any] | None) -> str:
+        title = escape(tile.get("title", tile.get("id", "Tile")))
+        question = escape(tile.get("business_question", ""))
+        tile_type = escape(tile.get("tile_type", "tile"))
+        data_view_id = escape(tile.get("data_view_id") or "none")
+        data_view_question = escape((data_view or {}).get("question", "No data view binding"))
+        fields = ", ".join(field.get("name", "") for field in (data_view or {}).get("output_schema", []))
+        return (
+            '<article class="panel tile">'
+            f"<h3>{title}</h3>"
+            f"<p>{question}</p>"
+            '<div class="meta">'
+            f'<span class="pill">{tile_type}</span>'
+            f'<span class="pill">{data_view_id}</span>'
+            "</div>"
+            f"<p>{data_view_question}</p>"
+            f"<p>{escape(fields or 'No output schema')}</p>"
+            "</article>"
+        )
+
+    async def _audit(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        asset_id: UUID,
+        version_id: UUID,
+        actor_type: str,
+        actor_id: str,
+        action: str,
+        outcome: str,
+        before_digest: str | None = None,
+        after_digest: str | None = None,
+        correlation_id: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        session.add(
+            DashboardAuditEvent(
+                tenant_id=tenant_id,
+                asset_id=asset_id,
+                version_id=version_id,
+                actor_type=actor_type,
+                actor_id=actor_id,
+                action=action,
+                outcome=outcome,
+                before_digest=before_digest,
+                after_digest=after_digest,
+                correlation_id=correlation_id,
+                details_json=details or {},
+            )
+        )

--- a/server/services/dashboard.py
+++ b/server/services/dashboard.py
@@ -52,13 +52,17 @@ class DashboardService:
         return manifest.model_dump(mode="json", by_alias=True)
 
     @staticmethod
-    def apply_manifest_patch(manifest_payload: dict[str, Any], patch_operations: list[dict[str, Any]]) -> dict[str, Any]:
+    def apply_manifest_patch(
+        manifest_payload: dict[str, Any], patch_operations: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         manifest = json.loads(DashboardService.canonical_json(manifest_payload))
         for operation in patch_operations:
             op = operation.get("op")
             path = operation.get("path")
             if op not in {"add", "replace", "remove"} or not isinstance(path, str):
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported dashboard patch operation")
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported dashboard patch operation"
+                )
             target = DashboardService._manifest_patch_target(path)
             if target not in DashboardService.PATCHABLE_MANIFEST_PATHS:
                 raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Dashboard patch path is not allowed")
@@ -88,7 +92,9 @@ class DashboardService:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path must be absolute")
         parts = [part for part in path.split("/") if part]
         if not parts:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Dashboard manifest root patch is not allowed")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Dashboard manifest root patch is not allowed"
+            )
         return parts[0].replace("~1", "/").replace("~0", "~")
 
     @staticmethod
@@ -101,7 +107,9 @@ class DashboardService:
             elif isinstance(parent, dict) and part in parent:
                 parent = parent[part]
             else:
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist"
+                )
 
         leaf = parts[-1]
         if isinstance(parent, list):
@@ -115,11 +123,15 @@ class DashboardService:
         elif isinstance(parent, dict):
             if op == "remove":
                 if leaf not in parent:
-                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist"
+                    )
                 parent.pop(leaf)
             elif op in {"add", "replace"}:
                 if op == "replace" and leaf not in parent:
-                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist"
+                    )
                 parent[leaf] = value
         else:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Dashboard patch path does not exist")
@@ -357,7 +369,9 @@ class DashboardService:
         manifest = self.validate_manifest_payload(draft.manifest_json)
         validation = self.validation_summary(manifest)
         if validation["blockers"]:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail={"code": "validation_blocked", **validation})
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail={"code": "validation_blocked", **validation}
+            )
 
         draft.status = "published"
         draft.change_summary = change_summary
@@ -404,7 +418,9 @@ class DashboardService:
                 detail={"code": "etag_conflict", "current_etag": asset.etag},
             )
         if not asset.published_version_id:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no published version to reload")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Dashboard has no published version to reload"
+            )
 
         published = await repo.get_asset_version(
             tenant_id=tenant_id,
@@ -457,7 +473,9 @@ class DashboardService:
         version.validation_result_json = {**validation, "semantic_diff": semantic_diff}
         asset.current_draft_version_id = version.id
         asset.lifecycle = "in_review"
-        asset.etag = self.digest_payload({"reload": str(version.id), "base_etag": base_etag, "content_hash": content_hash})
+        asset.etag = self.digest_payload(
+            {"reload": str(version.id), "base_etag": base_etag, "content_hash": content_hash}
+        )
         asset.health_summary_json = {
             **(asset.health_summary_json or {}),
             "freshness": "unknown",
@@ -515,11 +533,15 @@ class DashboardService:
         if not version:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dashboard version not found")
         if version.status == "draft":
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Draft dashboards must be published before export")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Draft dashboards must be published before export"
+            )
 
         if not version.manifest_json:
             if not version.html_content:
-                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Dashboard version has no exportable content")
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT, detail="Dashboard version has no exportable content"
+                )
             html_content = version.html_content
             artifact_kind = "legacy_html"
         else:
@@ -559,7 +581,9 @@ class DashboardService:
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         if mode != "live":
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="pinned_snapshot artifacts are not available")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="pinned_snapshot artifacts are not available"
+            )
 
         repo = DashboardRepository(session)
         asset = await repo.get_asset(asset_id, tenant_id)
@@ -788,7 +812,12 @@ class DashboardService:
         ]
         if saved_query_views:
             warnings.append(f"saved_query compatibility views require lineage review: {', '.join(saved_query_views)}")
-        return {"valid": not blockers, "blockers": blockers, "warnings": warnings, "validated_at": datetime.utcnow().isoformat()}
+        return {
+            "valid": not blockers,
+            "blockers": blockers,
+            "warnings": warnings,
+            "validated_at": datetime.utcnow().isoformat(),
+        }
 
     def _select_data_views(self, manifest: dict[str, Any], data_view_ids: list[str] | None) -> list[dict[str, Any]]:
         views_by_id = {data_view["id"]: data_view for data_view in manifest.get("data_views", [])}
@@ -840,7 +869,9 @@ class DashboardService:
             if not value_present:
                 default_value = dashboard_filter.get("default_value")
                 if default_value is not None:
-                    normalized[str(dashboard_filter["field"])] = self._validate_filter_value(dashboard_filter, default_value)
+                    normalized[str(dashboard_filter["field"])] = self._validate_filter_value(
+                        dashboard_filter, default_value
+                    )
                     continue
                 if dashboard_filter.get("required"):
                     raise HTTPException(
@@ -1097,7 +1128,9 @@ class DashboardService:
         )
 
     @staticmethod
-    def _filters_for_data_view(data_view: dict[str, Any], normalized_filters: dict[str, Any]) -> list[SavedQueryFilter] | None:
+    def _filters_for_data_view(
+        data_view: dict[str, Any], normalized_filters: dict[str, Any]
+    ) -> list[SavedQueryFilter] | None:
         filter_fields = set(data_view.get("filter_fields") or [])
         if not filter_fields:
             return None
@@ -1127,7 +1160,9 @@ class DashboardService:
             denied.append("metric_not_allowlisted")
         allowed_dimensions = set(binding.get("allowed_dimensions") or [])
         denied_dimensions = [
-            dimension for dimension in semantic_metric.get("dimensions", []) if allowed_dimensions and dimension not in allowed_dimensions
+            dimension
+            for dimension in semantic_metric.get("dimensions", [])
+            if allowed_dimensions and dimension not in allowed_dimensions
         ]
         if denied_dimensions:
             denied.append(f"dimensions_not_allowlisted={','.join(sorted(denied_dimensions))}")
@@ -1327,7 +1362,11 @@ class DashboardService:
     @staticmethod
     def _overall_freshness(view_results: list[dict[str, Any]]) -> str:
         if any(view.get("status") in {"error", "blocked", "permission_denied"} for view in view_results):
-            return "partial" if any(view.get("status") in {"success", "empty", "stale"} for view in view_results) else "blocked"
+            return (
+                "partial"
+                if any(view.get("status") in {"success", "empty", "stale"} for view in view_results)
+                else "blocked"
+            )
         if any(view.get("stale") for view in view_results):
             return "stale"
         return "fresh"

--- a/server/services/evaluation.py
+++ b/server/services/evaluation.py
@@ -1,0 +1,1335 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.conversation_evaluation import ConversationEvaluation
+from server.models.custom_skill import CustomSkill
+from server.models.evaluation import (
+    AdvisorChangeSet,
+    AdvisorSuggestion,
+    EvaluationArtifact,
+    EvaluationAssessment,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    PromotionDecision,
+)
+from server.models.notebooks import Notebook
+from server.models.skill_suggestion import SkillSuggestion
+from server.repositories.evaluation import EvaluationRepository
+from server.schemas.evaluation import EvaluationExpectedContract, EvaluationTargetSnapshot
+from server.utils.error_sanitizer import sanitize_error_payload
+
+SUPPORTED_TARGET_KINDS = {"connector", "semantic_model", "agent_answer", "dashboard", "policy", "end_to_end"}
+SUPPORTED_OPERATIONS = {"answer_question", "execute_sql", "query_dashboard", "apply_policy", "end_to_end_task"}
+
+
+class EvaluationService:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+        self._repo = EvaluationRepository(session)
+
+    async def list_suites(
+        self,
+        *,
+        tenant_id: str | UUID,
+        query: str = "",
+        target_kind: str = "",
+        status: str = "",
+        limit: int = 50,
+    ) -> list[EvaluationSuite]:
+        return await self._repo.list_suites(
+            tenant_id=tenant_id,
+            query=query,
+            target_kind=target_kind,
+            status=status,
+            limit=limit,
+        )
+
+    async def describe_suite(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_id: str | UUID,
+    ) -> tuple[EvaluationSuite, list[EvaluationSuiteVersion]]:
+        suite = await self._repo.get_suite(tenant_id=tenant_id, suite_id=suite_id)
+        if suite is None:
+            raise ValueError("evaluation suite not found")
+        versions = await self._repo.list_suite_versions(tenant_id=tenant_id, suite_id=suite.id)
+        return suite, versions
+
+    async def create_suite_with_draft(
+        self,
+        *,
+        tenant_id: str | UUID,
+        slug: str,
+        name: str,
+        description: str,
+        target_kinds: list[str],
+        gate_policy: dict[str, Any],
+        actor_id: str | UUID,
+    ) -> tuple[EvaluationSuite, EvaluationSuiteVersion]:
+        if await self._repo.get_suite_by_slug(tenant_id=tenant_id, slug=slug):
+            raise ValueError("evaluation suite slug already exists")
+        normalized_target_kinds = self._validate_target_kinds(target_kinds)
+        gate_policy_json = self._default_gate_policy(gate_policy)
+        manifest = {
+            "contract_version": "evaluation.suite_version.v1",
+            "suite_id": slug,
+            "version": 1,
+            "cases": [],
+            "gate_policy": gate_policy_json,
+            "owner": str(actor_id),
+            "description": description,
+        }
+        suite = await self._repo.create_suite(
+            tenant_id=tenant_id,
+            slug=slug,
+            name=name,
+            description=description,
+            owner_id=self._optional_uuid(actor_id),
+            target_kinds_json=normalized_target_kinds,
+            lifecycle="draft",
+        )
+        version = await self._repo.create_suite_version(
+            tenant_id=tenant_id,
+            suite_id=suite.id,
+            version_num=1,
+            status="draft",
+            contract_version="evaluation.suite_version.v1",
+            manifest_json=manifest,
+            gate_policy_json=gate_policy_json,
+            case_count=0,
+            content_hash=self._digest(manifest),
+            created_by=self._optional_uuid(actor_id),
+        )
+        suite.current_draft_version_id = version.id
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite.id,
+            suite_version_id=version.id,
+            run_id=None,
+            actor_type="human",
+            actor_id=str(actor_id),
+            action="evaluation.suite.create",
+            outcome="draft_created",
+            details_json={"slug": slug, "target_kinds": normalized_target_kinds},
+        )
+        await self._session.commit()
+        await self._session.refresh(suite)
+        await self._session.refresh(version)
+        return suite, version
+
+    async def create_draft_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_id: str | UUID,
+        actor_id: str | UUID,
+        copy_from_version_id: str | UUID | None = None,
+    ) -> EvaluationSuiteVersion:
+        suite = await self._repo.get_suite(tenant_id=tenant_id, suite_id=suite_id)
+        if suite is None:
+            raise ValueError("evaluation suite not found")
+        versions = await self._repo.list_suite_versions(tenant_id=tenant_id, suite_id=suite.id)
+        next_version_num = max((version.version_num for version in versions), default=0) + 1
+        source_version = None
+        if copy_from_version_id is not None:
+            source_version = await self._require_suite_version(
+                tenant_id=tenant_id,
+                suite_version_id=copy_from_version_id,
+            )
+            if source_version.suite_id != suite.id:
+                raise ValueError("evaluation source version does not belong to suite")
+        gate_policy_json = self._default_gate_policy(source_version.gate_policy_json if source_version else {})
+        manifest = {
+            "contract_version": "evaluation.suite_version.v1",
+            "suite_id": suite.slug,
+            "version": next_version_num,
+            "cases": [],
+            "gate_policy": gate_policy_json,
+            "owner": str(actor_id),
+            "description": suite.description,
+            "copied_from_version_id": str(source_version.id) if source_version else None,
+        }
+        version = await self._repo.create_suite_version(
+            tenant_id=tenant_id,
+            suite_id=suite.id,
+            version_num=next_version_num,
+            status="draft",
+            contract_version="evaluation.suite_version.v1",
+            manifest_json=manifest,
+            gate_policy_json=gate_policy_json,
+            case_count=0,
+            content_hash=self._digest(manifest),
+            created_by=self._optional_uuid(actor_id),
+        )
+        suite.current_draft_version_id = version.id
+        suite.lifecycle = "draft"
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite.id,
+            suite_version_id=version.id,
+            run_id=None,
+            actor_type="human",
+            actor_id=str(actor_id),
+            action="evaluation.suite_version.create_draft",
+            outcome="draft_created",
+            details_json={"version_num": next_version_num, "copied_from_version_id": manifest["copied_from_version_id"]},
+        )
+        await self._session.commit()
+        await self._session.refresh(version)
+        return version
+
+    async def list_cases(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+    ) -> list[EvaluationCase]:
+        await self._require_suite_version(tenant_id=tenant_id, suite_version_id=suite_version_id)
+        return await self._repo.list_cases_for_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+        )
+
+    async def list_runs(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        limit: int = 50,
+    ) -> list[EvaluationRun]:
+        await self._require_suite_version(tenant_id=tenant_id, suite_version_id=suite_version_id)
+        return await self._repo.list_runs_for_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+            limit=limit,
+        )
+
+    async def get_run_report(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+    ) -> tuple[EvaluationRun, list[tuple[EvaluationCaseRun, list[EvaluationAssessment]]]]:
+        run = await self._repo.get_run(tenant_id=tenant_id, run_id=run_id)
+        if run is None:
+            raise ValueError("evaluation run not found")
+        case_runs = await self._repo.list_case_runs_for_run(tenant_id=tenant_id, run_id=run.id)
+        assessments = await self._repo.list_assessments_for_case_runs(
+            tenant_id=tenant_id,
+            case_run_ids=[case_run.id for case_run in case_runs],
+        )
+        assessments_by_case_run: dict[str, list[EvaluationAssessment]] = {}
+        for assessment in assessments:
+            assessments_by_case_run.setdefault(str(assessment.case_run_id), []).append(assessment)
+        return run, [
+            (case_run, assessments_by_case_run.get(str(case_run.id), []))
+            for case_run in case_runs
+        ]
+
+    async def compare_runs(
+        self,
+        *,
+        tenant_id: str | UUID,
+        baseline_run_id: str | UUID,
+        candidate_run_id: str | UUID,
+    ) -> dict[str, Any]:
+        baseline, baseline_case_runs = await self.get_run_report(tenant_id=tenant_id, run_id=baseline_run_id)
+        candidate, candidate_case_runs = await self.get_run_report(tenant_id=tenant_id, run_id=candidate_run_id)
+        baseline_by_case = {str(case_run.case_id): case_run for case_run, _ in baseline_case_runs}
+        candidate_by_case = {str(case_run.case_id): case_run for case_run, _ in candidate_case_runs}
+        all_case_ids = sorted(set(baseline_by_case) | set(candidate_by_case))
+        regressions = []
+        improvements = []
+        unchanged = []
+        for case_id in all_case_ids:
+            baseline_status = baseline_by_case.get(case_id).status if case_id in baseline_by_case else "missing"
+            candidate_status = candidate_by_case.get(case_id).status if case_id in candidate_by_case else "missing"
+            item = {"case_id": case_id, "baseline_status": baseline_status, "candidate_status": candidate_status}
+            if baseline_status == "passed" and candidate_status != "passed":
+                regressions.append(item)
+            elif baseline_status != "passed" and candidate_status == "passed":
+                improvements.append(item)
+            else:
+                unchanged.append(item)
+        return {
+            "baseline_run_id": str(baseline.id),
+            "candidate_run_id": str(candidate.id),
+            "baseline_gate": self._run_gate_decision(baseline),
+            "candidate_gate": self._run_gate_decision(candidate),
+            "regressions": regressions,
+            "improvements": improvements,
+            "unchanged": unchanged,
+            "summary": {
+                "regression_count": len(regressions),
+                "improvement_count": len(improvements),
+                "unchanged_count": len(unchanged),
+            },
+        }
+
+    async def list_advisor_change_sets(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        limit: int = 50,
+    ) -> list[AdvisorChangeSet]:
+        await self._require_suite_version(tenant_id=tenant_id, suite_version_id=suite_version_id)
+        return await self._repo.list_change_sets_for_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+            limit=limit,
+        )
+
+    async def create_preflight_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        target_snapshot_payload: dict[str, Any],
+        actor_id: str,
+        idempotency_key: str | None = None,
+        actor_type: str = "agent",
+    ) -> EvaluationRun:
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+        )
+        if idempotency_key:
+            existing = await self._repo.get_run_by_idempotency_key(
+                tenant_id=tenant_id,
+                suite_version_id=suite_version.id,
+                idempotency_key=idempotency_key,
+            )
+            if existing is not None:
+                return existing
+        target_snapshot = EvaluationTargetSnapshot.model_validate(target_snapshot_payload)
+        blockers = target_snapshot.required_pin_blockers()
+        snapshot_json = target_snapshot.model_dump(mode="json")
+        snapshot = await self._repo.create_target_snapshot(
+            tenant_id=tenant_id,
+            target_kind=target_snapshot.target_kind,
+            target_ref=target_snapshot.target_ref,
+            contract_version=target_snapshot.contract_version,
+            snapshot_json=snapshot_json,
+            pin_digest=self._digest(snapshot_json),
+            blockers_json=blockers,
+        )
+        status = "blocked" if blockers else "queued"
+        run = await self._repo.create_run(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id,
+            target_snapshot_id=snapshot.id,
+            status=status,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            idempotency_key=idempotency_key,
+            preflight_blockers_json=blockers,
+        )
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=run.id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action="evaluation.run.preflight",
+            outcome=status,
+            details_json={"blockers": blockers},
+        )
+        await self._session.commit()
+        await self._session.refresh(run)
+        return run
+
+    async def heartbeat_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+        worker_id: str,
+        lease_seconds: int,
+    ) -> EvaluationRun:
+        run = await self._require_worker_run(
+            tenant_id=tenant_id,
+            run_id=run_id,
+            worker_id=worker_id,
+        )
+        now = datetime.utcnow()
+        run.heartbeat_at = now
+        run.lease_expires_at = now + timedelta(seconds=lease_seconds)
+        outcome = "running"
+        if run.stop_requested:
+            run.status = "canceled"
+            run.completed_at = now
+            run.summary_json = {**(run.summary_json or {}), "gate_decision": "canceled", "stop_requested": True}
+            outcome = "canceled"
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=run.suite_version_id,
+        )
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=run.id,
+            actor_type="worker",
+            actor_id=worker_id,
+            action="evaluation.run.heartbeat",
+            outcome=outcome,
+            details_json={"lease_seconds": lease_seconds},
+        )
+        await self._session.commit()
+        await self._session.refresh(run)
+        return run
+
+    async def request_run_stop(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+        actor_id: str,
+        actor_type: str = "human",
+    ) -> EvaluationRun:
+        run = await self._repo.get_run(tenant_id=tenant_id, run_id=run_id)
+        if run is None:
+            raise ValueError("evaluation run not found")
+        run.stop_requested = True
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=run.suite_version_id,
+        )
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=run.id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action="evaluation.run.stop_request",
+            outcome="requested",
+            details_json={},
+        )
+        await self._session.commit()
+        await self._session.refresh(run)
+        return run
+
+    async def record_run_artifact(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+        artifact_type: str,
+        uri: str,
+        content: Any,
+    ) -> EvaluationArtifact:
+        run = await self._repo.get_run(tenant_id=tenant_id, run_id=run_id)
+        if run is None:
+            raise ValueError("evaluation run not found")
+        content_hash = self._digest(content)
+        artifact = await self._repo.create_artifact(
+            tenant_id=tenant_id,
+            run_id=run.id,
+            case_run_id=None,
+            artifact_type=artifact_type,
+            uri=uri,
+            content_hash=content_hash,
+            metadata_json={"content_hash": content_hash},
+        )
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=run.suite_version_id,
+        )
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=run.id,
+            actor_type="service",
+            actor_id="evaluation-service",
+            action="evaluation.artifact.record",
+            outcome="created",
+            details_json={"artifact_type": artifact_type, "uri": uri, "content_hash": content_hash},
+        )
+        await self._session.commit()
+        await self._session.refresh(artifact)
+        return artifact
+
+    async def decide_promotion(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID,
+        actor_id: str,
+    ) -> PromotionDecision:
+        change_set = await self._repo.get_change_set(tenant_id=tenant_id, change_set_id=change_set_id)
+        if change_set is None:
+            raise ValueError("advisor change set not found")
+        verification_run = await self._repo.get_run(
+            tenant_id=tenant_id,
+            run_id=change_set.verification_run_id,
+        )
+        regression_run = await self._repo.get_run(
+            tenant_id=tenant_id,
+            run_id=change_set.regression_run_id,
+        )
+        verification_gate = self._run_gate_decision(verification_run)
+        regression_gate = self._run_gate_decision(regression_run)
+        accepted = verification_gate == "passed" and regression_gate == "passed"
+        decision = "accepted" if accepted else "rejected"
+        change_set.status = "promoted" if accepted else "rejected"
+        audit_json = {
+            "verification_gate": verification_gate,
+            "regression_gate": regression_gate,
+            "target_ref": change_set.target_ref,
+            "base_version_ref": change_set.base_version_ref,
+            "actor_id": actor_id,
+        }
+        promotion = await self._repo.create_promotion_decision(
+            tenant_id=tenant_id,
+            change_set_id=change_set.id,
+            verification_run_id=change_set.verification_run_id,
+            regression_run_id=change_set.regression_run_id,
+            decision=decision,
+            decided_by=self._optional_uuid(actor_id),
+            rationale=(
+                "Verification and regression gates passed."
+                if accepted
+                else "Promotion blocked until verification and regression gates both pass."
+            ),
+            audit_json=audit_json,
+        )
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=None,
+            suite_version_id=change_set.suite_version_id,
+            run_id=None,
+            actor_type="human",
+            actor_id=actor_id,
+            action="evaluation.promotion.decide",
+            outcome=decision,
+            details_json=audit_json,
+        )
+        await self._session.commit()
+        await self._session.refresh(promotion)
+        return promotion
+
+    async def get_advisor_review(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID,
+    ) -> dict[str, Any]:
+        change_set = await self._repo.get_change_set(tenant_id=tenant_id, change_set_id=change_set_id)
+        if change_set is None:
+            raise ValueError("advisor change set not found")
+        suggestions = await self._repo.list_advisor_suggestions_for_change_set(
+            tenant_id=tenant_id,
+            change_set_id=change_set.id,
+        )
+        verification_run = (
+            await self._repo.get_run(tenant_id=tenant_id, run_id=change_set.verification_run_id)
+            if change_set.verification_run_id
+            else None
+        )
+        regression_run = (
+            await self._repo.get_run(tenant_id=tenant_id, run_id=change_set.regression_run_id)
+            if change_set.regression_run_id
+            else None
+        )
+        promotions = await self._repo.list_promotion_decisions_for_change_set(
+            tenant_id=tenant_id,
+            change_set_id=change_set.id,
+        )
+        return {
+            "change_set": change_set,
+            "advisor_suggestions": suggestions,
+            "verification_run": verification_run,
+            "regression_run": regression_run,
+            "promotion_decisions": promotions,
+            "gate_summary": {
+                "verification_gate": self._run_gate_decision(verification_run),
+                "regression_gate": self._run_gate_decision(regression_run),
+                "ready_to_apply": (
+                    self._run_gate_decision(verification_run) == "passed"
+                    and self._run_gate_decision(regression_run) == "passed"
+                ),
+            },
+        }
+
+    async def promote_conversation_evaluation_to_case_draft(
+        self,
+        *,
+        tenant_id: str | UUID,
+        evaluation_id: str | UUID,
+        suite_version_id: str | UUID,
+        question: str | None,
+        tags: list[str],
+        actor_id: str,
+    ) -> tuple[EvaluationCase, bool]:
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+        )
+        if suite_version.status == "published":
+            raise ValueError("published evaluation suite version manifest is immutable")
+
+        evaluation = await self._get_conversation_evaluation(tenant_id=tenant_id, evaluation_id=evaluation_id)
+        if evaluation.verdict not in {"mistake", "ambiguous"}:
+            raise ValueError("only mistake or ambiguous conversation evaluations can become case drafts")
+        case_key = f"legacy-conversation-evaluation-{evaluation.id}"
+        existing = await self._repo.get_case_by_key(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id,
+            case_key=case_key,
+        )
+        if existing is not None:
+            return existing, False
+
+        notebook = await self._session.get(Notebook, evaluation.notebook_id)
+        findings = sanitize_error_payload(evaluation.findings or {})
+        feedback_question = (question or findings.get("question") or findings.get("description") or "").strip()
+        if not feedback_question:
+            feedback_question = f"Regression from conversation evaluation {evaluation.id}"
+        correction = (findings.get("correction") or "").strip()
+        summary = (findings.get("summary") or findings.get("description") or "").strip()
+        expected_contract = {
+            "semantic_intent": {
+                "description": summary,
+            },
+            "answer": {
+                "must_include_any": [correction] if correction else [],
+                "must_include_all": [],
+                "must_not_include": [],
+                "refusal_allowed": False,
+                "clarification_allowed": evaluation.verdict == "ambiguous",
+            },
+            "evidence": {
+                "required": True,
+                "lineage_refs": [str(evaluation.notebook_id)],
+            },
+            "policy": {
+                "required_scopes": [],
+                "forbidden_fields": [],
+                "expected_decision": None,
+                "security_hard_fail": True,
+            },
+            "feedback": {
+                "taxonomy": findings.get("taxonomy"),
+                "missed_instruction": findings.get("missed_instruction"),
+                "description": findings.get("description") or summary,
+                "findings": findings,
+            },
+        }
+        provenance = {
+            "source": "legacy_conversation_evaluation",
+            "feedback_id": str(evaluation.id),
+            "trace_id": findings.get("trace_id"),
+            "principal": findings.get("principal") or {},
+            "created_at": evaluation.evaluated_at.isoformat() if evaluation.evaluated_at else None,
+        }
+        case_tags = sorted({*tags, "legacy_conversation_evaluation", f"verdict:{evaluation.verdict}"})
+        case = await self._repo.create_case(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id,
+            case_key=case_key,
+            title=(summary or f"Conversation feedback {evaluation.verdict}")[:255],
+            target_kinds_json=["agent_answer"],
+            operation="answer_question",
+            question=feedback_question,
+            expected_contract_json=sanitize_error_payload(expected_contract),
+            provenance_json=sanitize_error_payload(provenance),
+            tags_json=case_tags,
+            content_hash=self._digest(
+                {
+                    "case_key": case_key,
+                    "question": feedback_question,
+                    "expected": expected_contract,
+                    "provenance": provenance,
+                    "tags": case_tags,
+                }
+            ),
+            immutable=False,
+        )
+        suite_version.case_count += 1
+        suite_version.manifest_json = {
+            **(suite_version.manifest_json or {}),
+            "last_feedback_case_draft_id": str(case.id),
+            "last_feedback_notebook_id": str(evaluation.notebook_id),
+            "last_feedback_notebook_name": notebook.notebook_name if notebook else None,
+        }
+        suite_version.content_hash = self._digest(suite_version.manifest_json)
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=None,
+            actor_type="human",
+            actor_id=actor_id,
+            action="evaluation.feedback.promote_to_case",
+            outcome="draft_created",
+            details_json={
+                "legacy_conversation_evaluation_id": str(evaluation.id),
+                "case_id": str(case.id),
+                "verdict": evaluation.verdict,
+            },
+        )
+        await self._session.commit()
+        await self._session.refresh(case)
+        return case, True
+
+    async def create_case_draft(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        case_key: str,
+        title: str,
+        target_kinds: list[str],
+        operation: str,
+        question: str,
+        expected_contract: dict[str, Any],
+        provenance: dict[str, Any],
+        tags: list[str],
+        actor_id: str,
+        actor_type: str = "agent",
+    ) -> tuple[EvaluationCase, bool]:
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+        )
+        if suite_version.status == "published":
+            raise ValueError("published evaluation suite version manifest is immutable")
+        normalized_target_kinds = self._validate_target_kinds(target_kinds)
+        if operation not in SUPPORTED_OPERATIONS:
+            raise ValueError(f"unsupported evaluation operation: {operation}")
+        existing = await self._repo.get_case_by_key(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id,
+            case_key=case_key,
+        )
+        if existing is not None:
+            return existing, False
+        validated_expected = EvaluationExpectedContract.model_validate(expected_contract).model_dump(mode="json")
+        sanitized_provenance = sanitize_error_payload(provenance or {})
+        sanitized_tags = sorted({str(tag) for tag in tags})
+        case = await self._repo.create_case(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id,
+            case_key=case_key,
+            title=title,
+            target_kinds_json=normalized_target_kinds,
+            operation=operation,
+            question=question,
+            expected_contract_json=sanitize_error_payload(validated_expected),
+            provenance_json=sanitized_provenance,
+            tags_json=sanitized_tags,
+            content_hash=self._digest(
+                {
+                    "case_key": case_key,
+                    "question": question,
+                    "expected": validated_expected,
+                    "provenance": sanitized_provenance,
+                    "tags": sanitized_tags,
+                }
+            ),
+            immutable=False,
+        )
+        suite_version.case_count += 1
+        suite_version.manifest_json = {
+            **(suite_version.manifest_json or {}),
+            "last_manual_case_draft_id": str(case.id),
+        }
+        suite_version.content_hash = self._digest(suite_version.manifest_json)
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=None,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action="evaluation.case.create_draft",
+            outcome="draft_created",
+            details_json={"case_id": str(case.id), "case_key": case.case_key},
+        )
+        await self._session.commit()
+        await self._session.refresh(case)
+        return case, True
+
+    async def import_case_drafts(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        cases: list[dict[str, Any]],
+        actor_id: str,
+        actor_type: str = "human",
+    ) -> dict[str, Any]:
+        if not cases:
+            raise ValueError("evaluation case import requires at least one case")
+        errors = []
+        for index, payload in enumerate(cases):
+            try:
+                self._validate_case_import_payload(payload)
+            except (KeyError, TypeError, ValueError) as exc:
+                errors.append({"index": index, "case_key": payload.get("case_key"), "error": str(exc)})
+        if errors:
+            raise ValueError(f"evaluation case import validation failed: {errors}")
+        imported = []
+        existing = []
+        for payload in cases:
+            case, created = await self.create_case_draft(
+                tenant_id=tenant_id,
+                suite_version_id=suite_version_id,
+                case_key=str(payload["case_key"]),
+                title=str(payload.get("title") or payload["case_key"]),
+                target_kinds=[str(kind) for kind in payload.get("target_kinds") or []],
+                operation=str(payload.get("operation") or "answer_question"),
+                question=str(payload["question"]),
+                expected_contract=dict(payload.get("expected_contract") or {}),
+                provenance=dict(payload.get("provenance") or {"source": "import"}),
+                tags=[str(tag) for tag in payload.get("tags") or []],
+                actor_id=actor_id,
+                actor_type=actor_type,
+            )
+            (imported if created else existing).append(case)
+        return {"created": imported, "existing": existing, "total": len(cases)}
+
+    async def create_advisor_change_set_from_skill_suggestion(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suggestion_id: str | UUID,
+        suite_version_id: str | UUID | None,
+        affected_case_ids: list[str | UUID],
+        actor_id: str,
+    ) -> tuple[AdvisorChangeSet, list[AdvisorSuggestion], bool]:
+        suite_version = None
+        if suite_version_id is not None:
+            suite_version = await self._require_suite_version(
+                tenant_id=tenant_id,
+                suite_version_id=suite_version_id,
+            )
+        suggestion = await self._get_skill_suggestion(tenant_id=tenant_id, suggestion_id=suggestion_id)
+        target_ref, base_version_ref, base_etag, patch = await self._advisor_target_and_patch(
+            tenant_id=tenant_id,
+            suggestion=suggestion,
+        )
+        existing = await self._repo.get_change_set_for_legacy_skill_suggestion(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id if suite_version else None,
+            suggestion_id=suggestion.id,
+            target_ref=target_ref,
+        )
+        if existing is not None:
+            advisor_suggestions = await self._repo.list_advisor_suggestions_for_change_set(
+                tenant_id=tenant_id,
+                change_set_id=existing.id,
+            )
+            return existing, advisor_suggestions, False
+
+        affected_ids = await self._validate_affected_cases(
+            tenant_id=tenant_id,
+            suite_version=suite_version,
+            affected_case_ids=affected_case_ids,
+        )
+        evidence = sanitize_error_payload(
+            {
+                "legacy_skill_suggestion_id": str(suggestion.id),
+                "legacy_status": suggestion.status,
+                "title": suggestion.title,
+                "rationale": suggestion.rationale,
+                "confidence": suggestion.confidence,
+                "evidence": suggestion.evidence or {},
+                "source": suggestion.source or {},
+                "created_at": suggestion.created_at.isoformat() if suggestion.created_at else None,
+            }
+        )
+        change_set = await self._repo.create_advisor_change_set(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id if suite_version else None,
+            target_ref=target_ref,
+            base_version_ref=base_version_ref,
+            base_etag=base_etag,
+            status="draft",
+            evidence_json=evidence,
+            created_by=actor_id,
+        )
+        advisor_suggestion = await self._repo.create_advisor_suggestion(
+            tenant_id=tenant_id,
+            change_set_id=change_set.id,
+            suggestion_type=self._advisor_suggestion_type(suggestion),
+            patch_json=sanitize_error_payload(patch),
+            affected_case_ids_json=[str(case_id) for case_id in affected_ids],
+            status="draft",
+        )
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id if suite_version else None,
+            suite_version_id=suite_version.id if suite_version else None,
+            run_id=None,
+            actor_type="human",
+            actor_id=actor_id,
+            action="evaluation.advisor.change_set.create",
+            outcome="draft_created",
+            details_json={
+                "legacy_skill_suggestion_id": str(suggestion.id),
+                "change_set_id": str(change_set.id),
+                "target_ref": target_ref,
+                "affected_case_ids": [str(case_id) for case_id in affected_ids],
+            },
+        )
+        await self._session.commit()
+        await self._session.refresh(change_set)
+        await self._session.refresh(advisor_suggestion)
+        return change_set, [advisor_suggestion], True
+
+    async def create_advisor_gate_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        change_set_id: str | UUID,
+        gate_kind: str,
+        target_snapshot_payload: dict[str, Any],
+        actor_id: str,
+        idempotency_key: str | None = None,
+    ) -> tuple[AdvisorChangeSet, EvaluationRun]:
+        if gate_kind not in {"verification", "regression"}:
+            raise ValueError("advisor gate kind must be verification or regression")
+        change_set = await self._repo.get_change_set(tenant_id=tenant_id, change_set_id=change_set_id)
+        if change_set is None:
+            raise ValueError("advisor change set not found")
+        if change_set.suite_version_id is None:
+            raise ValueError("advisor change set has no suite version for evaluation gates")
+        run = await self.create_preflight_run(
+            tenant_id=tenant_id,
+            suite_version_id=change_set.suite_version_id,
+            target_snapshot_payload=target_snapshot_payload,
+            actor_id=actor_id,
+            idempotency_key=idempotency_key or f"advisor-{gate_kind}-{change_set.id}",
+            actor_type="agent",
+        )
+        if gate_kind == "verification":
+            change_set.verification_run_id = run.id
+            change_set.status = "verification_queued"
+        else:
+            change_set.regression_run_id = run.id
+            change_set.status = "regression_queued"
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=None,
+            suite_version_id=change_set.suite_version_id,
+            run_id=run.id,
+            actor_type="agent",
+            actor_id=actor_id,
+            action=f"evaluation.advisor.{gate_kind}.run",
+            outcome=run.status,
+            details_json={"change_set_id": str(change_set.id), "target_ref": change_set.target_ref},
+        )
+        await self._session.commit()
+        await self._session.refresh(change_set)
+        await self._session.refresh(run)
+        return change_set, run
+
+    async def claim_next_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        worker_id: str,
+        lease_seconds: int,
+    ) -> EvaluationRun | None:
+        now = datetime.utcnow()
+        run = await self._repo.get_next_claimable_run(tenant_id=tenant_id, now=now)
+        if run is None:
+            return None
+        previous_holder = run.lease_holder
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=run.suite_version_id,
+        )
+        run.status = "running"
+        run.lease_holder = worker_id
+        run.lease_expires_at = now + timedelta(seconds=lease_seconds)
+        run.heartbeat_at = now
+        run.started_at = run.started_at or now
+        run.attempt += 1 if previous_holder and previous_holder != worker_id else 0
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=run.suite_version_id,
+            run_id=run.id,
+            actor_type="worker",
+            actor_id=worker_id,
+            action="evaluation.run.claim",
+            outcome="running",
+            details_json={"lease_seconds": lease_seconds},
+        )
+        await self._session.commit()
+        await self._session.refresh(run)
+        return run
+
+    async def complete_run_with_case_results(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+        worker_id: str,
+        case_results: list[dict[str, Any]],
+    ) -> EvaluationRun:
+        run = await self._repo.get_run(tenant_id=tenant_id, run_id=run_id)
+        if run is None:
+            raise ValueError("evaluation run not found")
+        if run.status != "running" or run.lease_holder != worker_id:
+            raise ValueError("evaluation run is not leased by this worker")
+
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=run.suite_version_id,
+        )
+        cases = await self._repo.list_cases_for_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=run.suite_version_id,
+        )
+        cases_by_key = {case.case_key: case for case in cases}
+        result_keys = {str(result.get("case_key")) for result in case_results}
+        if result_keys != set(cases_by_key):
+            missing = sorted(set(cases_by_key) - result_keys)
+            unknown = sorted(result_keys - set(cases_by_key))
+            raise ValueError(f"case results do not match suite version cases: missing={missing} unknown={unknown}")
+
+        now = datetime.utcnow()
+        hard_failures = 0
+        passed_cases = 0
+        failed_cases = 0
+        for result in case_results:
+            case = cases_by_key[str(result["case_key"])]
+            status = str(result.get("status") or "failed")
+            if status == "passed":
+                passed_cases += 1
+            else:
+                failed_cases += 1
+            result_payload = sanitize_error_payload(dict(result.get("result") or {}))
+            error_payload = sanitize_error_payload(dict(result.get("error") or {}))
+            case_run = await self._repo.create_case_run(
+                tenant_id=tenant_id,
+                run_id=run.id,
+                case_id=case.id,
+                status=status,
+                attempt=run.attempt,
+                input_digest=self._digest(case.expected_contract_json),
+                output_digest=self._digest(result_payload),
+                result_json=result_payload,
+                error_json=error_payload,
+                immutable=True,
+                started_at=now,
+                completed_at=now,
+            )
+            for assessment_payload in result.get("assessments") or []:
+                hard_fail = bool(assessment_payload.get("hard_fail"))
+                if hard_fail:
+                    hard_failures += 1
+                await self._repo.create_assessment(
+                    tenant_id=tenant_id,
+                    case_run_id=case_run.id,
+                    category=str(assessment_payload.get("category") or "overall"),
+                    status=str(assessment_payload.get("status") or status),
+                    score=assessment_payload.get("score"),
+                    hard_fail=hard_fail,
+                    details_json=sanitize_error_payload(dict(assessment_payload.get("details") or {})),
+                )
+
+        total_cases = len(cases)
+        pass_rate = passed_cases / total_cases if total_cases else 0.0
+        gate_policy = suite_version.gate_policy_json or {}
+        security_hard_fail = bool(gate_policy.get("security_hard_fail", True))
+        min_overall_pass_rate = float(gate_policy.get("min_overall_pass_rate", 1.0))
+        gate_failed = (security_hard_fail and hard_failures > 0) or pass_rate < min_overall_pass_rate
+        run.status = "failed" if gate_failed else "passed"
+        run.completed_at = now
+        run.summary_json = {
+            "total_cases": total_cases,
+            "passed_cases": passed_cases,
+            "failed_cases": failed_cases,
+            "pass_rate": pass_rate,
+            "hard_failures": hard_failures,
+            "gate_decision": "failed" if gate_failed else "passed",
+            "security_hard_fail": security_hard_fail,
+            "min_overall_pass_rate": min_overall_pass_rate,
+        }
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=run.id,
+            actor_type="worker",
+            actor_id=worker_id,
+            action="evaluation.run.complete",
+            outcome=run.status,
+            details_json=run.summary_json,
+        )
+        await self._session.commit()
+        await self._session.refresh(run)
+        return run
+
+    async def publish_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        actor_id: str,
+        actor_type: str = "human",
+    ) -> EvaluationSuiteVersion:
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+        )
+        suite = await self._repo.get_suite(tenant_id=tenant_id, suite_id=suite_version.suite_id)
+        if suite is None:
+            raise ValueError("evaluation suite not found")
+        if suite_version.case_count <= 0:
+            raise ValueError("evaluation suite version must contain at least one case before publish")
+        cases = await self._repo.list_cases_for_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id,
+        )
+        for case in cases:
+            case.immutable = True
+        suite_version.status = "published"
+        suite_version.published_at = datetime.utcnow()
+        suite.lifecycle = "published"
+        suite.published_version_id = suite_version.id
+        if suite.current_draft_version_id == suite_version.id:
+            suite.current_draft_version_id = None
+        await self._repo.create_audit_event(
+            tenant_id=tenant_id,
+            suite_id=suite_version.suite_id,
+            suite_version_id=suite_version.id,
+            run_id=None,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action="evaluation.suite_version.publish",
+            outcome="published",
+            details_json={},
+        )
+        await self._session.commit()
+        await self._session.refresh(suite_version)
+        return suite_version
+
+    async def patch_suite_version_manifest(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+        patch: dict[str, Any],
+    ) -> EvaluationSuiteVersion:
+        suite_version = await self._require_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+        )
+        if suite_version.status == "published":
+            raise ValueError("published evaluation suite version manifest is immutable")
+        suite_version.manifest_json = {**suite_version.manifest_json, **patch}
+        suite_version.content_hash = self._digest(suite_version.manifest_json)
+        await self._session.commit()
+        await self._session.refresh(suite_version)
+        return suite_version
+
+    async def _require_suite_version(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version_id: str | UUID,
+    ) -> EvaluationSuiteVersion:
+        suite_version = await self._repo.get_suite_version(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version_id,
+        )
+        if suite_version is None:
+            raise ValueError("evaluation suite version not found")
+        return suite_version
+
+    async def _get_conversation_evaluation(
+        self,
+        *,
+        tenant_id: str | UUID,
+        evaluation_id: str | UUID,
+    ) -> ConversationEvaluation:
+        result = await self._session.execute(
+            select(ConversationEvaluation).where(
+                ConversationEvaluation.tenant_id == tenant_id,
+                ConversationEvaluation.id == evaluation_id,
+            )
+        )
+        evaluation = result.scalar_one_or_none()
+        if evaluation is None:
+            raise ValueError("conversation evaluation not found")
+        return evaluation
+
+    async def _get_skill_suggestion(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suggestion_id: str | UUID,
+    ) -> SkillSuggestion:
+        result = await self._session.execute(
+            select(SkillSuggestion).where(
+                SkillSuggestion.tenant_id == tenant_id,
+                SkillSuggestion.id == suggestion_id,
+            )
+        )
+        suggestion = result.scalar_one_or_none()
+        if suggestion is None:
+            raise ValueError("skill suggestion not found")
+        return suggestion
+
+    async def _advisor_target_and_patch(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suggestion: SkillSuggestion,
+    ) -> tuple[str, str, str, dict[str, Any]]:
+        if suggestion.suggestion_type not in {"edit", "new_skill", "clarification"}:
+            raise ValueError("unsupported advisor suggestion type")
+        if suggestion.suggestion_type == "edit":
+            if suggestion.skill_id is None:
+                raise ValueError("edit suggestion has no target skill")
+            skill = await self._session.get(CustomSkill, suggestion.skill_id)
+            if skill is None or str(skill.tenant_id) != str(tenant_id):
+                raise ValueError("target skill not found")
+            target_ref = f"custom_skill:{skill.id}"
+            base_payload = {
+                "id": str(skill.id),
+                "name": skill.name,
+                "description": skill.description,
+                "instructions": skill.instructions,
+                "updated_at": skill.updated_at.isoformat() if skill.updated_at else None,
+            }
+            base_version_ref = f"{target_ref}:current"
+            patch = {
+                "op": "replace",
+                "path": "/instructions",
+                "value": suggestion.proposed_instructions or (suggestion.patch or {}).get("after") or "",
+                "legacy_patch": suggestion.patch or {},
+            }
+            return target_ref, base_version_ref, self._digest(base_payload), patch
+        target_ref = f"custom_skill:new:{suggestion.id}"
+        patch = {
+            "op": "create",
+            "path": "/custom_skills",
+            "value": {
+                "name": suggestion.title[:100],
+                "description": suggestion.rationale[:500],
+                "instructions": suggestion.proposed_instructions or suggestion.title,
+            },
+        }
+        return target_ref, f"{target_ref}:draft", self._digest({"suggestion_id": str(suggestion.id)}), patch
+
+    async def _validate_affected_cases(
+        self,
+        *,
+        tenant_id: str | UUID,
+        suite_version: EvaluationSuiteVersion | None,
+        affected_case_ids: list[str | UUID],
+    ) -> list[str | UUID]:
+        if suite_version is None or not affected_case_ids:
+            return affected_case_ids
+        cases = await self._repo.list_cases_by_ids(
+            tenant_id=tenant_id,
+            suite_version_id=suite_version.id,
+            case_ids=affected_case_ids,
+        )
+        found = {str(case.id) for case in cases}
+        missing = sorted(str(case_id) for case_id in affected_case_ids if str(case_id) not in found)
+        if missing:
+            raise ValueError(f"affected cases not found in suite version: {missing}")
+        return affected_case_ids
+
+    @staticmethod
+    def _advisor_suggestion_type(suggestion: SkillSuggestion) -> str:
+        if suggestion.suggestion_type in {"edit", "new_skill", "clarification"}:
+            return "instruction_skill"
+        return str(suggestion.suggestion_type)
+
+    async def _require_worker_run(
+        self,
+        *,
+        tenant_id: str | UUID,
+        run_id: str | UUID,
+        worker_id: str,
+    ) -> EvaluationRun:
+        run = await self._repo.get_run(tenant_id=tenant_id, run_id=run_id)
+        if run is None:
+            raise ValueError("evaluation run not found")
+        if run.status != "running" or run.lease_holder != worker_id:
+            raise ValueError("evaluation run is not leased by this worker")
+        return run
+
+    @staticmethod
+    def _run_gate_decision(run: EvaluationRun | None) -> str:
+        if run is None:
+            return "missing"
+        summary = run.summary_json or {}
+        gate_decision = summary.get("gate_decision")
+        if gate_decision in {"passed", "failed", "canceled", "blocked"}:
+            return str(gate_decision)
+        if run.status == "passed":
+            return "passed"
+        return "failed"
+
+    @staticmethod
+    def _optional_uuid(value: str | UUID) -> UUID | None:
+        if isinstance(value, UUID):
+            return value
+        try:
+            return UUID(str(value))
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _digest(payload: Any) -> str:
+        body = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+        return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _validate_target_kinds(target_kinds: list[str]) -> list[str]:
+        normalized = sorted({str(kind) for kind in target_kinds if str(kind)})
+        if not normalized:
+            raise ValueError("evaluation suite requires at least one target kind")
+        unsupported = sorted(set(normalized) - SUPPORTED_TARGET_KINDS)
+        if unsupported:
+            raise ValueError(f"unsupported evaluation target kinds: {unsupported}")
+        return normalized
+
+    @staticmethod
+    def _default_gate_policy(gate_policy: dict[str, Any] | None) -> dict[str, Any]:
+        payload = {
+            "version": "gate-policy.v1",
+            "security_hard_fail": True,
+            "min_overall_pass_rate": 1.0,
+            "max_new_regressions": 0,
+            "require_manual_review_for": [],
+            **(gate_policy or {}),
+        }
+        return sanitize_error_payload(payload)
+
+    @staticmethod
+    def _validate_case_import_payload(payload: dict[str, Any]) -> None:
+        if not str(payload["case_key"]).strip():
+            raise ValueError("case_key is required")
+        if not str(payload["question"]).strip():
+            raise ValueError("question is required")
+        EvaluationService._validate_target_kinds([str(kind) for kind in payload.get("target_kinds") or []])
+        operation = str(payload.get("operation") or "answer_question")
+        if operation not in SUPPORTED_OPERATIONS:
+            raise ValueError(f"unsupported evaluation operation: {operation}")
+        EvaluationExpectedContract.model_validate(dict(payload.get("expected_contract") or {}))

--- a/server/services/evaluation.py
+++ b/server/services/evaluation.py
@@ -184,7 +184,10 @@ class EvaluationService:
             actor_id=str(actor_id),
             action="evaluation.suite_version.create_draft",
             outcome="draft_created",
-            details_json={"version_num": next_version_num, "copied_from_version_id": manifest["copied_from_version_id"]},
+            details_json={
+                "version_num": next_version_num,
+                "copied_from_version_id": manifest["copied_from_version_id"],
+            },
         )
         await self._session.commit()
         await self._session.refresh(version)
@@ -233,10 +236,7 @@ class EvaluationService:
         assessments_by_case_run: dict[str, list[EvaluationAssessment]] = {}
         for assessment in assessments:
             assessments_by_case_run.setdefault(str(assessment.case_run_id), []).append(assessment)
-        return run, [
-            (case_run, assessments_by_case_run.get(str(case_run.id), []))
-            for case_run in case_runs
-        ]
+        return run, [(case_run, assessments_by_case_run.get(str(case_run.id), [])) for case_run in case_runs]
 
     async def compare_runs(
         self,

--- a/server/services/folder_service.py
+++ b/server/services/folder_service.py
@@ -29,6 +29,7 @@ from server.schemas.notebook_export import NotebookExport
 from server.services.agent_session_factory import create_agent_session
 from server.services.dataset import DatasetService
 from server.services.notebook_export_service import NotebookExportService
+from server.services.sharing import SharingService
 from server.utils.custom_logger import get_logger
 
 logger = get_logger(__name__)
@@ -291,6 +292,15 @@ class FolderService:
         await session.commit()
         await session.refresh(folder_notebook)
 
+        await SharingService(session).ensure_folder_notebook_grant(
+            tenant_id=notebook.tenant_id,
+            actor_id=shared_by,
+            folder_notebook_id=folder_notebook.id,
+            notebook_id=notebook_id,
+            is_snapshot=is_snapshot,
+            snapshot_updated_at=snapshot_updated_at,
+        )
+
         share_type = "snapshot" if is_snapshot else "live"
         logger.info(f"Notebook {notebook_id} shared ({share_type}) to folder {folder_id} by user {shared_by}")
         return folder_notebook
@@ -322,6 +332,13 @@ class FolderService:
 
         result = await folder_notebook_repo.delete(folder_notebook.id)
         if result:
+            await SharingService(session).revoke_legacy_grant(
+                tenant_id=notebook.tenant_id,
+                legacy_surface="folder_notebook",
+                legacy_id=str(folder_notebook.id),
+                actor_id=user_id,
+                reason="folder notebook share removed",
+            )
             logger.info(f"Notebook {notebook_id} unshared from folder {folder_id}")
         return result
 
@@ -421,6 +438,12 @@ class FolderService:
             existing_from_notebook.is_snapshot = is_snapshot
             await session.commit()
             await session.refresh(existing_from_notebook)
+            await SharingService(session).ensure_folder_dashboard_grant(
+                tenant_id=dashboard.tenant_id,
+                actor_id=shared_by,
+                folder_dashboard_id=existing_from_notebook.id,
+                dashboard_id=dashboard_id,
+            )
             logger.info(
                 f"Dashboard share updated from {old_dashboard_id} to {dashboard_id} "
                 f"in folder {folder_id} by user {shared_by}"
@@ -440,6 +463,13 @@ class FolderService:
         session.add(folder_dashboard)
         await session.commit()
         await session.refresh(folder_dashboard)
+
+        await SharingService(session).ensure_folder_dashboard_grant(
+            tenant_id=dashboard.tenant_id,
+            actor_id=shared_by,
+            folder_dashboard_id=folder_dashboard.id,
+            dashboard_id=dashboard_id,
+        )
 
         share_type = "snapshot" if is_snapshot else "live"
         logger.info(f"Dashboard {dashboard_id} shared ({share_type}) to folder {folder_id} by user {shared_by}")
@@ -479,6 +509,13 @@ class FolderService:
 
         result = await folder_dashboard_repo.delete(folder_dashboard.id)
         if result:
+            await SharingService(session).revoke_legacy_grant(
+                tenant_id=dashboard.tenant_id,
+                legacy_surface="folder_dashboard",
+                legacy_id=str(folder_dashboard.id),
+                actor_id=user_id,
+                reason="folder dashboard share removed",
+            )
             logger.info(f"Dashboard {dashboard_id} unshared from folder {folder_id}")
         return result
 
@@ -595,6 +632,13 @@ class FolderService:
         folder_dashboard.dashboard_id = new_dashboard_id
         await session.commit()
         await session.refresh(folder_dashboard)
+
+        await SharingService(session).ensure_folder_dashboard_grant(
+            tenant_id=new_dashboard.tenant_id,
+            actor_id=user_id,
+            folder_dashboard_id=folder_dashboard.id,
+            dashboard_id=new_dashboard_id,
+        )
 
         logger.info(
             f"Dashboard version updated in folder {folder_id}: {old_dashboard_id} -> {new_dashboard_id} by user {user_id}"

--- a/server/services/semantic_model_service.py
+++ b/server/services/semantic_model_service.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.semantic_models import SemanticModel, SemanticModelAuditEvent
+from server.models.source_resources import SourceResource
+from server.models.source_snapshots import SourceSnapshot
+from server.schemas.semantic_models import SemanticModelCreate, SemanticModelPatch
+
+
+class SemanticModelService:
+    @staticmethod
+    async def create_model(
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        user_id: UUID | None,
+        payload: SemanticModelCreate,
+    ) -> SemanticModel:
+        slug = payload.slug or SemanticModelService._slugify(payload.name)
+        await SemanticModelService._validate_sources(
+            session=session,
+            tenant_id=tenant_id,
+            source_resource_ids=payload.source_resource_ids,
+            source_snapshot_ids=payload.source_snapshot_ids,
+        )
+        model = SemanticModel(
+            tenant_id=tenant_id,
+            created_by=user_id,
+            slug=slug,
+            name=payload.name,
+            domain=payload.domain,
+            owner=payload.owner,
+            description=payload.description,
+            datasource_id=payload.datasource_id,
+            datasource_name=payload.datasource_name,
+            datasource_kind=payload.datasource_kind,
+            manifest_json=SemanticModelService._normalize_manifest(payload.manifest),
+            source_resource_ids_json=[str(item) for item in payload.source_resource_ids],
+            source_snapshot_ids_json=[str(item) for item in payload.source_snapshot_ids],
+            status="beta",
+            readiness=20,
+            readiness_level="partial",
+            validation_result_json=SemanticModelService._partial_validation(
+                source_snapshot_ids=[str(item) for item in payload.source_snapshot_ids],
+                manifest=payload.manifest,
+            ),
+            consumer_summary_json=payload.consumer_summary,
+        )
+        session.add(model)
+        await session.flush()
+        session.add(
+            SemanticModelAuditEvent(
+                tenant_id=tenant_id,
+                model_id=model.id,
+                actor_id=user_id,
+                action="semantic_model.beta.create",
+                details_json={"commercial_status": "PARTIAL"},
+            )
+        )
+        await session.commit()
+        await session.refresh(model)
+        return model
+
+    @staticmethod
+    async def list_models(*, session: AsyncSession, tenant_id: UUID) -> list[dict[str, Any]]:
+        result = await session.execute(
+            select(SemanticModel).where(SemanticModel.tenant_id == tenant_id).order_by(SemanticModel.updated_at.desc())
+        )
+        return [SemanticModelService.model_to_payload(model) for model in result.scalars().all()]
+
+    @staticmethod
+    async def get_model(*, session: AsyncSession, tenant_id: UUID, slug: str) -> SemanticModel | None:
+        return await session.scalar(
+            select(SemanticModel).where(SemanticModel.tenant_id == tenant_id, SemanticModel.slug == slug)
+        )
+
+    @staticmethod
+    async def update_model(
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        slug: str,
+        user_id: UUID | None,
+        payload: SemanticModelPatch,
+    ) -> SemanticModel | None:
+        model = await SemanticModelService.get_model(session=session, tenant_id=tenant_id, slug=slug)
+        if model is None:
+            return None
+        expected_revision = payload.revision_guard()
+        if expected_revision is None:
+            raise ValueError("expected_revision is required for semantic model updates")
+        if expected_revision != model.revision:
+            raise RuntimeError(f"Semantic Model revision conflict: current revision is {model.revision}")
+
+        next_source_resource_ids = (
+            [str(item) for item in payload.source_resource_ids]
+            if payload.source_resource_ids is not None
+            else list(model.source_resource_ids_json or [])
+        )
+        next_source_snapshot_ids = (
+            [str(item) for item in payload.source_snapshot_ids]
+            if payload.source_snapshot_ids is not None
+            else list(model.source_snapshot_ids_json or [])
+        )
+        await SemanticModelService._validate_sources(
+            session=session,
+            tenant_id=tenant_id,
+            source_resource_ids=[UUID(item) for item in next_source_resource_ids],
+            source_snapshot_ids=[UUID(item) for item in next_source_snapshot_ids],
+        )
+
+        for field in ("name", "domain", "owner", "description", "datasource_id", "datasource_name", "datasource_kind"):
+            value = getattr(payload, field)
+            if value is not None:
+                setattr(model, field, value)
+        if payload.manifest is not None:
+            model.manifest_json = SemanticModelService._normalize_manifest(payload.manifest)
+        if payload.source_resource_ids is not None:
+            model.source_resource_ids_json = next_source_resource_ids
+        if payload.source_snapshot_ids is not None:
+            model.source_snapshot_ids_json = next_source_snapshot_ids
+        if payload.consumer_summary is not None:
+            model.consumer_summary_json = payload.consumer_summary
+
+        model.revision += 1
+        model.draft_revision = f"draft-{model.revision}"
+        model.status = "beta"
+        model.readiness = min(model.readiness or 20, 40)
+        model.readiness_level = "partial"
+        model.validation_result_json = SemanticModelService._partial_validation(
+            source_snapshot_ids=list(model.source_snapshot_ids_json or []),
+            manifest=dict(model.manifest_json or {}),
+        )
+        session.add(
+            SemanticModelAuditEvent(
+                tenant_id=tenant_id,
+                model_id=model.id,
+                actor_id=user_id,
+                action="semantic_model.beta.update",
+                details_json={"revision": model.revision, "commercial_status": "PARTIAL"},
+            )
+        )
+        await session.commit()
+        await session.refresh(model)
+        return model
+
+    @staticmethod
+    async def validate_model(
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        slug: str,
+        user_id: UUID | None,
+    ) -> SemanticModel | None:
+        model = await SemanticModelService.get_model(session=session, tenant_id=tenant_id, slug=slug)
+        if model is None:
+            return None
+        validation = SemanticModelService._partial_validation(
+            source_snapshot_ids=list(model.source_snapshot_ids_json or []),
+            manifest=dict(model.manifest_json or {}),
+        )
+        model.validation_result_json = validation
+        model.readiness = int(validation["score"])
+        model.readiness_level = "partial"
+        model.status = "needs_review" if validation["warnings"] else "beta"
+        session.add(
+            SemanticModelAuditEvent(
+                tenant_id=tenant_id,
+                model_id=model.id,
+                actor_id=user_id,
+                action="semantic_model.beta.validate",
+                details_json=validation,
+            )
+        )
+        await session.commit()
+        await session.refresh(model)
+        return model
+
+    @staticmethod
+    async def publish_model(*, session: AsyncSession, tenant_id: UUID, slug: str) -> SemanticModel | None:
+        model = await SemanticModelService.get_model(session=session, tenant_id=tenant_id, slug=slug)
+        if model is None:
+            return None
+        raise RuntimeError(
+            "Semantic Model publish is blocked in the official beta until runtime execution credentials, "
+            "source provenance, and maintainer-reviewed validation are certified."
+        )
+
+    @staticmethod
+    async def query_metric(*, session: AsyncSession, tenant_id: UUID, slug: str) -> SemanticModel | None:
+        model = await SemanticModelService.get_model(session=session, tenant_id=tenant_id, slug=slug)
+        if model is None:
+            return None
+        raise RuntimeError("Semantic metric execution is beta-blocked in this official landing batch.")
+
+    @staticmethod
+    def model_to_payload(model: SemanticModel) -> dict[str, Any]:
+        validation = dict(model.validation_result_json or {})
+        return {
+            "id": model.slug,
+            "uuid": model.id,
+            "slug": model.slug,
+            "name": model.name,
+            "domain": model.domain,
+            "owner": model.owner,
+            "description": model.description,
+            "datasourceId": model.datasource_id,
+            "datasourceName": model.datasource_name,
+            "datasourceKind": model.datasource_kind,
+            "contractVersion": model.contract_version,
+            "manifest": model.manifest_json,
+            "sourceResourceIds": model.source_resource_ids_json,
+            "sourceSnapshotIds": model.source_snapshot_ids_json,
+            "status": model.status,
+            "commercialStatus": "PARTIAL",
+            "runtimeStatus": "not_certified",
+            "revision": model.revision,
+            "draftRevision": model.draft_revision,
+            "publishedVersion": model.published_version,
+            "readiness": model.readiness,
+            "readinessLevel": model.readiness_level,
+            "readinessDetail": validation,
+            "consumerSummary": model.consumer_summary_json,
+            "createdBy": model.created_by,
+            "createdAt": model.created_at,
+            "updatedAt": model.updated_at,
+        }
+
+    @staticmethod
+    async def _validate_sources(
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        source_resource_ids: list[UUID],
+        source_snapshot_ids: list[UUID],
+    ) -> None:
+        if source_resource_ids:
+            result = await session.execute(
+                select(SourceResource.id).where(
+                    SourceResource.tenant_id == tenant_id,
+                    SourceResource.id.in_(source_resource_ids),
+                )
+            )
+            found = {str(item) for item in result.scalars().all()}
+            missing = {str(item) for item in source_resource_ids} - found
+            if missing:
+                raise ValueError("Source resource not found")
+        if source_snapshot_ids:
+            result = await session.execute(
+                select(SourceSnapshot.id).where(
+                    SourceSnapshot.tenant_id == tenant_id,
+                    SourceSnapshot.id.in_(source_snapshot_ids),
+                )
+            )
+            found = {str(item) for item in result.scalars().all()}
+            missing = {str(item) for item in source_snapshot_ids} - found
+            if missing:
+                raise ValueError("Source snapshot not found")
+
+    @staticmethod
+    def _partial_validation(*, source_snapshot_ids: list[str], manifest: dict[str, Any]) -> dict[str, Any]:
+        metrics = manifest.get("metrics") if isinstance(manifest.get("metrics"), list) else []
+        entities = manifest.get("entities") if isinstance(manifest.get("entities"), list) else []
+        warnings: list[str] = []
+        if not source_snapshot_ids:
+            warnings.append("No immutable Source snapshot provenance is attached.")
+        if not entities:
+            warnings.append("No reviewed semantic entities are attached.")
+        if not metrics:
+            warnings.append("No reviewed metrics are attached.")
+        blockers = [
+            "Official semantic modeling runtime is beta/PARTIAL; publish and query execution are blocked until certified.",
+        ]
+        score = 40 if source_snapshot_ids and entities and metrics else 20
+        return {
+            "valid": False,
+            "status": "PARTIAL",
+            "score": score,
+            "level": "partial",
+            "blockers": blockers,
+            "warnings": warnings,
+            "validated_at": datetime.utcnow().isoformat(),
+        }
+
+    @staticmethod
+    def _normalize_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "schema_version": manifest.get("schema_version")
+            or manifest.get("schemaVersion")
+            or "semantic.model.v1beta",
+            "entities": manifest.get("entities") if isinstance(manifest.get("entities"), list) else [],
+            "relationships": manifest.get("relationships") if isinstance(manifest.get("relationships"), list) else [],
+            "metrics": manifest.get("metrics") if isinstance(manifest.get("metrics"), list) else [],
+            "dimensions": manifest.get("dimensions") if isinstance(manifest.get("dimensions"), list) else [],
+            "policy": manifest.get("policy") if isinstance(manifest.get("policy"), dict) else {},
+            "provenance": manifest.get("provenance") if isinstance(manifest.get("provenance"), dict) else {},
+        }
+
+    @staticmethod
+    def _slugify(value: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+        return slug or "semantic-model"
+
+    @staticmethod
+    def _content_hash(payload: dict[str, Any]) -> str:
+        encoded = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+        return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/server/services/sharing.py
+++ b/server/services/sharing.py
@@ -1,0 +1,756 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.dashboard import Dashboard
+from server.models.folder_dashboard import FolderDashboard
+from server.models.sharing import (
+    SharingAuditEvent,
+    SharingCompatibilityLink,
+    SharingGrant,
+    SharingSecret,
+    SharingViewerSession,
+)
+from server.services.viewer_session_service import ViewerSessionService
+from server.utils.error_sanitizer import sanitize_error_payload
+
+_SECRET_ALGORITHM = "pbkdf2_sha256:210000"
+
+
+class SharingService:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def create_dashboard_public_link(
+        self,
+        *,
+        tenant_id: str | UUID,
+        actor_id: str | UUID,
+        dashboard_id: str | UUID,
+        password: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> SharingGrant:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        actor_uuid = _coerce_uuid(actor_id)
+        dashboard = await self._require_dashboard(tenant_id=tenant_uuid, dashboard_id=_coerce_uuid(dashboard_id))
+        version_digest = _dashboard_digest(dashboard)
+        grant = SharingGrant(
+            tenant_id=tenant_uuid,
+            object_type="dashboard",
+            object_id=dashboard.id,
+            object_version_id=dashboard.id,
+            object_version_digest=version_digest,
+            mode="immutable_version",
+            channel="public_link",
+            audience="link_holder",
+            status="active",
+            created_by=actor_uuid,
+            metadata_json=sanitize_error_payload(metadata or {}),
+        )
+        self._session.add(grant)
+        await self._session.flush()
+        if password:
+            self._session.add(
+                self._build_secret(
+                    tenant_id=tenant_uuid,
+                    grant_id=grant.id,
+                    actor_id=actor_uuid,
+                    secret=password,
+                )
+            )
+        self._session.add(
+            self._audit_event(
+                tenant_id=tenant_uuid,
+                grant=grant,
+                actor_id=str(actor_uuid),
+                action="sharing.grant.create",
+                outcome="active",
+                details={"metadata": metadata or {}, "has_password": bool(password)},
+            )
+        )
+        await self._session.commit()
+        await self._session.refresh(grant)
+        return grant
+
+    async def ensure_folder_dashboard_grant(
+        self,
+        *,
+        tenant_id: str | UUID,
+        actor_id: str | UUID,
+        folder_dashboard_id: str | UUID,
+        dashboard_id: str | UUID,
+    ) -> SharingGrant:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        actor_uuid = _coerce_uuid(actor_id)
+        folder_dashboard_uuid = _coerce_uuid(folder_dashboard_id)
+        legacy_id = str(folder_dashboard_uuid)
+        existing = await self._grant_for_legacy_link("folder_dashboard", legacy_id)
+        dashboard = await self._require_dashboard(tenant_id=tenant_uuid, dashboard_id=_coerce_uuid(dashboard_id))
+        version_digest = _dashboard_digest(dashboard)
+        metadata = sanitize_error_payload(
+            {"legacy_surface": "folder_dashboard", "legacy_id": legacy_id, "dashboard_id": str(dashboard.id)}
+        )
+        if existing is not None:
+            existing.object_id = dashboard.id
+            existing.object_version_id = dashboard.id
+            existing.object_version_digest = version_digest
+            existing.status = "active"
+            existing.revoked_at = None
+            existing.revoked_by = None
+            existing.revocation_reason = None
+            existing.metadata_json = metadata
+            link = await self._compatibility_link_for_grant(
+                grant_id=existing.id,
+                legacy_surface="folder_dashboard",
+                legacy_id=legacy_id,
+            )
+            if link is not None:
+                link.metadata_json = metadata
+            await self._session.flush()
+            grant = existing
+        else:
+            grant = SharingGrant(
+                tenant_id=tenant_uuid,
+                object_type="dashboard",
+                object_id=dashboard.id,
+                object_version_id=dashboard.id,
+                object_version_digest=version_digest,
+                mode="immutable_version",
+                channel="folder",
+                audience="folder_member",
+                status="active",
+                created_by=actor_uuid,
+                metadata_json=metadata,
+            )
+            self._session.add(grant)
+            await self._session.flush()
+            self._session.add(
+                SharingCompatibilityLink(
+                    tenant_id=tenant_uuid,
+                    grant_id=grant.id,
+                    legacy_surface="folder_dashboard",
+                    legacy_id=legacy_id,
+                    metadata_json=metadata,
+                )
+            )
+        self._session.add(
+            self._audit_event(
+                tenant_id=tenant_uuid,
+                grant=grant,
+                actor_id=str(actor_uuid),
+                action="sharing.compat.folder_dashboard.upsert",
+                outcome="active",
+                details=metadata,
+            )
+        )
+        await self._session.commit()
+        await self._session.refresh(grant)
+        return grant
+
+    async def ensure_notebook_worker_grant(
+        self,
+        *,
+        tenant_id: str | UUID,
+        actor_id: str | UUID,
+        notebook_id: str | UUID,
+        legacy_surface: str,
+        legacy_id: str,
+        has_password: bool = False,
+        password: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> SharingGrant:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        actor_uuid = _coerce_uuid(actor_id)
+        notebook_uuid = _coerce_uuid(notebook_id)
+        existing = await self._grant_for_legacy_link(legacy_surface, legacy_id)
+        grant_metadata = sanitize_error_payload(
+            {
+                "legacy_surface": legacy_surface,
+                "legacy_id": legacy_id,
+                "has_password": has_password,
+                **(metadata or {}),
+            }
+        )
+        if existing is not None:
+            existing.object_id = notebook_uuid
+            existing.object_version_id = None
+            existing.object_version_digest = ""
+            existing.status = "active"
+            existing.revoked_at = None
+            existing.revoked_by = None
+            existing.revocation_reason = None
+            existing.metadata_json = grant_metadata
+            grant = existing
+        else:
+            grant = SharingGrant(
+                tenant_id=tenant_uuid,
+                object_type="notebook",
+                object_id=notebook_uuid,
+                object_version_id=None,
+                object_version_digest="",
+                mode="live_notebook_export",
+                channel="worker",
+                audience="link_holder",
+                status="active",
+                created_by=actor_uuid,
+                metadata_json=grant_metadata,
+            )
+            self._session.add(grant)
+            await self._session.flush()
+            self._session.add(
+                SharingCompatibilityLink(
+                    tenant_id=tenant_uuid,
+                    grant_id=grant.id,
+                    legacy_surface=legacy_surface,
+                    legacy_id=legacy_id,
+                    metadata_json=sanitize_error_payload({"notebook_id": str(notebook_uuid), **(metadata or {})}),
+                )
+            )
+        await self._replace_password_secret(
+            tenant_id=tenant_uuid,
+            grant_id=grant.id,
+            actor_id=actor_uuid,
+            password=password,
+            has_password=has_password,
+        )
+        self._session.add(
+            self._audit_event(
+                tenant_id=tenant_uuid,
+                grant=grant,
+                actor_id=str(actor_uuid),
+                action="sharing.compat.notebook_worker.upsert",
+                outcome="active",
+                details={
+                    "legacy_surface": legacy_surface,
+                    "legacy_id": legacy_id,
+                    "notebook_id": str(notebook_uuid),
+                    "has_password": has_password,
+                },
+            )
+        )
+        await self._session.commit()
+        await self._session.refresh(grant)
+        return grant
+
+    async def ensure_folder_notebook_grant(
+        self,
+        *,
+        tenant_id: str | UUID,
+        actor_id: str | UUID,
+        folder_notebook_id: str | UUID,
+        notebook_id: str | UUID,
+        is_snapshot: bool,
+        snapshot_updated_at: datetime | None = None,
+    ) -> SharingGrant:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        actor_uuid = _coerce_uuid(actor_id)
+        folder_notebook_uuid = _coerce_uuid(folder_notebook_id)
+        notebook_uuid = _coerce_uuid(notebook_id)
+        legacy_id = str(folder_notebook_uuid)
+        mode = "snapshot_export" if is_snapshot else "live_notebook"
+        metadata = sanitize_error_payload(
+            {
+                "legacy_surface": "folder_notebook",
+                "legacy_id": legacy_id,
+                "notebook_id": str(notebook_uuid),
+                "is_snapshot": is_snapshot,
+                "snapshot_updated_at": snapshot_updated_at.isoformat() if snapshot_updated_at else None,
+            }
+        )
+        existing = await self._grant_for_legacy_link("folder_notebook", legacy_id)
+        if existing is not None:
+            existing.object_id = notebook_uuid
+            existing.object_version_id = None
+            existing.object_version_digest = ""
+            existing.mode = mode
+            existing.status = "active"
+            existing.revoked_at = None
+            existing.revoked_by = None
+            existing.revocation_reason = None
+            existing.metadata_json = metadata
+            link = await self._compatibility_link_for_grant(
+                grant_id=existing.id,
+                legacy_surface="folder_notebook",
+                legacy_id=legacy_id,
+            )
+            if link is not None:
+                link.metadata_json = metadata
+            grant = existing
+        else:
+            grant = SharingGrant(
+                tenant_id=tenant_uuid,
+                object_type="notebook",
+                object_id=notebook_uuid,
+                object_version_id=None,
+                object_version_digest="",
+                mode=mode,
+                channel="folder",
+                audience="folder_member",
+                status="active",
+                created_by=actor_uuid,
+                metadata_json=metadata,
+            )
+            self._session.add(grant)
+            await self._session.flush()
+            self._session.add(
+                SharingCompatibilityLink(
+                    tenant_id=tenant_uuid,
+                    grant_id=grant.id,
+                    legacy_surface="folder_notebook",
+                    legacy_id=legacy_id,
+                    metadata_json=metadata,
+                )
+            )
+        self._session.add(
+            self._audit_event(
+                tenant_id=tenant_uuid,
+                grant=grant,
+                actor_id=str(actor_uuid),
+                action="sharing.compat.folder_notebook.upsert",
+                outcome="active",
+                details=metadata,
+            )
+        )
+        await self._session.commit()
+        await self._session.refresh(grant)
+        return grant
+
+    async def list_grants(
+        self,
+        *,
+        tenant_id: str | UUID,
+        object_type: str | None = None,
+        object_id: str | UUID | None = None,
+        legacy_surface: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+    ) -> list[SharingGrant]:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        query = select(SharingGrant).where(SharingGrant.tenant_id == tenant_uuid)
+        if legacy_surface:
+            query = query.join(SharingCompatibilityLink, SharingCompatibilityLink.grant_id == SharingGrant.id).where(
+                SharingCompatibilityLink.legacy_surface == legacy_surface
+            )
+        if object_type:
+            query = query.where(SharingGrant.object_type == object_type)
+        if object_id is not None:
+            query = query.where(SharingGrant.object_id == _coerce_uuid(object_id))
+        if status:
+            query = query.where(SharingGrant.status == status)
+        query = query.order_by(SharingGrant.created_at.desc()).limit(max(1, min(limit, 100)))
+        result = await self._session.execute(query)
+        return list(result.scalars().unique().all())
+
+    async def grant_evidence(self, *, tenant_id: str | UUID, grant_id: str | UUID) -> dict[str, Any]:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        grant_uuid = _coerce_uuid(grant_id)
+        grant = await self._session.scalar(
+            select(SharingGrant).where(SharingGrant.tenant_id == tenant_uuid, SharingGrant.id == grant_uuid)
+        )
+        if grant is None:
+            raise ValueError("sharing grant not found")
+        link_result = await self._session.execute(
+            select(SharingCompatibilityLink).where(
+                SharingCompatibilityLink.tenant_id == tenant_uuid,
+                SharingCompatibilityLink.grant_id == grant.id,
+            )
+        )
+        secret_counts = (
+            await self._session.execute(
+                select(SharingSecret.secret_type, SharingSecret.status, func.count(SharingSecret.id))
+                .where(SharingSecret.tenant_id == tenant_uuid, SharingSecret.grant_id == grant.id)
+                .group_by(SharingSecret.secret_type, SharingSecret.status)
+            )
+        ).all()
+        viewer_count = await self._session.scalar(
+            select(func.count(SharingViewerSession.id)).where(
+                SharingViewerSession.tenant_id == tenant_uuid,
+                SharingViewerSession.grant_id == grant.id,
+                SharingViewerSession.revoked_at.is_(None),
+            )
+        )
+        audit_result = await self._session.execute(
+            select(SharingAuditEvent)
+            .where(SharingAuditEvent.tenant_id == tenant_uuid, SharingAuditEvent.grant_id == grant.id)
+            .order_by(SharingAuditEvent.created_at.desc())
+            .limit(10)
+        )
+        return {
+            "grant": grant,
+            "compatibility_links": list(link_result.scalars().all()),
+            "secret_counts": [
+                {"secret_type": secret_type, "status": secret_status, "count": count}
+                for secret_type, secret_status, count in secret_counts
+            ],
+            "active_viewer_session_count": int(viewer_count or 0),
+            "audit_events": list(audit_result.scalars().all()),
+        }
+
+    async def revoke_legacy_grant(
+        self,
+        *,
+        tenant_id: str | UUID,
+        legacy_surface: str,
+        legacy_id: str,
+        actor_id: str | UUID,
+        reason: str,
+    ) -> SharingGrant | None:
+        grant = await self._grant_for_legacy_link(legacy_surface, legacy_id)
+        if grant is None or grant.tenant_id != _coerce_uuid(tenant_id):
+            return None
+        return await self.revoke_grant(
+            tenant_id=tenant_id,
+            grant_id=grant.id,
+            actor_id=actor_id,
+            reason=reason,
+        )
+
+    async def verify_grant_secret(self, *, grant_id: str | UUID, secret: str) -> bool:
+        grant_uuid = _coerce_uuid(grant_id)
+        result = await self._session.execute(
+            select(SharingSecret).where(
+                SharingSecret.grant_id == grant_uuid,
+                SharingSecret.secret_type == "password",
+                SharingSecret.status == "active",
+            )
+        )
+        saved = result.scalars().first()
+        if saved is None:
+            return False
+        return hmac.compare_digest(saved.verifier_hash, _hash_secret(secret=secret, salt=saved.salt))
+
+    async def issue_viewer_session(
+        self,
+        *,
+        tenant_id: str | UUID,
+        grant_id: str | UUID,
+        viewer_user_id: str | UUID | None = None,
+        principal: dict[str, Any] | None = None,
+    ) -> tuple[str, SharingViewerSession]:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        grant_uuid = _coerce_uuid(grant_id)
+        grant = await self._require_active_grant(tenant_id=tenant_uuid, grant_id=grant_uuid)
+        viewer_uuid = _coerce_uuid(viewer_user_id) if viewer_user_id is not None else None
+        token = ViewerSessionService.generate_token(
+            user_id=viewer_uuid or grant.created_by or tenant_uuid,
+            tenant_id=tenant_uuid,
+            grant_id=grant.id,
+            asset_id=grant.object_id,
+            version_id=grant.object_version_id,
+        )
+        payload = ViewerSessionService.verify(token)
+        if payload is None:
+            raise ValueError("viewer session token could not be verified")
+        now = self._now()
+        expires_at = datetime.fromtimestamp(int(payload["exp"]), UTC).replace(tzinfo=None)
+        viewer_session = SharingViewerSession(
+            tenant_id=tenant_uuid,
+            grant_id=grant.id,
+            object_type=grant.object_type,
+            object_id=grant.object_id,
+            object_version_id=grant.object_version_id,
+            token_id=str(payload["jti"]),
+            token_digest=_digest_text(token),
+            viewer_user_id=viewer_uuid,
+            viewer_principal_json=sanitize_error_payload(principal or {}),
+            issued_at=now,
+            expires_at=expires_at,
+        )
+        self._session.add(viewer_session)
+        await self._session.flush()
+        self._session.add(
+            self._audit_event(
+                tenant_id=tenant_uuid,
+                grant=grant,
+                viewer_session_id=viewer_session.id,
+                actor_id=str(viewer_uuid or "anonymous"),
+                action="sharing.viewer_session.issue",
+                outcome="issued",
+                details={"principal": principal or {}},
+            )
+        )
+        await self._session.commit()
+        await self._session.refresh(viewer_session)
+        return token, viewer_session
+
+    async def require_viewer_session(
+        self,
+        *,
+        token: str,
+        grant_id: str | UUID,
+        object_id: str | UUID,
+        object_version_id: str | UUID | None = None,
+    ) -> SharingViewerSession | None:
+        payload = ViewerSessionService.verify(token)
+        if payload is None:
+            return None
+        grant_uuid = _coerce_uuid(grant_id)
+        object_uuid = _coerce_uuid(object_id)
+        version_uuid = _coerce_uuid(object_version_id) if object_version_id is not None else None
+        if payload.get("grant_id") != str(grant_uuid):
+            return None
+        if payload.get("asset_id") != str(object_uuid):
+            return None
+        if version_uuid is not None and payload.get("version_id") != str(version_uuid):
+            return None
+        result = await self._session.execute(
+            select(SharingViewerSession, SharingGrant)
+            .join(SharingGrant, SharingGrant.id == SharingViewerSession.grant_id)
+            .where(
+                SharingViewerSession.token_digest == _digest_text(token),
+                SharingViewerSession.grant_id == grant_uuid,
+                SharingViewerSession.object_id == object_uuid,
+                SharingViewerSession.object_version_id == version_uuid,
+                SharingViewerSession.revoked_at.is_(None),
+                SharingViewerSession.expires_at > self._now(),
+                SharingGrant.status == "active",
+                SharingGrant.revoked_at.is_(None),
+            )
+        )
+        row = result.first()
+        return row[0] if row else None
+
+    async def require_viewer_session_for_dashboard(
+        self,
+        *,
+        token: str,
+        dashboard_id: str | UUID,
+    ) -> tuple[UUID, SharingViewerSession] | None:
+        payload = ViewerSessionService.verify(token)
+        if payload is None or not payload.get("uid") or not payload.get("grant_id"):
+            return None
+        dashboard = await self._dashboard_for_viewer_payload(payload=payload, dashboard_id=_coerce_uuid(dashboard_id))
+        if dashboard is None:
+            return None
+        viewer_session = await self.require_viewer_session(
+            token=token,
+            grant_id=payload["grant_id"],
+            object_id=dashboard.id,
+            object_version_id=dashboard.id,
+        )
+        if viewer_session is None:
+            return None
+        if not await self._legacy_folder_dashboard_is_active(viewer_session=viewer_session):
+            return None
+        return _coerce_uuid(payload["uid"]), viewer_session
+
+    async def revoke_grant(
+        self,
+        *,
+        tenant_id: str | UUID,
+        grant_id: str | UUID,
+        actor_id: str | UUID,
+        reason: str,
+    ) -> SharingGrant:
+        tenant_uuid = _coerce_uuid(tenant_id)
+        actor_uuid = _coerce_uuid(actor_id)
+        grant = await self._require_active_grant(tenant_id=tenant_uuid, grant_id=_coerce_uuid(grant_id))
+        now = self._now()
+        grant.status = "revoked"
+        grant.revoked_at = now
+        grant.revoked_by = actor_uuid
+        grant.revocation_reason = reason
+        result = await self._session.execute(
+            select(SharingViewerSession).where(
+                SharingViewerSession.grant_id == grant.id,
+                SharingViewerSession.revoked_at.is_(None),
+            )
+        )
+        for viewer_session in result.scalars():
+            viewer_session.revoked_at = now
+        self._session.add(
+            self._audit_event(
+                tenant_id=tenant_uuid,
+                grant=grant,
+                actor_id=str(actor_uuid),
+                action="sharing.grant.revoke",
+                outcome="revoked",
+                details={"reason": reason},
+            )
+        )
+        await self._session.commit()
+        await self._session.refresh(grant)
+        return grant
+
+    async def _require_dashboard(self, *, tenant_id: UUID, dashboard_id: UUID) -> Dashboard:
+        result = await self._session.execute(
+            select(Dashboard).where(
+                Dashboard.tenant_id == tenant_id,
+                Dashboard.id == dashboard_id,
+            )
+        )
+        dashboard = result.scalars().first()
+        if dashboard is None:
+            raise ValueError("dashboard not found")
+        return dashboard
+
+    async def _grant_for_legacy_link(self, legacy_surface: str, legacy_id: str) -> SharingGrant | None:
+        result = await self._session.execute(
+            select(SharingGrant)
+            .join(SharingCompatibilityLink, SharingCompatibilityLink.grant_id == SharingGrant.id)
+            .where(
+                SharingCompatibilityLink.legacy_surface == legacy_surface,
+                SharingCompatibilityLink.legacy_id == legacy_id,
+            )
+        )
+        return result.scalars().first()
+
+    async def _compatibility_link_for_grant(
+        self,
+        *,
+        grant_id: UUID,
+        legacy_surface: str,
+        legacy_id: str,
+    ) -> SharingCompatibilityLink | None:
+        result = await self._session.execute(
+            select(SharingCompatibilityLink).where(
+                SharingCompatibilityLink.grant_id == grant_id,
+                SharingCompatibilityLink.legacy_surface == legacy_surface,
+                SharingCompatibilityLink.legacy_id == legacy_id,
+            )
+        )
+        return result.scalars().first()
+
+    async def _dashboard_for_viewer_payload(self, *, payload: dict[str, Any], dashboard_id: UUID) -> Dashboard | None:
+        try:
+            tenant_id = _coerce_uuid(payload["tid"])
+            version_id = _coerce_uuid(payload["version_id"])
+        except (KeyError, ValueError):
+            return None
+        if version_id != dashboard_id:
+            return None
+        result = await self._session.execute(
+            select(Dashboard).where(Dashboard.tenant_id == tenant_id, Dashboard.id == dashboard_id)
+        )
+        return result.scalars().first()
+
+    async def _legacy_folder_dashboard_is_active(self, *, viewer_session: SharingViewerSession) -> bool:
+        result = await self._session.execute(
+            select(SharingGrant, SharingCompatibilityLink)
+            .join(SharingCompatibilityLink, SharingCompatibilityLink.grant_id == SharingGrant.id)
+            .where(
+                SharingGrant.id == viewer_session.grant_id,
+                SharingCompatibilityLink.legacy_surface == "folder_dashboard",
+            )
+        )
+        row = result.first()
+        if row is None:
+            return True
+        _, link = row
+        try:
+            legacy_id = _coerce_uuid(link.legacy_id)
+        except ValueError:
+            return False
+        legacy = await self._session.get(FolderDashboard, legacy_id)
+        return legacy is not None and legacy.dashboard_id == viewer_session.object_version_id
+
+    async def _require_active_grant(self, *, tenant_id: UUID, grant_id: UUID) -> SharingGrant:
+        result = await self._session.execute(
+            select(SharingGrant).where(
+                SharingGrant.tenant_id == tenant_id,
+                SharingGrant.id == grant_id,
+                SharingGrant.status == "active",
+                SharingGrant.revoked_at.is_(None),
+            )
+        )
+        grant = result.scalars().first()
+        if grant is None:
+            raise ValueError("active sharing grant not found")
+        return grant
+
+    def _build_secret(self, *, tenant_id: UUID, grant_id: UUID, actor_id: UUID, secret: str) -> SharingSecret:
+        salt = secrets.token_urlsafe(32)
+        return SharingSecret(
+            tenant_id=tenant_id,
+            grant_id=grant_id,
+            secret_type="password",
+            algorithm=_SECRET_ALGORITHM,
+            salt=salt,
+            verifier_hash=_hash_secret(secret=secret, salt=salt),
+            status="active",
+            created_by=actor_id,
+        )
+
+    async def _replace_password_secret(
+        self,
+        *,
+        tenant_id: UUID,
+        grant_id: UUID,
+        actor_id: UUID,
+        password: str | None,
+        has_password: bool,
+    ) -> None:
+        result = await self._session.execute(
+            select(SharingSecret).where(
+                SharingSecret.grant_id == grant_id,
+                SharingSecret.secret_type == "password",
+                SharingSecret.status == "active",
+            )
+        )
+        active_secret = result.scalars().first()
+        if active_secret is not None and (password is not None or not has_password):
+            active_secret.status = "rotated"
+            active_secret.rotated_at = self._now()
+        if password:
+            self._session.add(
+                self._build_secret(
+                    tenant_id=tenant_id,
+                    grant_id=grant_id,
+                    actor_id=actor_id,
+                    secret=password,
+                )
+            )
+
+    def _audit_event(
+        self,
+        *,
+        tenant_id: UUID,
+        grant: SharingGrant,
+        actor_id: str,
+        action: str,
+        outcome: str,
+        details: dict[str, Any],
+        viewer_session_id: UUID | None = None,
+    ) -> SharingAuditEvent:
+        return SharingAuditEvent(
+            tenant_id=tenant_id,
+            grant_id=grant.id,
+            viewer_session_id=viewer_session_id,
+            object_type=grant.object_type,
+            object_id=grant.object_id,
+            object_version_id=grant.object_version_id,
+            actor_type="human",
+            actor_id=actor_id,
+            action=action,
+            outcome=outcome,
+            details_json=sanitize_error_payload(details),
+        )
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _coerce_uuid(value: str | UUID) -> UUID:
+    return value if isinstance(value, UUID) else UUID(str(value))
+
+
+def _hash_secret(*, secret: str, salt: str) -> str:
+    digest = hashlib.pbkdf2_hmac("sha256", secret.encode(), salt.encode(), 210000)
+    return "sha256:" + digest.hex()
+
+
+def _digest_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode()).hexdigest()
+
+
+def _dashboard_digest(dashboard: Dashboard) -> str:
+    return "sha256:" + hashlib.sha256((dashboard.html_content or "").encode()).hexdigest()

--- a/server/services/source_connections.py
+++ b/server/services/source_connections.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.source_connections import SourceConnection
+from server.models.source_resources import SourceResource
+from server.schemas.source_connections import SourceConnectionCreate
+from server.services.connector_catalog import (
+    connector_catalog_summary,
+    get_connector_definition,
+    list_connector_definitions,
+)
+from server.services.crypto_service import CryptoService
+
+
+class SourceConnectionService:
+    def list_connector_definitions(self) -> dict[str, Any]:
+        items = list_connector_definitions()
+        return {"items": items, "total": len(items), "summary": connector_catalog_summary()}
+
+    async def create_connection(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        user_id: UUID | None,
+        payload: SourceConnectionCreate,
+    ) -> SourceConnection:
+        definition = get_connector_definition(payload.provider)
+        if definition is None or definition.availability != "beta":
+            raise ValueError(f"Connector {payload.provider} is not enabled for this official beta")
+        if payload.auth_mode != definition.auth_mode:
+            raise ValueError(f"Connector {payload.provider} requires auth_mode={definition.auth_mode}")
+
+        credentials = dict(payload.credentials or {})
+        encrypted = await CryptoService.encrypt_config(credentials, session)
+        capabilities = {
+            "catalog_status": definition.availability,
+            "runtime_status": "not_certified",
+            "commercial_status": "PARTIAL",
+            **dict(payload.capabilities or {}),
+        }
+        connection = SourceConnection(
+            tenant_id=tenant_id,
+            provider=payload.provider,
+            auth_mode=payload.auth_mode,
+            encrypted_credentials=encrypted,
+            external_account_id=payload.external_account_id,
+            display_name=payload.display_name,
+            status="beta",
+            capabilities_json=capabilities,
+            token_expires_at=self._parse_expires_at(credentials.get("expires_at")),
+            created_by=user_id,
+        )
+        session.add(connection)
+        await session.commit()
+        await session.refresh(connection)
+        return connection
+
+    async def list_connections(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        provider: str | None = None,
+        user_id: UUID | None = None,
+        include_all: bool = True,
+    ) -> list[SourceConnection]:
+        stmt = select(SourceConnection).where(SourceConnection.tenant_id == tenant_id)
+        if provider:
+            stmt = stmt.where(SourceConnection.provider == provider)
+        if not include_all:
+            stmt = stmt.where(SourceConnection.created_by == user_id)
+        result = await session.execute(stmt.order_by(SourceConnection.updated_at.desc()))
+        return list(result.scalars().all())
+
+    async def get_connection(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        connection_id: str | UUID,
+        user_id: UUID | None = None,
+        include_all: bool = True,
+    ) -> SourceConnection | None:
+        stmt = select(SourceConnection).where(
+            SourceConnection.tenant_id == tenant_id,
+            SourceConnection.id == connection_id,
+        )
+        if not include_all:
+            stmt = stmt.where(SourceConnection.created_by == user_id)
+        return await session.scalar(stmt)
+
+    async def delete_connection(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        connection_id: str | UUID,
+        user_id: UUID | None = None,
+        include_all: bool = True,
+    ) -> tuple[bool, int]:
+        connection = await self.get_connection(
+            session=session,
+            tenant_id=tenant_id,
+            connection_id=connection_id,
+            user_id=user_id,
+            include_all=include_all,
+        )
+        if connection is None:
+            return False, 0
+        resource_count = int(
+            await session.scalar(
+                select(func.count(SourceResource.id)).where(
+                    SourceResource.tenant_id == tenant_id,
+                    SourceResource.source_connection_id == connection.id,
+                )
+            )
+            or 0
+        )
+        connection.status = "disconnected"
+        connection.encrypted_credentials = await CryptoService.encrypt_config({"disconnected": True}, session)
+        await session.commit()
+        return True, resource_count
+
+    def connection_payload(self, connection: SourceConnection | None) -> dict[str, Any] | None:
+        if connection is None:
+            return None
+        return {
+            "id": connection.id,
+            "provider": connection.provider,
+            "auth_mode": connection.auth_mode,
+            "external_account_id": connection.external_account_id,
+            "display_name": connection.display_name,
+            "status": connection.status,
+            "capabilities": connection.capabilities_json,
+            "token_expires_at": connection.token_expires_at,
+            "created_by": connection.created_by,
+            "created_at": connection.created_at,
+            "updated_at": connection.updated_at,
+        }
+
+    def _parse_expires_at(self, value: Any) -> datetime | None:
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str) and value:
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+            except ValueError:
+                return None
+        return None

--- a/server/services/source_resources.py
+++ b/server/services/source_resources.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from server.models.connections import Connection
+from server.models.source_connections import SourceConnection
+from server.models.source_resources import SourceResource
+from server.models.source_snapshots import SourceSnapshot
+from server.schemas.source_resources import SourceResourceCreate, SourceResourceSyncRequest
+
+
+class SourceResourceService:
+    async def create_resource(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        user_id: UUID | None,
+        payload: SourceResourceCreate,
+        include_all_connections: bool = True,
+    ) -> dict[str, Any]:
+        await self._validate_source_connection(
+            session=session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            source_connection_id=payload.source_connection_id,
+            include_all=include_all_connections,
+        )
+        await self._validate_connection(
+            session=session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            connection_id=payload.connection_id,
+            include_all=include_all_connections,
+        )
+        resource = SourceResource(
+            tenant_id=tenant_id,
+            connection_id=payload.connection_id,
+            source_connection_id=payload.source_connection_id,
+            resource_type=payload.resource_type,
+            name=payload.name,
+            external_id=payload.external_id,
+            source_url=payload.source_url,
+            parent_external_id=payload.parent_external_id,
+            selection_config_json=payload.selection_config,
+            owner_id=user_id,
+            visibility=payload.visibility,
+            sync_mode=payload.sync_mode,
+            sync_config_json={
+                "commercial_status": "PARTIAL",
+                "runtime_status": "not_certified",
+                **payload.sync_config,
+            },
+            status="beta",
+        )
+        session.add(resource)
+        await session.flush()
+
+        if payload.content and payload.content.strip():
+            snapshot = self._build_snapshot(
+                resource=resource,
+                content=payload.content,
+                external_revision=payload.external_revision,
+                raw_storage_uri=payload.raw_storage_uri,
+                parser_version=payload.parser_version,
+                metadata=payload.metadata,
+            )
+            session.add(snapshot)
+            await session.flush()
+            resource.latest_snapshot_id = snapshot.id
+            resource.status = "ready"
+
+        await session.commit()
+        await session.refresh(resource)
+        return await self.resource_payload(session=session, resource=resource)
+
+    async def list_resources(self, *, session: AsyncSession, tenant_id: UUID) -> list[dict[str, Any]]:
+        result = await session.execute(
+            select(SourceResource)
+            .options(selectinload(SourceResource.source_connection), selectinload(SourceResource.snapshots))
+            .where(SourceResource.tenant_id == tenant_id)
+            .order_by(SourceResource.updated_at.desc())
+        )
+        return [await self.resource_payload(session=session, resource=resource) for resource in result.scalars().all()]
+
+    async def get_resource(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        resource_id: str | UUID,
+    ) -> SourceResource | None:
+        return await session.scalar(
+            select(SourceResource)
+            .options(selectinload(SourceResource.source_connection), selectinload(SourceResource.snapshots))
+            .where(SourceResource.tenant_id == tenant_id, SourceResource.id == resource_id)
+        )
+
+    async def sync_resource(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        resource_id: str | UUID,
+        payload: SourceResourceSyncRequest,
+        user_id: UUID | None = None,
+        include_all: bool = True,
+    ) -> dict[str, Any]:
+        resource = await self.get_resource(session=session, tenant_id=tenant_id, resource_id=resource_id)
+        if resource is None:
+            raise ValueError("Source resource not found")
+        if not include_all and resource.owner_id != user_id:
+            raise PermissionError("You can only update source resources you created")
+        if not payload.content or not payload.content.strip():
+            resource.status = "needs_confirmation"
+            await session.commit()
+            await session.refresh(resource)
+            return await self.resource_payload(session=session, resource=resource)
+
+        snapshot = self._build_snapshot(
+            resource=resource,
+            content=payload.content,
+            external_revision=payload.external_revision,
+            raw_storage_uri=payload.raw_storage_uri,
+            parser_version=payload.parser_version,
+            metadata=payload.metadata,
+        )
+        session.add(snapshot)
+        await session.flush()
+        resource.latest_snapshot_id = snapshot.id
+        resource.status = "ready"
+        await session.commit()
+        await session.refresh(resource)
+        return await self.resource_payload(session=session, resource=resource)
+
+    async def list_snapshots(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        resource_id: str | UUID,
+    ) -> dict[str, Any]:
+        resource = await self.get_resource(session=session, tenant_id=tenant_id, resource_id=resource_id)
+        if resource is None:
+            raise ValueError("Source resource not found")
+        result = await session.execute(
+            select(SourceSnapshot)
+            .where(SourceSnapshot.tenant_id == tenant_id, SourceSnapshot.resource_id == resource.id)
+            .order_by(SourceSnapshot.captured_at.desc())
+        )
+        items = [self._snapshot_payload(snapshot) for snapshot in result.scalars().all()]
+        return {"items": items, "total": len(items)}
+
+    async def delete_resource(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        resource_id: str | UUID,
+    ) -> bool:
+        resource = await self.get_resource(session=session, tenant_id=tenant_id, resource_id=resource_id)
+        if resource is None:
+            return False
+        await session.delete(resource)
+        await session.commit()
+        return True
+
+    async def resource_payload(self, *, session: AsyncSession, resource: SourceResource) -> dict[str, Any]:
+        latest_snapshot = await self._latest_snapshot(session=session, resource=resource)
+        source_connection = await self._source_connection(session=session, resource=resource)
+        return {
+            "id": resource.id,
+            "connection_id": resource.connection_id,
+            "source_connection_id": resource.source_connection_id,
+            "source_connection": self._source_connection_payload(source_connection),
+            "resource_type": resource.resource_type,
+            "name": resource.name,
+            "external_id": resource.external_id,
+            "source_url": resource.source_url,
+            "parent_external_id": resource.parent_external_id,
+            "selection_config_json": resource.selection_config_json,
+            "visibility": resource.visibility,
+            "sync_mode": resource.sync_mode,
+            "sync_config_json": resource.sync_config_json,
+            "status": resource.status,
+            "latest_snapshot_id": resource.latest_snapshot_id,
+            "created_at": resource.created_at,
+            "updated_at": resource.updated_at,
+            "latest_snapshot": self._snapshot_payload(latest_snapshot),
+        }
+
+    async def _validate_source_connection(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        user_id: UUID | None,
+        source_connection_id: UUID | None,
+        include_all: bool,
+    ) -> None:
+        if source_connection_id is None:
+            return
+        stmt = select(SourceConnection).where(
+            SourceConnection.tenant_id == tenant_id,
+            SourceConnection.id == source_connection_id,
+            SourceConnection.status != "disconnected",
+        )
+        if not include_all:
+            stmt = stmt.where(SourceConnection.created_by == user_id)
+        connection = await session.scalar(stmt)
+        if connection is None:
+            raise ValueError("Source connection not found")
+
+    async def _validate_connection(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: UUID,
+        user_id: UUID | None,
+        connection_id: UUID | None,
+        include_all: bool,
+    ) -> None:
+        if connection_id is None:
+            return
+        stmt = select(Connection).where(Connection.tenant_id == tenant_id, Connection.id == connection_id)
+        if not include_all:
+            stmt = stmt.where(Connection.created_by == user_id)
+        connection = await session.scalar(stmt)
+        if connection is None:
+            raise ValueError("Connection not found")
+
+    async def _latest_snapshot(self, *, session: AsyncSession, resource: SourceResource) -> SourceSnapshot | None:
+        if resource.latest_snapshot_id:
+            snapshot = await session.get(SourceSnapshot, resource.latest_snapshot_id)
+            if snapshot is not None and snapshot.tenant_id == resource.tenant_id:
+                return snapshot
+        return await session.scalar(
+            select(SourceSnapshot)
+            .where(SourceSnapshot.tenant_id == resource.tenant_id, SourceSnapshot.resource_id == resource.id)
+            .order_by(SourceSnapshot.captured_at.desc())
+            .limit(1)
+        )
+
+    async def _source_connection(
+        self,
+        *,
+        session: AsyncSession,
+        resource: SourceResource,
+    ) -> SourceConnection | None:
+        if resource.source_connection_id is None:
+            return None
+        return await session.scalar(
+            select(SourceConnection).where(
+                SourceConnection.tenant_id == resource.tenant_id,
+                SourceConnection.id == resource.source_connection_id,
+            )
+        )
+
+    def _build_snapshot(
+        self,
+        *,
+        resource: SourceResource,
+        content: str,
+        external_revision: str | None,
+        raw_storage_uri: str | None,
+        parser_version: str | None,
+        metadata: dict[str, Any],
+    ) -> SourceSnapshot:
+        content_hash = "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
+        return SourceSnapshot(
+            tenant_id=resource.tenant_id,
+            resource_id=resource.id,
+            external_revision=external_revision,
+            content_hash=content_hash,
+            raw_storage_uri=raw_storage_uri
+            or f"control-plane://source-resources/{resource.id}/snapshots/{content_hash}",
+            parser_version=parser_version or "metadata-only-v1",
+            metadata_json={
+                "content_length": len(content),
+                "commercial_status": "PARTIAL",
+                "runtime_status": "caller_supplied_content",
+                **metadata,
+            },
+            status="captured",
+        )
+
+    def _snapshot_payload(self, snapshot: SourceSnapshot | None) -> dict[str, Any] | None:
+        if snapshot is None:
+            return None
+        return {
+            "id": snapshot.id,
+            "resource_id": snapshot.resource_id,
+            "external_revision": snapshot.external_revision,
+            "content_hash": snapshot.content_hash,
+            "raw_storage_uri": snapshot.raw_storage_uri,
+            "captured_at": snapshot.captured_at,
+            "parser_version": snapshot.parser_version,
+            "metadata_json": snapshot.metadata_json,
+            "status": snapshot.status,
+            "error_json": snapshot.error_json,
+        }
+
+    def _source_connection_payload(self, connection: SourceConnection | None) -> dict[str, Any] | None:
+        if connection is None:
+            return None
+        return {
+            "id": connection.id,
+            "provider": connection.provider,
+            "auth_mode": connection.auth_mode,
+            "external_account_id": connection.external_account_id,
+            "display_name": connection.display_name,
+            "status": connection.status,
+            "capabilities": connection.capabilities_json,
+            "token_expires_at": connection.token_expires_at,
+            "created_by": connection.created_by,
+            "created_at": connection.created_at,
+            "updated_at": connection.updated_at,
+        }

--- a/server/services/viewer_session_service.py
+++ b/server/services/viewer_session_service.py
@@ -6,7 +6,7 @@ import hmac
 import json
 import os
 import time
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from server.utils.config_loader import get_auth_secret
 
@@ -24,13 +24,31 @@ def _b64url_decode(data: str) -> bytes:
 
 class ViewerSessionService:
     @staticmethod
-    def generate_token(user_id: UUID, tenant_id: UUID) -> str:
-        exp = int(time.time()) + (VIEWER_SESSION_MINUTES * 60)
+    def generate_token(
+        user_id: UUID,
+        tenant_id: UUID,
+        grant_id: UUID | str | None = None,
+        asset_id: UUID | str | None = None,
+        version_id: UUID | str | None = None,
+    ) -> str:
+        now = int(time.time())
+        exp = now + (VIEWER_SESSION_MINUTES * 60)
         payload = {
+            "iss": "byaan-api",
+            "aud": "byaan-viewer",
             "uid": str(user_id),
             "tid": str(tenant_id),
+            "jti": str(uuid4()),
+            "iat": now,
+            "nbf": now,
             "exp": exp,
         }
+        if grant_id is not None:
+            payload["grant_id"] = str(grant_id)
+        if asset_id is not None:
+            payload["asset_id"] = str(asset_id)
+        if version_id is not None:
+            payload["version_id"] = str(version_id)
         payload_bytes = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
         payload_b64 = _b64url_encode(payload_bytes)
         secret = get_auth_secret().encode()
@@ -52,6 +70,12 @@ class ViewerSessionService:
 
             payload = json.loads(_b64url_decode(payload_b64))
             if int(payload.get("exp", 0)) <= int(time.time()):
+                return None
+            if int(payload.get("nbf", 0)) > int(time.time()):
+                return None
+            if payload.get("iss", "byaan-api") != "byaan-api":
+                return None
+            if payload.get("aud", "byaan-viewer") != "byaan-viewer":
                 return None
 
             return payload

--- a/server/tests/test_dashboard_contract_schemas.py
+++ b/server/tests/test_dashboard_contract_schemas.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from server.schemas.dashboard import DashboardManifest, DashboardRun
+
+
+def _valid_manifest_payload() -> dict:
+    return {
+        "schema_version": "dashboard.manifest.v1",
+        "dashboard_id": "dash-revenue",
+        "title": "Revenue operations",
+        "description": "Decision surface for pipeline and recognized revenue",
+        "audience": ["sales_ops", "finance"],
+        "semantic_bindings": [
+            {
+                "id": "sales-model",
+                "model_slug": "sales",
+                "model_version": "v3",
+                "source_snapshot_ids": ["snapshot-1"],
+                "allowed_metrics": ["revenue"],
+                "allowed_dimensions": ["region"],
+            }
+        ],
+        "data_views": [
+            {
+                "id": "dv-revenue-by-region",
+                "kind": "semantic_metric",
+                "question": "How much revenue is recognized by region?",
+                "output_schema": [
+                    {"name": "region", "data_type": "string", "description": "Sales region"},
+                    {
+                        "name": "revenue",
+                        "data_type": "number",
+                        "description": "Recognized revenue",
+                        "unit": "USD",
+                    },
+                ],
+                "filter_fields": ["region"],
+                "semantic_metric": {
+                    "semantic_binding_id": "sales-model",
+                    "metric": "revenue",
+                    "dimensions": ["region"],
+                    "grain": "month",
+                },
+            }
+        ],
+        "filters": [
+            {
+                "id": "region",
+                "label": "Region",
+                "source": "semantic_field",
+                "field": "region",
+                "filter_type": "enum",
+                "operators": ["in"],
+                "affected_data_view_ids": ["dv-revenue-by-region"],
+                "domain": ["AMER", "EMEA"],
+            }
+        ],
+        "layout": {"sections": [{"id": "summary", "title": "Summary", "tile_ids": ["tile-revenue"]}]},
+        "tiles": [
+            {
+                "id": "tile-revenue",
+                "title": "Revenue by region",
+                "tile_type": "bar",
+                "business_question": "Which regions contribute revenue?",
+                "data_view_id": "dv-revenue-by-region",
+                "encoding": {"x": "region", "y": "revenue"},
+                "accessible_fallback": {
+                    "summary": "Revenue by region table",
+                    "table_fields": ["region", "revenue"],
+                },
+            }
+        ],
+        "actions": [
+            {
+                "id": "export",
+                "label": "Export",
+                "action_type": "export",
+                "required_scope": "dashboard:export",
+            }
+        ],
+        "freshness_policy": {"mode": "live", "max_age_seconds": 1800, "allow_stale": True},
+        "access_policy": {
+            "required_scopes": ["dashboard:read", "dashboard:query"],
+            "row_policy_refs": ["tenant_rls"],
+            "column_policy_refs": ["finance_columns"],
+            "redaction_policy_refs": ["pii_redaction"],
+        },
+        "provenance": {
+            "created_by_actor_type": "human",
+            "created_by": "user-1",
+            "source": "human",
+            "evidence_refs": ["source-understanding-1"],
+        },
+        "migration": {"state": "new_structured", "blockers": []},
+    }
+
+
+def _valid_run_payload() -> dict:
+    now = datetime.now(UTC)
+    return {
+        "contract_version": "dashboard.run.v1",
+        "run_id": "run-1",
+        "dashboard_id": "dash-revenue",
+        "dashboard_version_id": "version-1",
+        "actor_type": "agent",
+        "actor_id": "mcp-key-1",
+        "correlation_id": "corr-1",
+        "mode": "live",
+        "normalized_filters": {"region": ["AMER"]},
+        "filter_digest": "filters:abc",
+        "pinned_versions": {"semantic_models": {"sales": "v3"}, "source_snapshots": ["snapshot-1"]},
+        "execution_plan_digest": "plan:def",
+        "started_at": now,
+        "completed_at": now,
+        "overall_freshness": "fresh",
+        "views": [
+            {
+                "data_view_id": "dv-revenue-by-region",
+                "status": "success",
+                "result": [{"region": "AMER", "revenue": 120}],
+                "schema": [
+                    {"name": "region", "data_type": "string"},
+                    {"name": "revenue", "data_type": "number", "unit": "USD"},
+                ],
+                "row_count": 1,
+                "cached": False,
+                "stale": False,
+                "as_of": now,
+            }
+        ],
+    }
+
+
+def test_dashboard_manifest_accepts_structured_contract() -> None:
+    manifest = DashboardManifest.model_validate(_valid_manifest_payload())
+
+    assert manifest.schema_version == "dashboard.manifest.v1"
+    assert manifest.data_views[0].semantic_metric is not None
+    assert manifest.tiles[0].data_view_id == manifest.data_views[0].id
+
+
+def test_dashboard_manifest_json_schema_requires_authoritative_sections() -> None:
+    schema = DashboardManifest.model_json_schema()
+
+    assert schema["properties"]["schema_version"]["const"] == "dashboard.manifest.v1"
+    assert {
+        "schema_version",
+        "dashboard_id",
+        "title",
+        "audience",
+        "semantic_bindings",
+        "data_views",
+        "filters",
+        "layout",
+        "tiles",
+        "actions",
+        "freshness_policy",
+        "access_policy",
+        "provenance",
+        "migration",
+    }.issubset(set(schema["required"]))
+
+
+def test_dashboard_manifest_rejects_unbound_references() -> None:
+    payload = _valid_manifest_payload()
+    payload["tiles"][0]["data_view_id"] = "missing-view"
+
+    with pytest.raises(ValidationError, match="unknown data view"):
+        DashboardManifest.model_validate(payload)
+
+
+def test_dashboard_manifest_rejects_draft_semantic_binding() -> None:
+    payload = _valid_manifest_payload()
+    payload["semantic_bindings"][0]["readiness"] = "blocked"
+
+    with pytest.raises(ValidationError, match="published model versions"):
+        DashboardManifest.model_validate(payload)
+
+
+def test_dashboard_run_rejects_pinned_snapshot_without_artifact() -> None:
+    payload = _valid_run_payload()
+    payload["mode"] = "pinned_snapshot"
+
+    with pytest.raises(ValidationError, match="result_artifact_id"):
+        DashboardRun.model_validate(payload)

--- a/server/tests/test_dashboard_legacy_tool_gating.py
+++ b/server/tests/test_dashboard_legacy_tool_gating.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from server.models.dashboard import Dashboard
+from server.tools.agentic import _ensure_legacy_html_dashboard, _load_dashboard_body
+from server.utils.dashboard_editing import DashboardEditError
+
+
+class _DummyCtx:
+    def __init__(self, context: dict):
+        self.context = context
+
+
+class _DummyDashboardRepo:
+    def __init__(self, dashboard=None):
+        self.dashboard = dashboard
+
+    async def get_version(self, notebook_id, version_num):
+        return self.dashboard
+
+    async def get_latest_version(self, notebook_id):
+        return self.dashboard
+
+
+def _dashboard(**overrides) -> Dashboard:
+    payload = {
+        "id": uuid4(),
+        "tenant_id": uuid4(),
+        "notebook_id": uuid4(),
+        "version_num": 1,
+        "html_content": "<html>legacy</html>",
+        "status": "legacy_unstructured",
+        "migration_state": "legacy_unstructured",
+    }
+    payload.update(overrides)
+    return Dashboard(**payload)
+
+
+def test_legacy_html_guard_allows_legacy_unstructured_dashboard() -> None:
+    _ensure_legacy_html_dashboard(_dashboard(asset_id=uuid4()))
+
+
+def test_legacy_html_guard_blocks_structured_manifest_dashboard() -> None:
+    dashboard = _dashboard(
+        asset_id=uuid4(),
+        manifest_schema_version="dashboard.manifest.v1",
+        manifest_json={"schema_version": "dashboard.manifest.v1"},
+        status="published",
+        migration_state="new_structured",
+    )
+
+    with pytest.raises(DashboardEditError, match="Legacy HTML tools are deprecated"):
+        _ensure_legacy_html_dashboard(dashboard)
+
+
+@pytest.mark.asyncio
+async def test_load_dashboard_body_blocks_structured_latest_dashboard_before_html_edit() -> None:
+    dashboard = _dashboard(
+        asset_id=uuid4(),
+        manifest_schema_version="dashboard.manifest.v1",
+        manifest_json={"schema_version": "dashboard.manifest.v1"},
+        status="published",
+        migration_state="new_structured",
+    )
+
+    with pytest.raises(DashboardEditError, match="base_etag JSON Patch"):
+        await _load_dashboard_body(
+            _DummyCtx({"notebook_id": str(dashboard.notebook_id)}),
+            _DummyDashboardRepo(dashboard),
+        )
+
+
+@pytest.mark.asyncio
+async def test_load_dashboard_body_still_returns_starter_template_when_no_legacy_dashboard_exists() -> None:
+    html, version = await _load_dashboard_body(
+        _DummyCtx({"notebook_id": str(uuid4())}),
+        _DummyDashboardRepo(None),
+    )
+
+    assert version is None
+    assert "No content yet" in html

--- a/server/tests/test_dashboard_mcp_contract.py
+++ b/server/tests/test_dashboard_mcp_contract.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from server.mcp import tool_wrappers
+from server.mcp.tool_wrappers import (
+    _json_error,
+    create_dashboard_draft_wrapper,
+    describe_dashboard_wrapper,
+    get_dashboard_lineage_wrapper,
+    patch_dashboard_draft_wrapper,
+    publish_dashboard_wrapper,
+    query_dashboard_wrapper,
+    search_dashboards_wrapper,
+    validate_dashboard_wrapper,
+)
+from server.models.dashboard import DashboardRun
+from server.models.notebooks import Notebook
+from server.models.tenant import Tenant
+from server.models.tenant_member import TenantMember, TenantRole
+from server.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+def test_dashboard_mcp_json_error_redacts_sensitive_exception_values() -> None:
+    payload = json.loads(
+        _json_error(
+            RuntimeError(
+                "password=plain-password verifier=argon2id-verifier "
+                "token=raw-token credential=worker-credential "
+                "sql=select * from other_tenant.secret_orders"
+            ),
+            operation="query_dashboard",
+        )
+    )
+
+    serialized = json.dumps(payload)
+    assert payload["success"] is False
+    assert payload["operation"] == "query_dashboard"
+    assert "plain-password" not in serialized
+    assert "argon2id-verifier" not in serialized
+    assert "raw-token" not in serialized
+    assert "worker-credential" not in serialized
+    assert "select * from other_tenant.secret_orders" not in serialized
+
+
+def _manifest_payload(query_id: str) -> dict:
+    return {
+        "schema_version": "dashboard.manifest.v1",
+        "dashboard_id": "dash-mcp",
+        "title": "MCP governed dashboard",
+        "description": "Dashboard exposed through governed MCP tools",
+        "audience": ["finance"],
+        "semantic_bindings": [
+            {
+                "id": "sales-model",
+                "model_slug": "sales",
+                "model_version": "v1",
+                "source_snapshot_ids": ["snapshot-1"],
+                "allowed_metrics": ["revenue"],
+                "allowed_dimensions": ["region"],
+            }
+        ],
+        "data_views": [
+            {
+                "id": "dv-saved-revenue",
+                "kind": "saved_query",
+                "question": "What revenue did the reviewed query return?",
+                "output_schema": [{"name": "revenue", "data_type": "number", "unit": "USD"}],
+                "filter_fields": ["region"],
+                "saved_query": {
+                    "query_id": query_id,
+                    "compatibility_reason": "reviewed legacy dashboard query",
+                    "filter_contract": {},
+                    "lineage": [
+                        {
+                            "id": "query-lineage",
+                            "kind": "saved_query",
+                            "name": "Revenue query",
+                            "ref": query_id,
+                        }
+                    ],
+                },
+            }
+        ],
+        "filters": [
+            {
+                "id": "region",
+                "label": "Region",
+                "source": "saved_query_contract",
+                "field": "region",
+                "filter_type": "enum",
+                "operators": ["eq"],
+                "affected_data_view_ids": ["dv-saved-revenue"],
+            }
+        ],
+        "layout": {"sections": [{"id": "main", "tile_ids": ["tile-revenue"]}]},
+        "tiles": [
+            {
+                "id": "tile-revenue",
+                "title": "Revenue",
+                "tile_type": "kpi",
+                "business_question": "What is revenue?",
+                "data_view_id": "dv-saved-revenue",
+            }
+        ],
+        "actions": [],
+        "freshness_policy": {"mode": "live", "max_age_seconds": 3600, "allow_stale": True},
+        "access_policy": {"required_scopes": ["dashboard:read", "dashboard:query"]},
+        "provenance": {"created_by_actor_type": "agent", "created_by": "mcp-key-1", "source": "agent"},
+        "migration": {"state": "new_structured", "blockers": []},
+    }
+
+
+async def _seed_owner_notebook(test_session: AsyncSession) -> dict:
+    user_id = uuid4()
+    tenant_id = uuid4()
+    test_session.add(
+        User(
+            id=user_id,
+            email=f"dashboard-mcp-owner-{user_id}@example.test",
+            hashed_password="hash",
+            is_active=True,
+            is_verified=True,
+        )
+    )
+    await test_session.flush()
+    tenant = Tenant(id=tenant_id, name="Dashboard MCP Tenant", slug=f"dashboard-mcp-{tenant_id}", owner_id=user_id)
+    test_session.add(tenant)
+    await test_session.flush()
+    notebook = Notebook(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        created_by=tenant.owner_id,
+        notebook_name="Dashboard MCP notebook",
+    )
+    test_session.add(notebook)
+    await test_session.commit()
+    await test_session.refresh(notebook)
+    return {"tenant_id": tenant.id, "user_id": tenant.owner_id, "notebook_id": notebook.id}
+
+
+@pytest.fixture(autouse=True)
+def _patch_mcp_session_factory(test_engine, monkeypatch: pytest.MonkeyPatch):
+    test_session_factory = async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(tool_wrappers, "AsyncSessionFactory", test_session_factory)
+
+
+async def test_dashboard_mcp_contract_lifecycle_and_query(
+    test_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ids = await _seed_owner_notebook(test_session)
+    query_id = str(uuid4())
+    manifest = _manifest_payload(query_id)
+
+    create_payload = json.loads(
+        await create_dashboard_draft_wrapper(
+            "mcp-governed-dashboard",
+            str(ids["notebook_id"]),
+            json.dumps(manifest),
+            ids["tenant_id"],
+            ids["user_id"],
+            tags=["finance"],
+        )
+    )
+    assert create_payload["success"] is True
+    dashboard = create_payload["dashboard"]
+    assert dashboard["slug"] == "mcp-governed-dashboard"
+
+    search_payload = json.loads(
+        await search_dashboards_wrapper("mcp", ["finance"], "draft", "", ids["tenant_id"], ids["user_id"])
+    )
+    assert search_payload["success"] is True
+    assert search_payload["items"][0]["id"] == dashboard["id"]
+
+    describe_payload = json.loads(
+        await describe_dashboard_wrapper(dashboard["id"], "draft", "full", ids["tenant_id"], ids["user_id"])
+    )
+    assert describe_payload["success"] is True
+    assert describe_payload["version"]["manifest"]["tiles"][0]["id"] == "tile-revenue"
+
+    validate_payload = json.loads(await validate_dashboard_wrapper(dashboard["id"], ids["tenant_id"], ids["user_id"]))
+    assert validate_payload["success"] is True
+    assert validate_payload["validation"]["valid"] is True
+
+    patch_payload = json.loads(
+        await patch_dashboard_draft_wrapper(
+            dashboard["id"],
+            dashboard["etag"],
+            json.dumps([{"op": "replace", "path": "/title", "value": "MCP governed dashboard reviewed"}]),
+            "review title through MCP",
+            ids["tenant_id"],
+            ids["user_id"],
+        )
+    )
+    assert patch_payload["success"] is True
+    assert patch_payload["version"]["version_num"] == 2
+
+    stale_payload = json.loads(
+        await patch_dashboard_draft_wrapper(
+            dashboard["id"],
+            dashboard["etag"],
+            json.dumps([{"op": "replace", "path": "/title", "value": "stale"}]),
+            "stale retry",
+            ids["tenant_id"],
+            ids["user_id"],
+        )
+    )
+    assert stale_payload["success"] is False
+    assert stale_payload["status_code"] == 409
+    assert stale_payload["details"]["code"] == "etag_conflict"
+
+    refreshed_payload = json.loads(
+        await describe_dashboard_wrapper(dashboard["id"], "draft", "compact", ids["tenant_id"], ids["user_id"])
+    )
+    publish_payload = json.loads(
+        await publish_dashboard_wrapper(
+            dashboard["id"],
+            refreshed_payload["dashboard"]["etag"],
+            "publish through MCP",
+            ids["tenant_id"],
+            ids["user_id"],
+        )
+    )
+    assert publish_payload["success"] is True
+    assert publish_payload["version"]["status"] == "published"
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_saved_query(session, query_id_arg, filters=None, viewer_user_id=None):
+        captured["query_id"] = query_id_arg
+        captured["filters"] = filters
+        captured["viewer_user_id"] = viewer_user_id
+        return {
+            "success": True,
+            "data": [{"revenue": 42}, {"revenue": 43}],
+            "cached": True,
+            "stale": False,
+            "as_of": "2026-08-16T12:34:56",
+        }
+
+    monkeypatch.setattr("server.services.dashboard.QueryService.execute_saved_query", fake_execute_saved_query)
+
+    query_payload = json.loads(
+        await query_dashboard_wrapper(
+            dashboard["id"],
+            ["dv-saved-revenue"],
+            {"region": "AMER"},
+            "",
+            1,
+            ids["tenant_id"],
+            ids["user_id"],
+        )
+    )
+    assert query_payload["success"] is True
+    run = query_payload["run"]
+    assert run["actor_type"] == "agent"
+    assert run["normalized_filters"] == {"region": "AMER"}
+    assert run["views"][0]["result"] == [{"revenue": 42}]
+    assert run["views"][0]["pagination"]["has_more"] is True
+    assert captured["query_id"] == query_id
+
+    saved_run = await test_session.get(DashboardRun, run["run_id"])
+    assert saved_run is not None
+    assert saved_run.actor_type == "agent"
+
+    lineage_payload = json.loads(
+        await get_dashboard_lineage_wrapper(dashboard["id"], "tile-revenue", ids["tenant_id"], ids["user_id"])
+    )
+    assert lineage_payload["success"] is True
+    assert lineage_payload["lineage"]["data_views"][0]["lineage"][0]["ref"] == query_id
+
+
+async def test_dashboard_mcp_publish_requires_share_scope(test_session: AsyncSession) -> None:
+    ids = await _seed_owner_notebook(test_session)
+    member_id = uuid4()
+    test_session.add(
+        User(
+            id=member_id,
+            email=f"dashboard-mcp-member-{member_id}@example.test",
+            hashed_password="hash",
+            is_active=True,
+            is_verified=True,
+        )
+    )
+    await test_session.flush()
+    test_session.add(TenantMember(user_id=member_id, tenant_id=ids["tenant_id"], role=TenantRole.MEMBER.value))
+    await test_session.commit()
+
+    create_payload = json.loads(
+        await create_dashboard_draft_wrapper(
+            "mcp-member-dashboard",
+            str(ids["notebook_id"]),
+            json.dumps(_manifest_payload(str(uuid4()))),
+            ids["tenant_id"],
+            ids["user_id"],
+        )
+    )
+    dashboard = create_payload["dashboard"]
+
+    publish_payload = json.loads(
+        await publish_dashboard_wrapper(
+            dashboard["id"],
+            dashboard["etag"],
+            "member cannot publish",
+            ids["tenant_id"],
+            member_id,
+        )
+    )
+    assert publish_payload["success"] is False
+    assert publish_payload["status_code"] == 403
+    assert "dashboard.share" in publish_payload["error"]

--- a/server/tests/test_dashboard_persistence_migration.py
+++ b/server/tests/test_dashboard_persistence_migration.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table, Text, create_engine, inspect, text
+
+from server.db.base import Base
+from server.migrations.versions import add_governed_dashboard_assets, backfill_legacy_dashboard_assets
+from server.models.dashboard import Dashboard, DashboardAsset, DashboardAuditEvent, DashboardRun
+
+
+def _create_minimal_dashboard_legacy_schema(engine) -> None:
+    metadata = MetaData()
+    Table("users", metadata, Column("id", String(36), primary_key=True))
+    Table(
+        "tenants",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("owner_id", String(36), ForeignKey("users.id"), nullable=False),
+    )
+    Table(
+        "notebooks",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("tenant_id", String(36), ForeignKey("tenants.id"), nullable=False),
+        Column("created_by", String(36), ForeignKey("users.id"), nullable=True),
+        Column("notebook_name", String(255), nullable=True),
+    )
+    Table(
+        "dashboards",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("tenant_id", String(36), ForeignKey("tenants.id"), nullable=False),
+        Column("notebook_id", String(36), ForeignKey("notebooks.id"), nullable=False),
+        Column("version_num", Integer, nullable=False),
+        Column("html_content", Text, nullable=False),
+    )
+    metadata.create_all(engine)
+
+
+def test_dashboard_persistence_models_are_registered() -> None:
+    assert DashboardAsset.__tablename__ in Base.metadata.tables
+    assert DashboardRun.__tablename__ in Base.metadata.tables
+    assert DashboardAuditEvent.__tablename__ in Base.metadata.tables
+
+    dashboard_columns = {column.name for column in Dashboard.__table__.columns}
+    assert {
+        "asset_id",
+        "manifest_schema_version",
+        "manifest_json",
+        "content_hash",
+        "status",
+        "pinned_model_versions_json",
+        "pinned_source_snapshots_json",
+        "validation_result_json",
+        "migration_state",
+        "is_published_immutable",
+    }.issubset(dashboard_columns)
+
+
+def test_governed_dashboard_migration_upgrade_and_downgrade_sqlite() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    _create_minimal_dashboard_legacy_schema(engine)
+
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        operations = Operations(context)
+        original_op = add_governed_dashboard_assets.op
+        add_governed_dashboard_assets.op = operations
+        try:
+            add_governed_dashboard_assets.upgrade()
+            inspector = inspect(connection)
+            assert "dashboard_assets" in inspector.get_table_names()
+            assert "dashboard_runs" in inspector.get_table_names()
+            assert "dashboard_audit_events" in inspector.get_table_names()
+
+            dashboard_columns = {column["name"] for column in inspector.get_columns("dashboards")}
+            assert {
+                "asset_id",
+                "manifest_json",
+                "status",
+                "migration_state",
+                "is_published_immutable",
+            }.issubset(dashboard_columns)
+
+            add_governed_dashboard_assets.downgrade()
+            inspector = inspect(connection)
+            assert "dashboard_assets" not in inspector.get_table_names()
+            assert "dashboard_runs" not in inspector.get_table_names()
+            assert "dashboard_audit_events" not in inspector.get_table_names()
+            dashboard_columns = {column["name"] for column in inspector.get_columns("dashboards")}
+            assert "asset_id" not in dashboard_columns
+            assert "html_content" in dashboard_columns
+        finally:
+            add_governed_dashboard_assets.op = original_op
+
+
+def test_legacy_dashboard_backfill_links_existing_rows_without_html_parsing() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    _create_minimal_dashboard_legacy_schema(engine)
+
+    with engine.begin() as connection:
+        connection.execute(text("INSERT INTO users (id) VALUES ('user-1')"))
+        connection.execute(text("INSERT INTO tenants (id, owner_id) VALUES ('tenant-1', 'user-1')"))
+        connection.execute(
+            text(
+                "INSERT INTO notebooks (id, tenant_id, created_by, notebook_name) "
+                "VALUES ('notebook-1', 'tenant-1', 'user-1', 'Legacy Revenue')"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO dashboards (id, tenant_id, notebook_id, version_num, html_content) "
+                "VALUES ('dash-1', 'tenant-1', 'notebook-1', 1, '<html>query-a</html>')"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO dashboards (id, tenant_id, notebook_id, version_num, html_content) "
+                "VALUES ('dash-2', 'tenant-1', 'notebook-1', 2, '<html>query-b</html>')"
+            )
+        )
+
+        context = MigrationContext.configure(connection)
+        operations = Operations(context)
+        original_asset_op = add_governed_dashboard_assets.op
+        original_backfill_op = backfill_legacy_dashboard_assets.op
+        add_governed_dashboard_assets.op = operations
+        backfill_legacy_dashboard_assets.op = operations
+        try:
+            add_governed_dashboard_assets.upgrade()
+            backfill_legacy_dashboard_assets.upgrade()
+
+            assets = connection.execute(text("SELECT * FROM dashboard_assets")).mappings().all()
+            assert len(assets) == 1
+            asset = assets[0]
+            assert asset["slug"].startswith("legacy-notebook-1")
+            assert asset["name"] == "Legacy Revenue"
+            assert asset["lifecycle"] == "legacy_unstructured"
+            assert asset["published_version_id"] == "dash-2"
+
+            dashboards = connection.execute(
+                text(
+                    "SELECT id, asset_id, html_content, status, migration_state, manifest_json "
+                    "FROM dashboards ORDER BY version_num"
+                )
+            ).mappings().all()
+            assert {dashboard["asset_id"] for dashboard in dashboards} == {asset["id"]}
+            assert [dashboard["html_content"] for dashboard in dashboards] == [
+                "<html>query-a</html>",
+                "<html>query-b</html>",
+            ]
+            assert {dashboard["status"] for dashboard in dashboards} == {"legacy_unstructured"}
+            assert {dashboard["migration_state"] for dashboard in dashboards} == {"legacy_unstructured"}
+            assert all(dashboard["manifest_json"] is None for dashboard in dashboards)
+
+            backfill_legacy_dashboard_assets.upgrade()
+            assert connection.execute(text("SELECT COUNT(*) FROM dashboard_assets")).scalar_one() == 1
+
+            backfill_legacy_dashboard_assets.downgrade()
+            assert connection.execute(text("SELECT COUNT(*) FROM dashboard_assets")).scalar_one() == 0
+            assert (
+                connection.execute(text("SELECT COUNT(*) FROM dashboards WHERE html_content LIKE '<html>query-%'")).scalar_one()
+                == 2
+            )
+        finally:
+            add_governed_dashboard_assets.op = original_asset_op
+            backfill_legacy_dashboard_assets.op = original_backfill_op

--- a/server/tests/test_dashboard_persistence_migration.py
+++ b/server/tests/test_dashboard_persistence_migration.py
@@ -139,12 +139,16 @@ def test_legacy_dashboard_backfill_links_existing_rows_without_html_parsing() ->
             assert asset["lifecycle"] == "legacy_unstructured"
             assert asset["published_version_id"] == "dash-2"
 
-            dashboards = connection.execute(
-                text(
-                    "SELECT id, asset_id, html_content, status, migration_state, manifest_json "
-                    "FROM dashboards ORDER BY version_num"
+            dashboards = (
+                connection.execute(
+                    text(
+                        "SELECT id, asset_id, html_content, status, migration_state, manifest_json "
+                        "FROM dashboards ORDER BY version_num"
+                    )
                 )
-            ).mappings().all()
+                .mappings()
+                .all()
+            )
             assert {dashboard["asset_id"] for dashboard in dashboards} == {asset["id"]}
             assert [dashboard["html_content"] for dashboard in dashboards] == [
                 "<html>query-a</html>",
@@ -160,7 +164,9 @@ def test_legacy_dashboard_backfill_links_existing_rows_without_html_parsing() ->
             backfill_legacy_dashboard_assets.downgrade()
             assert connection.execute(text("SELECT COUNT(*) FROM dashboard_assets")).scalar_one() == 0
             assert (
-                connection.execute(text("SELECT COUNT(*) FROM dashboards WHERE html_content LIKE '<html>query-%'")).scalar_one()
+                connection.execute(
+                    text("SELECT COUNT(*) FROM dashboards WHERE html_content LIKE '<html>query-%'")
+                ).scalar_one()
                 == 2
             )
         finally:

--- a/server/tests/test_dashboard_rest_api.py
+++ b/server/tests/test_dashboard_rest_api.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from server.models.dashboard import DashboardRun
+from server.models.notebooks import Notebook
+from server.models.tenant import Tenant
+
+pytestmark = pytest.mark.asyncio
+
+
+def _manifest_payload(query_id: str | None = None, dashboard_id: str = "dash-rest") -> dict:
+    query_id = query_id or str(uuid4())
+    return {
+        "schema_version": "dashboard.manifest.v1",
+        "dashboard_id": dashboard_id,
+        "title": "REST governed dashboard",
+        "description": "Dashboard exposed through the governed REST contract",
+        "audience": ["finance"],
+        "semantic_bindings": [
+            {
+                "id": "sales-model",
+                "model_slug": "sales",
+                "model_version": "v1",
+                "source_snapshot_ids": ["snapshot-1"],
+                "allowed_metrics": ["revenue"],
+                "allowed_dimensions": ["region"],
+            }
+        ],
+        "data_views": [
+            {
+                "id": "dv-saved-revenue",
+                "kind": "saved_query",
+                "question": "What revenue did the reviewed query return?",
+                "output_schema": [{"name": "revenue", "data_type": "number", "unit": "USD"}],
+                "filter_fields": ["region"],
+                "saved_query": {
+                    "query_id": query_id,
+                    "compatibility_reason": "reviewed legacy dashboard query",
+                    "filter_contract": {},
+                    "lineage": [
+                        {
+                            "id": "query-lineage",
+                            "kind": "saved_query",
+                            "name": "Revenue query",
+                            "ref": query_id,
+                        }
+                    ],
+                },
+            }
+        ],
+        "filters": [
+            {
+                "id": "region",
+                "label": "Region",
+                "source": "saved_query_contract",
+                "field": "region",
+                "filter_type": "enum",
+                "operators": ["eq"],
+                "affected_data_view_ids": ["dv-saved-revenue"],
+            }
+        ],
+        "layout": {"sections": [{"id": "main", "tile_ids": ["tile-revenue"]}]},
+        "tiles": [
+            {
+                "id": "tile-revenue",
+                "title": "Revenue",
+                "tile_type": "kpi",
+                "business_question": "What is revenue?",
+                "data_view_id": "dv-saved-revenue",
+            }
+        ],
+        "actions": [],
+        "freshness_policy": {"mode": "live", "max_age_seconds": 3600, "allow_stale": True},
+        "access_policy": {"required_scopes": ["dashboard:read", "dashboard:query"]},
+        "provenance": {"created_by_actor_type": "human", "created_by": "user-1", "source": "human"},
+        "migration": {"state": "new_structured", "blockers": []},
+    }
+
+
+async def _seed_notebook(test_session) -> Notebook:
+    tenant = (await test_session.execute(select(Tenant))).scalars().first()
+    assert tenant is not None
+    notebook = Notebook(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        created_by=tenant.owner_id,
+        notebook_name="Dashboard REST notebook",
+    )
+    test_session.add(notebook)
+    await test_session.commit()
+    await test_session.refresh(notebook)
+    return notebook
+
+
+async def test_dashboard_asset_rest_lifecycle_query_state_lineage_and_audit(
+    test_client,
+    test_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    notebook = await _seed_notebook(test_session)
+    query_id = str(uuid4())
+    manifest = _manifest_payload(query_id)
+
+    create_response = await test_client.post(
+        "/api/dashboard-assets",
+        json={
+            "slug": "rest-governed-dashboard",
+            "notebook_id": str(notebook.id),
+            "manifest": manifest,
+            "tags": ["finance"],
+            "change_summary": "create from API",
+        },
+    )
+    assert create_response.status_code == 201
+    asset = create_response.json()["data"]
+    assert asset["slug"] == "rest-governed-dashboard"
+    assert asset["lifecycle"] == "draft"
+    assert asset["etag"].startswith("sha256:")
+
+    list_response = await test_client.get("/api/dashboard-assets")
+    assert list_response.status_code == 200
+    assert list_response.json()["data"]["total"] == 1
+
+    version_response = await test_client.get(f"/api/dashboard-assets/{asset['id']}/versions/1")
+    assert version_response.status_code == 200
+    assert version_response.json()["data"]["manifest"]["data_views"][0]["id"] == "dv-saved-revenue"
+
+    validate_response = await test_client.post(f"/api/dashboard-assets/{asset['id']}/validate", json={})
+    assert validate_response.status_code == 200
+    assert validate_response.json()["data"]["validation"]["valid"] is True
+
+    patched_manifest = deepcopy(manifest)
+    patched_manifest["title"] = "REST governed dashboard reviewed"
+    patch_response = await test_client.patch(
+        f"/api/dashboard-assets/{asset['id']}/draft",
+        json={
+            "base_etag": asset["etag"],
+            "manifest": patched_manifest,
+            "change_summary": "review title",
+        },
+    )
+    assert patch_response.status_code == 200
+    patched = patch_response.json()["data"]
+    assert patched["version_num"] == 2
+    assert patched["manifest"]["title"] == "REST governed dashboard reviewed"
+
+    stale_patch_response = await test_client.patch(
+        f"/api/dashboard-assets/{asset['id']}/draft",
+        json={
+            "base_etag": asset["etag"],
+            "manifest": patched_manifest,
+            "change_summary": "stale retry",
+        },
+    )
+    assert stale_patch_response.status_code == 409
+    assert stale_patch_response.json()["data"]["code"] == "etag_conflict"
+
+    refreshed_response = await test_client.get(f"/api/dashboard-assets/{asset['id']}")
+    assert refreshed_response.status_code == 200
+    refreshed = refreshed_response.json()["data"]
+    publish_response = await test_client.post(
+        f"/api/dashboard-assets/{asset['id']}/publish",
+        json={"base_etag": refreshed["etag"], "change_summary": "publish from API"},
+    )
+    assert publish_response.status_code == 200
+    published = publish_response.json()["data"]
+    assert published["status"] == "published"
+    assert published["is_published_immutable"] is True
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_saved_query(session, query_id_arg, filters=None, viewer_user_id=None):
+        captured["query_id"] = query_id_arg
+        captured["filters"] = filters
+        captured["viewer_user_id"] = viewer_user_id
+        return {
+            "success": True,
+            "data": [{"revenue": 42}],
+            "query_id": query_id_arg,
+            "cached": True,
+            "stale": False,
+            "as_of": "2026-08-16T00:00:00",
+        }
+
+    monkeypatch.setattr("server.services.dashboard.QueryService.execute_saved_query", fake_execute_saved_query)
+
+    preview_response = await test_client.post(
+        f"/api/dashboard-assets/{asset['id']}/preview",
+        json={"data_view_ids": ["dv-saved-revenue"], "correlation_id": "corr-preview"},
+    )
+    assert preview_response.status_code == 200
+    assert preview_response.json()["data"]["preview"] is True
+
+    query_response = await test_client.post(
+        f"/api/dashboard-assets/{asset['id']}/query",
+        json={
+            "filters": {"region": "AMER"},
+            "data_view_ids": ["dv-saved-revenue"],
+            "correlation_id": "corr-rest",
+        },
+    )
+    assert query_response.status_code == 200
+    run = query_response.json()["data"]
+    assert captured["query_id"] == query_id
+    assert captured["viewer_user_id"] is None
+    assert run["dashboard_id"] == asset["id"]
+    assert run["views"][0]["result"] == [{"revenue": 42}]
+    assert run["views"][0]["cached"] is True
+
+    saved_run = await test_session.get(DashboardRun, run["run_id"])
+    assert saved_run is not None
+    assert saved_run.correlation_id == "corr-rest"
+
+    unknown_view_response = await test_client.post(
+        f"/api/dashboard-assets/{asset['id']}/query",
+        json={"data_view_ids": ["missing-view"]},
+    )
+    assert unknown_view_response.status_code == 403
+
+    export_response = await test_client.get(f"/api/dashboard-assets/{asset['id']}/export/html")
+    assert export_response.status_code == 200
+    assert "text/html" in export_response.headers["content-type"]
+    assert 'attachment; filename="rest-governed-dashboard-v2.html"' == export_response.headers["content-disposition"]
+    assert "dashboard.manifest.v1" in export_response.text
+
+    state_response = await test_client.get(f"/api/dashboard-assets/{asset['id']}/state")
+    assert state_response.status_code == 200
+    state_payload = state_response.json()["data"]
+    assert state_payload["published_version_id"] == published["id"]
+    assert len(state_payload["versions"]) == 2
+
+    lineage_response = await test_client.get(f"/api/dashboard-assets/{asset['id']}/lineage")
+    assert lineage_response.status_code == 200
+    assert lineage_response.json()["data"]["lineage"]["data_views"][0]["lineage"][0]["ref"] == query_id
+
+    audit_response = await test_client.get(f"/api/dashboard-assets/{asset['id']}/audit")
+    assert audit_response.status_code == 200
+    audit_actions = [item["action"] for item in audit_response.json()["data"]["items"]]
+    assert "dashboard.draft.create" in audit_actions
+    assert "dashboard.draft.patch" in audit_actions
+    assert "dashboard.publish" in audit_actions
+    assert "dashboard.preview" in audit_actions
+    assert "dashboard.query" in audit_actions
+    assert "dashboard.export" in audit_actions
+
+
+async def test_dashboard_full_manifest_patch_rejects_non_allowlisted_top_level_change(
+    test_client,
+    test_session,
+) -> None:
+    notebook = await _seed_notebook(test_session)
+    manifest = _manifest_payload()
+    create_response = await test_client.post(
+        "/api/dashboard-assets",
+        json={
+            "slug": "rest-governed-dashboard-full-manifest-guard",
+            "notebook_id": str(notebook.id),
+            "manifest": manifest,
+            "change_summary": "create guard fixture",
+        },
+    )
+    assert create_response.status_code == 201
+    asset = create_response.json()["data"]
+
+    blocked_manifest = deepcopy(manifest)
+    blocked_manifest["dashboard_id"] = "blocked-dashboard-id-rewrite"
+    patch_response = await test_client.patch(
+        f"/api/dashboard-assets/{asset['id']}/draft",
+        json={
+            "base_etag": asset["etag"],
+            "manifest": blocked_manifest,
+            "change_summary": "attempt non-allowlisted full manifest change",
+        },
+    )
+
+    assert patch_response.status_code == 403
+    data = patch_response.json()["data"]
+    assert data["code"] == "dashboard_manifest_patch_forbidden"
+    assert data["blocked_keys"] == ["dashboard_id"]

--- a/server/tests/test_dashboard_service.py
+++ b/server/tests/test_dashboard_service.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.dashboard import Dashboard, DashboardAuditEvent, DashboardRun
+from server.models.notebooks import Notebook
+from server.models.tenant import Tenant
+from server.models.user import User
+from server.services.dashboard import DashboardService
+
+
+def _saved_query_manifest(query_id: str, dashboard_id: str = "dash-saved-query") -> dict:
+    return {
+        "schema_version": "dashboard.manifest.v1",
+        "dashboard_id": dashboard_id,
+        "title": "Saved query dashboard",
+        "description": "Compatibility dashboard",
+        "audience": ["finance"],
+        "semantic_bindings": [
+            {
+                "id": "sales-model",
+                "model_slug": "sales",
+                "model_version": "v1",
+                "source_snapshot_ids": ["snapshot-1"],
+                "allowed_metrics": ["revenue"],
+            }
+        ],
+        "data_views": [
+            {
+                "id": "dv-saved-revenue",
+                "kind": "saved_query",
+                "question": "What revenue did the saved query return?",
+                "output_schema": [{"name": "revenue", "data_type": "number", "unit": "USD"}],
+                "filter_fields": ["region"],
+                "saved_query": {
+                    "query_id": query_id,
+                    "compatibility_reason": "legacy reviewed dashboard query",
+                    "filter_contract": {},
+                    "lineage": [
+                        {
+                            "id": "query-lineage",
+                            "kind": "saved_query",
+                            "name": "Revenue query",
+                            "ref": query_id,
+                        }
+                    ],
+                },
+            }
+        ],
+        "filters": [
+            {
+                "id": "region",
+                "label": "Region",
+                "source": "saved_query_contract",
+                "field": "region",
+                "filter_type": "enum",
+                "operators": ["eq"],
+                "affected_data_view_ids": ["dv-saved-revenue"],
+            }
+        ],
+        "layout": {"sections": [{"id": "main", "tile_ids": ["tile-revenue"]}]},
+        "tiles": [
+            {
+                "id": "tile-revenue",
+                "title": "Revenue",
+                "tile_type": "kpi",
+                "business_question": "What is revenue?",
+                "data_view_id": "dv-saved-revenue",
+            }
+        ],
+        "actions": [],
+        "freshness_policy": {"mode": "live", "max_age_seconds": 3600, "allow_stale": True},
+        "access_policy": {"required_scopes": ["dashboard:read", "dashboard:query"]},
+        "provenance": {"created_by_actor_type": "human", "created_by": "user-1", "source": "human"},
+        "migration": {"state": "new_structured", "blockers": []},
+    }
+
+
+def _semantic_manifest() -> dict:
+    manifest = _saved_query_manifest(str(uuid4()), "dash-semantic")
+    manifest["data_views"] = [
+        {
+            "id": "dv-paid-revenue",
+            "kind": "semantic_metric",
+            "question": "What paid revenue is recognized?",
+            "output_schema": [{"name": "paid_revenue", "data_type": "number", "unit": "USD"}],
+            "filter_fields": ["region"],
+            "semantic_metric": {
+                "semantic_binding_id": "sales-model",
+                "metric": "revenue",
+                "dimensions": [],
+            },
+        }
+    ]
+    manifest["filters"][0]["source"] = "semantic_field"
+    manifest["filters"][0]["affected_data_view_ids"] = ["dv-paid-revenue"]
+    manifest["tiles"][0]["data_view_id"] = "dv-paid-revenue"
+    return manifest
+
+
+async def _seed_owner_notebook(test_session: AsyncSession) -> dict[str, UUID]:
+    user_id = uuid4()
+    tenant_id = uuid4()
+    notebook_id = uuid4()
+    test_session.add(
+        User(
+            id=user_id,
+            email=f"dashboard-{user_id}@example.test",
+            hashed_password="hash",
+            is_active=True,
+            is_verified=True,
+        )
+    )
+    await test_session.flush()
+    test_session.add(Tenant(id=tenant_id, name="Dashboard Tenant", slug=f"dashboard-{tenant_id}", owner_id=user_id))
+    await test_session.flush()
+    test_session.add(
+        Notebook(
+            id=notebook_id,
+            tenant_id=tenant_id,
+            created_by=user_id,
+            notebook_name="Dashboard notebook",
+        )
+    )
+    await test_session.commit()
+    return {"tenant_id": tenant_id, "user_id": user_id, "notebook_id": notebook_id}
+
+
+@pytest.mark.asyncio
+async def test_create_patch_publish_and_export_dashboard(test_session: AsyncSession) -> None:
+    ids = await _seed_owner_notebook(test_session)
+    service = DashboardService()
+    manifest = _saved_query_manifest(str(uuid4()))
+
+    asset = await service.create_asset_draft(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        actor_id=ids["user_id"],
+        notebook_id=ids["notebook_id"],
+        slug="revenue-ops",
+        manifest_payload=manifest,
+    )
+
+    assert asset.lifecycle == "draft"
+    assert asset.etag.startswith("sha256:")
+    assert asset.current_draft_version_id is not None
+    draft = await test_session.scalar(select(Dashboard).where(Dashboard.asset_id == asset.id))
+    assert draft is not None
+    assert draft.status == "draft"
+    assert draft.manifest_schema_version == "dashboard.manifest.v1"
+    assert draft.pinned_model_versions_json == {"sales": "v1"}
+    assert draft.pinned_source_snapshots_json == ["snapshot-1"]
+    assert draft.validation_result_json["valid"] is True
+
+    patched_manifest = deepcopy(manifest)
+    patched_manifest["title"] = "Revenue operations reviewed"
+    patched = await service.patch_draft(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        asset_id=asset.id,
+        actor_id=ids["user_id"],
+        base_etag=asset.etag,
+        manifest_payload=patched_manifest,
+        change_summary="review title",
+    )
+    await test_session.refresh(asset)
+    assert patched.version_num == 2
+    assert asset.current_draft_version_id == patched.id
+
+    published = await service.publish(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        asset_id=asset.id,
+        actor_id=ids["user_id"],
+        base_etag=asset.etag,
+        change_summary="publish reviewed dashboard",
+    )
+    await test_session.refresh(asset)
+    assert published.status == "published"
+    assert published.is_published_immutable is True
+    assert asset.lifecycle == "published"
+    assert asset.published_version_id == published.id
+
+    html, filename = await service.export_dashboard_html(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        asset_id=asset.id,
+        actor_id=ids["user_id"],
+    )
+    assert filename == "revenue-ops-v2.html"
+    assert "Revenue operations reviewed" in html
+    assert "dashboard.manifest.v1" in html
+
+    audit_events = (
+        await test_session.execute(
+            select(DashboardAuditEvent.action)
+            .where(DashboardAuditEvent.asset_id == asset.id)
+            .order_by(DashboardAuditEvent.created_at)
+        )
+    ).scalars().all()
+    assert audit_events == [
+        "dashboard.draft.create",
+        "dashboard.draft.patch",
+        "dashboard.publish",
+        "dashboard.export",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_patch_draft_rejects_stale_etag_and_non_allowlisted_manifest_keys(test_session: AsyncSession) -> None:
+    ids = await _seed_owner_notebook(test_session)
+    service = DashboardService()
+    manifest = _saved_query_manifest(str(uuid4()), "dash-conflict")
+    asset = await service.create_asset_draft(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        actor_id=ids["user_id"],
+        notebook_id=ids["notebook_id"],
+        slug="revenue-conflict",
+        manifest_payload=manifest,
+    )
+
+    with pytest.raises(HTTPException) as stale:
+        await service.patch_draft(
+            session=test_session,
+            tenant_id=ids["tenant_id"],
+            asset_id=asset.id,
+            actor_id=ids["user_id"],
+            base_etag="stale",
+            manifest_payload=manifest,
+            change_summary="stale patch",
+        )
+    assert stale.value.status_code == 409
+    assert stale.value.detail["code"] == "etag_conflict"
+
+    blocked_manifest = deepcopy(manifest)
+    blocked_manifest["dashboard_id"] = "dash-full-manifest-rewrite"
+    with pytest.raises(HTTPException) as blocked:
+        await service.patch_draft(
+            session=test_session,
+            tenant_id=ids["tenant_id"],
+            asset_id=asset.id,
+            actor_id=ids["user_id"],
+            base_etag=asset.etag,
+            manifest_payload=blocked_manifest,
+            change_summary="blocked manifest rewrite",
+        )
+    assert blocked.value.status_code == 403
+    assert blocked.value.detail["code"] == "dashboard_manifest_patch_forbidden"
+    assert blocked.value.detail["blocked_keys"] == ["dashboard_id"]
+
+
+@pytest.mark.asyncio
+async def test_query_saved_query_dashboard_persists_run_and_blocks_unknown_filters(
+    test_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ids = await _seed_owner_notebook(test_session)
+    query_id = str(uuid4())
+    service = DashboardService()
+    asset = await service.create_asset_draft(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        actor_id=ids["user_id"],
+        notebook_id=ids["notebook_id"],
+        slug="revenue-query",
+        manifest_payload=_saved_query_manifest(query_id),
+    )
+    published = await service.publish(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        asset_id=asset.id,
+        actor_id=ids["user_id"],
+        base_etag=asset.etag,
+        change_summary="publish",
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_saved_query(session, query_id_arg, filters=None, viewer_user_id=None):
+        captured["query_id"] = query_id_arg
+        captured["filters"] = filters
+        captured["viewer_user_id"] = viewer_user_id
+        return {
+            "success": True,
+            "data": [{"revenue": 42}],
+            "query_id": query_id_arg,
+            "cached": True,
+            "stale": False,
+            "as_of": "2026-08-16T00:00:00",
+        }
+
+    monkeypatch.setattr("server.services.dashboard.QueryService.execute_saved_query", fake_execute_saved_query)
+
+    run = await service.query_dashboard(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        asset_id=asset.id,
+        actor_id=str(ids["user_id"]),
+        actor_type="human",
+        filters={"region": "AMER"},
+        data_view_ids=["dv-saved-revenue"],
+        correlation_id="corr-service",
+    )
+
+    assert run["dashboard_version_id"] == str(published.id)
+    assert run["normalized_filters"] == {"region": "AMER"}
+    assert run["views"][0]["result"] == [{"revenue": 42}]
+    assert captured["query_id"] == query_id
+    assert captured["viewer_user_id"] is None
+
+    saved_run = await test_session.get(DashboardRun, run["run_id"])
+    assert saved_run is not None
+    assert saved_run.correlation_id == "corr-service"
+
+    with pytest.raises(HTTPException) as unknown_filter:
+        await service.query_dashboard(
+            session=test_session,
+            tenant_id=ids["tenant_id"],
+            asset_id=asset.id,
+            actor_id=str(ids["user_id"]),
+            actor_type="human",
+            filters={"raw_sql": "select * from other_tenant.secret"},
+            data_view_ids=["dv-saved-revenue"],
+        )
+    assert unknown_filter.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_semantic_metric_execution_is_explicitly_partial_until_modeling_lands(test_session: AsyncSession) -> None:
+    ids = await _seed_owner_notebook(test_session)
+    service = DashboardService()
+    asset = await service.create_asset_draft(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        actor_id=ids["user_id"],
+        notebook_id=ids["notebook_id"],
+        slug="semantic-partial",
+        manifest_payload=_semantic_manifest(),
+    )
+    await service.publish(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        asset_id=asset.id,
+        actor_id=ids["user_id"],
+        base_etag=asset.etag,
+        change_summary="publish",
+    )
+
+    run = await service.query_dashboard(
+        session=test_session,
+        tenant_id=ids["tenant_id"],
+        asset_id=asset.id,
+        actor_id=str(ids["user_id"]),
+        actor_type="human",
+        filters={"region": "AMER"},
+        data_view_ids=["dv-paid-revenue"],
+    )
+
+    assert run["overall_freshness"] == "blocked"
+    assert run["views"][0]["status"] == "blocked"
+    assert run["views"][0]["error"]["code"] == "semantic_metric_partial"

--- a/server/tests/test_dashboard_service.py
+++ b/server/tests/test_dashboard_service.py
@@ -198,12 +198,16 @@ async def test_create_patch_publish_and_export_dashboard(test_session: AsyncSess
     assert "dashboard.manifest.v1" in html
 
     audit_events = (
-        await test_session.execute(
-            select(DashboardAuditEvent.action)
-            .where(DashboardAuditEvent.asset_id == asset.id)
-            .order_by(DashboardAuditEvent.created_at)
+        (
+            await test_session.execute(
+                select(DashboardAuditEvent.action)
+                .where(DashboardAuditEvent.asset_id == asset.id)
+                .order_by(DashboardAuditEvent.created_at)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert audit_events == [
         "dashboard.draft.create",
         "dashboard.draft.patch",

--- a/server/tests/test_evaluation_contract_schemas.py
+++ b/server/tests/test_evaluation_contract_schemas.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from server.schemas.evaluation import (
+    EvaluationCaseContract,
+    EvaluationSuiteVersionManifest,
+    EvaluationTargetSnapshot,
+)
+
+
+def _valid_expected_contract() -> dict:
+    return {
+        "semantic_intent": {
+            "metric": "revenue",
+            "dimensions": ["region"],
+            "grain": "month",
+            "timezone": "UTC",
+        },
+        "ground_truth_sql": {
+            "sql": "SELECT region, SUM(revenue) AS revenue FROM fact_sales GROUP BY region",
+            "dialect": "duckdb",
+            "must_reference": ["fact_sales"],
+        },
+        "expected_schema": [
+            {"name": "region", "data_type": "string"},
+            {"name": "revenue", "data_type": "number", "unit": "USD"},
+        ],
+        "normalized_result": {
+            "mode": "multiset",
+            "rows": [{"region": "AMER", "revenue": "123.45"}],
+            "canonical_hash": "sha256:result",
+        },
+        "tolerance": {"absolute": 0.01, "relative": 0.001},
+        "answer": {"must_include_any": ["AMER"], "must_not_include": ["restricted"]},
+        "evidence": {"required": True, "lineage_refs": ["source-1"]},
+        "policy": {"required_scopes": ["dashboard.export"], "forbidden_fields": ["free_text"]},
+        "dashboard": {"manifest_id": "dash-1", "run_contract_version": "dashboard.run.v1"},
+        "human_mcp_parity": {"required": True, "compare_fields": ["values", "units", "warnings"]},
+    }
+
+
+def _valid_case() -> dict:
+    return {
+        "contract_version": "evaluation.case.v1",
+        "case_id": "case-revenue-by-region",
+        "title": "Revenue by region",
+        "target_kinds": ["semantic_model", "dashboard"],
+        "operation": "answer_question",
+        "question": "What is revenue by region?",
+        "expected": _valid_expected_contract(),
+        "tags": ["finance"],
+        "provenance": {"source": "human_feedback", "feedback_id": "fb-1"},
+    }
+
+
+def _complete_target_snapshot(target_kind: str = "dashboard") -> dict:
+    return {
+        "contract_version": "evaluation.target_snapshot.v1",
+        "target_kind": target_kind,
+        "target_ref": "dashboard:dash-1",
+        "app": {
+            "git_sha": "abc123",
+            "image_digest": "sha256:image",
+            "migration_revision": "add_evaluation_authoritative_model",
+        },
+        "connector": {"version": "connector-v1"},
+        "source": {"snapshot_id": "source-1", "snapshot_hash": "sha256:source"},
+        "semantic_model": {"version_id": "semver-1", "version_hash": "sha256:semantic"},
+        "dashboard": {
+            "version_id": "dash-version-1",
+            "manifest_hash": "sha256:manifest",
+            "renderer_version": "renderer-v1",
+        },
+        "prompt": {"version": "prompt-v1"},
+        "tool_registry_hash": "sha256:tools",
+        "skill_registry_hash": "sha256:skills",
+        "llm": {"provider": "openai", "model": "gpt-5", "params_hash": "sha256:llm"},
+        "principal": {
+            "tenant_id": "tenant-1",
+            "actor_type": "agent",
+            "actor_id": "agent-1",
+            "scopes": ["dashboard.export"],
+            "rls": {"region": "AMER"},
+            "cls": ["revenue"],
+        },
+        "dataset": {"snapshot_id": "dataset-1", "snapshot_hash": "sha256:dataset"},
+        "feature_flags": {"evaluation_governance": True},
+        "time_fixture": {"now": "2026-08-16T00:00:00Z", "timezone": "UTC"},
+    }
+
+
+def test_evaluation_case_contract_accepts_authoritative_expected_sections() -> None:
+    case = EvaluationCaseContract.model_validate(_valid_case())
+
+    assert case.contract_version == "evaluation.case.v1"
+    assert case.expected.ground_truth_sql is not None
+    assert case.expected.human_mcp_parity.required is True
+
+
+def test_evaluation_case_contract_rejects_non_readonly_ground_truth_sql() -> None:
+    payload = _valid_case()
+    payload["expected"]["ground_truth_sql"]["sql"] = "DELETE FROM fact_sales"
+
+    with pytest.raises(ValidationError, match="read-only"):
+        EvaluationCaseContract.model_validate(payload)
+
+
+def test_evaluation_manifest_json_schema_requires_authoritative_sections() -> None:
+    schema = EvaluationSuiteVersionManifest.model_json_schema()
+
+    assert schema["properties"]["contract_version"]["const"] == "evaluation.suite_version.v1"
+    assert {"contract_version", "suite_id", "version", "cases", "gate_policy"}.issubset(schema["required"])
+
+
+def test_target_snapshot_reports_missing_required_pins_without_latest_fallback() -> None:
+    snapshot = EvaluationTargetSnapshot.model_validate(
+        {
+            "contract_version": "evaluation.target_snapshot.v1",
+            "target_kind": "semantic_model",
+            "target_ref": "semantic_model:sales",
+            "app": {"git_sha": "abc123"},
+            "principal": {"tenant_id": "tenant-1", "actor_type": "human", "actor_id": "user-1", "scopes": []},
+            "feature_flags": {},
+            "time_fixture": {"timezone": "UTC"},
+        }
+    )
+
+    blockers = snapshot.required_pin_blockers()
+
+    assert "app.image_digest" in blockers
+    assert "app.migration_revision" in blockers
+    assert "source.snapshot_hash" in blockers
+    assert "semantic_model.version_hash" in blockers
+    assert "time_fixture.now" in blockers
+
+
+def test_target_snapshot_accepts_complete_dashboard_pins() -> None:
+    snapshot = EvaluationTargetSnapshot.model_validate(_complete_target_snapshot("dashboard"))
+
+    assert snapshot.required_pin_blockers() == []

--- a/server/tests/test_evaluation_mcp_contract.py
+++ b/server/tests/test_evaluation_mcp_contract.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import json
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from server.mcp import tool_wrappers
+from server.mcp.tool_wrappers import (
+    create_advisor_change_set_wrapper,
+    create_evaluation_case_draft_wrapper,
+    describe_evaluation_failure_wrapper,
+    describe_evaluation_suite_wrapper,
+    get_evaluation_run_wrapper,
+    list_evaluation_cases_wrapper,
+    preview_evaluation_ground_truth_wrapper,
+    run_advisor_gate_wrapper,
+    run_evaluation_wrapper,
+    search_evaluation_suites_wrapper,
+    submit_evaluation_feedback_wrapper,
+)
+from server.models.conversation_evaluation import ConversationEvaluation
+from server.models.custom_skill import CustomSkill
+from server.models.evaluation import (
+    EvaluationAssessment,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    EvaluationTargetSnapshot,
+)
+from server.models.notebooks import Notebook
+from server.models.skill_suggestion import SkillSuggestion
+from server.models.tenant import Tenant
+from server.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _patch_mcp_session_factory(test_engine, monkeypatch: pytest.MonkeyPatch):
+    test_session_factory = async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(tool_wrappers, "AsyncSessionFactory", test_session_factory)
+
+
+async def _seed_suite(test_session: AsyncSession) -> tuple[Tenant, User, EvaluationSuite, EvaluationSuiteVersion]:
+    tenant = (await test_session.execute(select(Tenant))).scalars().first()
+    if tenant is None:
+        user = User(
+            id=uuid4(),
+            email=f"evaluation-mcp-owner-{uuid4()}@example.test",
+            hashed_password="fakehash",
+            is_active=True,
+            is_verified=True,
+        )
+        test_session.add(user)
+        await test_session.flush()
+        tenant = Tenant(
+            id=uuid4(),
+            name="Evaluation MCP Tenant",
+            slug=f"evaluation-mcp-{uuid4().hex[:8]}",
+            owner_id=user.id,
+            is_personal=True,
+        )
+        test_session.add(tenant)
+        await test_session.flush()
+    owner = await test_session.get(User, tenant.owner_id)
+    assert owner is not None
+    suite = EvaluationSuite(
+        tenant_id=tenant.id,
+        slug=f"mcp-suite-{uuid4()}",
+        name="MCP Evaluation suite",
+        description="Suite exposed through MCP",
+        owner_id=owner.id,
+        target_kinds_json=["agent_answer", "semantic_model"],
+        lifecycle="draft",
+    )
+    test_session.add(suite)
+    await test_session.flush()
+    version = EvaluationSuiteVersion(
+        tenant_id=tenant.id,
+        suite_id=suite.id,
+        version_num=1,
+        status="draft",
+        contract_version="evaluation.suite_version.v1",
+        manifest_json={"contract_version": "evaluation.suite_version.v1", "suite_id": "mcp", "version": 1},
+        gate_policy_json={"version": "gate-policy.v1", "security_hard_fail": True, "min_overall_pass_rate": 1.0},
+        case_count=0,
+        content_hash="sha256:mcp-suite",
+        created_by=owner.id,
+    )
+    test_session.add(version)
+    await test_session.commit()
+    return tenant, owner, suite, version
+
+
+def _expected_contract() -> dict:
+    return {
+        "semantic_intent": {"description": "The answer must exclude refunded rows."},
+        "ground_truth_sql": {"sql": "SELECT SUM(revenue) AS revenue FROM fact_sales", "dialect": "duckdb"},
+        "answer": {"must_include_any": ["exclude refunds"], "must_not_include": ["password=plain-password"]},
+        "evidence": {"required": True},
+        "policy": {"security_hard_fail": True},
+    }
+
+
+def _target_snapshot(tenant_id: UUID) -> dict:
+    return {
+        "contract_version": "evaluation.target_snapshot.v1",
+        "target_kind": "agent_answer",
+        "target_ref": "agent:revenue-answer",
+        "app": {
+            "git_sha": "abc123",
+            "image_digest": "sha256:image",
+            "migration_revision": "add_evaluation_authoritative_model",
+        },
+        "source": {"snapshot_id": "source-1", "snapshot_hash": "sha256:source"},
+        "semantic_model": {"version_id": "semver-1", "version_hash": "sha256:semantic"},
+        "prompt": {"version": "prompt-v1", "prompt_hash": "sha256:prompt"},
+        "tool_registry_hash": "sha256:tools",
+        "skill_registry_hash": "sha256:skills",
+        "llm": {"provider": "openai", "model": "gpt", "params_hash": "sha256:params"},
+        "principal": {"tenant_id": str(tenant_id), "actor_type": "agent", "actor_id": "mcp-agent", "scopes": []},
+        "dataset": {"snapshot_id": "dataset-1", "snapshot_hash": "sha256:dataset"},
+        "feature_flags": {"evaluation_governance": True},
+        "time_fixture": {"now": "2026-08-16T00:00:00Z", "timezone": "UTC"},
+    }
+
+
+async def test_evaluation_mcp_suite_case_and_run_contract(test_session: AsyncSession) -> None:
+    tenant, owner, suite, suite_version = await _seed_suite(test_session)
+
+    search_payload = json.loads(
+        await search_evaluation_suites_wrapper("MCP", "agent_answer", "draft", tenant.id, owner.id)
+    )
+    assert search_payload["success"] is True
+    assert search_payload["items"][0]["id"] == str(suite.id)
+
+    describe_payload = json.loads(await describe_evaluation_suite_wrapper(str(suite.id), tenant.id, owner.id, True))
+    assert describe_payload["success"] is True
+    assert describe_payload["suite"]["versions"][0]["manifest"]["suite_id"] == "mcp"
+
+    ground_truth_payload = json.loads(
+        await preview_evaluation_ground_truth_wrapper(json.dumps(_expected_contract()), tenant.id, owner.id)
+    )
+    assert ground_truth_payload["success"] is True
+    assert ground_truth_payload["ground_truth"]["readonly"] is True
+    assert "SELECT SUM" not in json.dumps(ground_truth_payload)
+
+    case_payload = json.loads(
+        await create_evaluation_case_draft_wrapper(
+            str(suite_version.id),
+            json.dumps(
+                {
+                    "case_key": "mcp-case-one",
+                    "title": "MCP case one",
+                    "target_kinds": ["agent_answer"],
+                    "operation": "answer_question",
+                    "question": "What revenue should exclude refunds?",
+                    "expected_contract": _expected_contract(),
+                    "provenance": {"source": "manual", "trace_id": "trace-123", "principal": {"token": "raw-token"}},
+                    "tags": ["mcp"],
+                }
+            ),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert case_payload["success"] is True
+    assert case_payload["created"] is True
+    assert "raw-token" not in json.dumps(case_payload)
+    assert "plain-password" not in json.dumps(case_payload)
+
+    list_payload = json.loads(
+        await list_evaluation_cases_wrapper(str(suite_version.id), tenant.id, owner.id, include_expected_contract=False)
+    )
+    assert list_payload["success"] is True
+    assert list_payload["items"][0]["has_ground_truth_sql"] is True
+    assert "expected_contract" not in list_payload["items"][0]
+
+    run_payload = json.loads(
+        await run_evaluation_wrapper(
+            str(suite_version.id),
+            json.dumps(_target_snapshot(tenant.id)),
+            "mcp-run-one",
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert run_payload["success"] is True
+    assert run_payload["run"]["status"] == "queued"
+
+    run_report = json.loads(await get_evaluation_run_wrapper(run_payload["run"]["id"], tenant.id, owner.id))
+    assert run_report["success"] is True
+    assert run_report["run"]["id"] == run_payload["run"]["id"]
+
+
+async def test_evaluation_mcp_feedback_advisor_and_failure_surfaces_are_redacted(test_session: AsyncSession) -> None:
+    tenant, owner, _suite, suite_version = await _seed_suite(test_session)
+    notebook = Notebook(tenant_id=tenant.id, created_by=owner.id, notebook_name="MCP feedback notebook")
+    test_session.add(notebook)
+    await test_session.flush()
+    legacy_feedback = ConversationEvaluation(
+        tenant_id=tenant.id,
+        notebook_id=notebook.id,
+        trigger="manual",
+        verdict="mistake",
+        findings={
+            "summary": "Wrong answer included refunds",
+            "correction": "exclude refunds",
+            "trace_id": "trace-123",
+            "token": "raw-token",
+            "sql": "select * from restricted_table",
+        },
+    )
+    test_session.add(legacy_feedback)
+    await test_session.flush()
+    skill = CustomSkill(
+        tenant_id=tenant.id,
+        created_by=owner.id,
+        name="Revenue skill",
+        description="Revenue rules",
+        instructions="Old instructions",
+        scope="org",
+    )
+    test_session.add(skill)
+    await test_session.flush()
+    suggestion = SkillSuggestion(
+        tenant_id=tenant.id,
+        skill_id=skill.id,
+        suggestion_type="edit",
+        title="Exclude refunds",
+        rationale="Refund rows caused a miss.",
+        confidence="high",
+        evidence={"token": "raw-token", "summary": "Need safer instructions"},
+        patch={"after": "password=plain-password"},
+        proposed_instructions="Always exclude refunds. token=raw-token",
+        source={"origin": "mcp"},
+        status="pending",
+    )
+    test_session.add(suggestion)
+    await test_session.commit()
+
+    feedback_payload = json.loads(
+        await submit_evaluation_feedback_wrapper(
+            str(suite_version.id),
+            json.dumps({"legacy_conversation_evaluation_id": str(legacy_feedback.id), "tags": ["feedback"]}),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert feedback_payload["success"] is True
+    assert feedback_payload["case"]["provenance"]["source"] == "legacy_conversation_evaluation"
+    assert "raw-token" not in json.dumps(feedback_payload)
+    assert "restricted_table" not in json.dumps(feedback_payload)
+
+    affected_case_id = feedback_payload["case"]["id"]
+    advisor_payload = json.loads(
+        await create_advisor_change_set_wrapper(
+            str(suggestion.id),
+            str(suite_version.id),
+            [affected_case_id],
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert advisor_payload["success"] is True
+    assert advisor_payload["change_set"]["status"] == "draft"
+    assert advisor_payload["advisor_suggestions"][0]["affected_case_ids"] == [affected_case_id]
+    assert "raw-token" not in json.dumps(advisor_payload)
+    assert "plain-password" not in json.dumps(advisor_payload)
+
+    verification_payload = json.loads(
+        await run_advisor_gate_wrapper(
+            advisor_payload["change_set"]["id"],
+            json.dumps(_target_snapshot(tenant.id)),
+            "verification",
+            "mcp-advisor-verification",
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert verification_payload["success"] is True
+    assert verification_payload["change_set"]["verification_run_id"] == verification_payload["run"]["id"]
+
+    snapshot = EvaluationTargetSnapshot(
+        tenant_id=tenant.id,
+        target_kind="agent_answer",
+        target_ref="agent:failed",
+        contract_version="evaluation.target_snapshot.v1",
+        snapshot_json={"target_ref": "agent:failed"},
+        pin_digest="sha256:failed",
+        blockers_json=[],
+    )
+    test_session.add(snapshot)
+    await test_session.flush()
+    failed_run = EvaluationRun(
+        tenant_id=tenant.id,
+        suite_version_id=suite_version.id,
+        target_snapshot_id=snapshot.id,
+        status="failed",
+        actor_type="agent",
+        actor_id="mcp-agent",
+        preflight_blockers_json=[],
+        summary_json={"gate_decision": "failed", "token": "raw-token"},
+    )
+    test_session.add(failed_run)
+    await test_session.flush()
+    case = await test_session.get(EvaluationCase, UUID(affected_case_id))
+    assert case is not None
+    case_run = EvaluationCaseRun(
+        tenant_id=tenant.id,
+        run_id=failed_run.id,
+        case_id=case.id,
+        status="failed",
+        attempt=1,
+        input_digest="sha256:input",
+        output_digest="sha256:output",
+        result_json={"answer": "bad answer"},
+        error_json={"sql": "select * from secret_table"},
+        immutable=True,
+    )
+    test_session.add(case_run)
+    await test_session.flush()
+    test_session.add(
+        EvaluationAssessment(
+            tenant_id=tenant.id,
+            case_run_id=case_run.id,
+            category="security",
+            status="failed",
+            score="0",
+            hard_fail=True,
+            details_json={"token": "raw-token", "reason": "leaked SQL"},
+            immutable=True,
+        )
+    )
+    await test_session.commit()
+
+    failure_payload = json.loads(await describe_evaluation_failure_wrapper(str(failed_run.id), tenant.id, owner.id))
+    assert failure_payload["success"] is True
+    assert failure_payload["failures"][0]["status"] == "failed"
+    serialized = json.dumps(failure_payload)
+    assert "raw-token" not in serialized
+    assert "secret_table" not in serialized

--- a/server/tests/test_evaluation_persistence_migration.py
+++ b/server/tests/test_evaluation_persistence_migration.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Column, ForeignKey, MetaData, String, Table, create_engine, inspect
+
+from server.db.base import Base
+from server.migrations.versions import add_evaluation_authoritative_model
+from server.models.evaluation import (
+    AdvisorChangeSet,
+    AdvisorSuggestion,
+    EvaluationArtifact,
+    EvaluationAssessment,
+    EvaluationAuditEvent,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationOverride,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    EvaluationTargetSnapshot,
+    PromotionDecision,
+)
+
+
+def _create_minimal_legacy_schema(engine) -> None:
+    metadata = MetaData()
+    Table("users", metadata, Column("id", String(36), primary_key=True))
+    Table(
+        "tenants",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("owner_id", String(36), ForeignKey("users.id"), nullable=False),
+    )
+    Table(
+        "notebooks",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("tenant_id", String(36), ForeignKey("tenants.id"), nullable=False),
+    )
+    Table(
+        "conversation_evaluations",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("tenant_id", String(36), ForeignKey("tenants.id"), nullable=False),
+        Column("notebook_id", String(36), ForeignKey("notebooks.id"), nullable=False),
+    )
+    Table(
+        "skill_suggestions",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("tenant_id", String(36), ForeignKey("tenants.id"), nullable=False),
+    )
+    metadata.create_all(engine)
+
+
+def test_evaluation_persistence_models_are_registered() -> None:
+    for model in (
+        EvaluationSuite,
+        EvaluationSuiteVersion,
+        EvaluationCase,
+        EvaluationTargetSnapshot,
+        EvaluationRun,
+        EvaluationCaseRun,
+        EvaluationAssessment,
+        EvaluationOverride,
+        EvaluationArtifact,
+        AdvisorChangeSet,
+        AdvisorSuggestion,
+        PromotionDecision,
+        EvaluationAuditEvent,
+    ):
+        assert model.__tablename__ in Base.metadata.tables
+
+
+def test_evaluation_authoritative_model_migration_upgrade_and_downgrade_sqlite() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    _create_minimal_legacy_schema(engine)
+
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        operations = Operations(context)
+        original_op = add_evaluation_authoritative_model.op
+        add_evaluation_authoritative_model.op = operations
+        try:
+            add_evaluation_authoritative_model.upgrade()
+            inspector = inspect(connection)
+            table_names = set(inspector.get_table_names())
+            assert {
+                "evaluation_suites",
+                "evaluation_suite_versions",
+                "evaluation_cases",
+                "evaluation_target_snapshots",
+                "evaluation_runs",
+                "evaluation_case_runs",
+                "evaluation_assessments",
+                "evaluation_overrides",
+                "evaluation_artifacts",
+                "advisor_change_sets",
+                "advisor_suggestions",
+                "promotion_decisions",
+                "evaluation_audit_events",
+            }.issubset(table_names)
+            assert "conversation_evaluations" in table_names
+            assert "skill_suggestions" in table_names
+
+            run_columns = {column["name"] for column in inspector.get_columns("evaluation_runs")}
+            assert {"status", "preflight_blockers_json", "target_snapshot_id", "idempotency_key"}.issubset(run_columns)
+
+            add_evaluation_authoritative_model.downgrade()
+            table_names = set(inspect(connection).get_table_names())
+            assert "evaluation_suites" not in table_names
+            assert "conversation_evaluations" in table_names
+            assert "skill_suggestions" in table_names
+        finally:
+            add_evaluation_authoritative_model.op = original_op

--- a/server/tests/test_evaluation_rest_api.py
+++ b/server/tests/test_evaluation_rest_api.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.evaluation import (
+    AdvisorChangeSet,
+    EvaluationArtifact,
+    EvaluationAssessment,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    EvaluationTargetSnapshot,
+)
+from server.models.tenant import Tenant
+from server.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_suite_version(test_session: AsyncSession) -> tuple[Tenant, User, EvaluationSuiteVersion]:
+    tenant = (await test_session.execute(select(Tenant))).scalars().first()
+    assert tenant is not None
+    owner = await test_session.get(User, tenant.owner_id)
+    assert owner is not None
+    suite = EvaluationSuite(
+        tenant_id=tenant.id,
+        slug=f"rest-eval-suite-{uuid4()}",
+        name="REST Evaluation suite",
+        description="Evaluation suite exposed through REST",
+        owner_id=owner.id,
+        target_kinds_json=["semantic_model"],
+        lifecycle="published",
+    )
+    test_session.add(suite)
+    await test_session.flush()
+    version = EvaluationSuiteVersion(
+        tenant_id=tenant.id,
+        suite_id=suite.id,
+        version_num=1,
+        status="published",
+        contract_version="evaluation.suite_version.v1",
+        manifest_json={"contract_version": "evaluation.suite_version.v1", "suite_id": "rest", "version": 1},
+        gate_policy_json={"version": "gate-policy.v1", "security_hard_fail": True, "min_overall_pass_rate": 1.0},
+        case_count=2,
+        content_hash="sha256:rest-suite",
+        created_by=owner.id,
+    )
+    test_session.add(version)
+    await test_session.flush()
+    test_session.add_all(
+        [
+            EvaluationCase(
+                tenant_id=tenant.id,
+                suite_version_id=version.id,
+                case_key="case-one",
+                title="Case one",
+                target_kinds_json=["semantic_model"],
+                operation="answer_question",
+                question="What is revenue?",
+                expected_contract_json={"policy": {"security_hard_fail": True}},
+                provenance_json={"source": "manual"},
+                tags_json=["rest"],
+                content_hash="sha256:case-one",
+                immutable=True,
+            ),
+            EvaluationCase(
+                tenant_id=tenant.id,
+                suite_version_id=version.id,
+                case_key="case-two",
+                title="Case two",
+                target_kinds_json=["semantic_model"],
+                operation="answer_question",
+                question="What is margin?",
+                expected_contract_json={"policy": {"security_hard_fail": True}},
+                provenance_json={"source": "manual"},
+                tags_json=["rest"],
+                content_hash="sha256:case-two",
+                immutable=True,
+            ),
+        ]
+    )
+    await test_session.commit()
+    return tenant, owner, version
+
+
+def _complete_snapshot(tenant_id: str) -> dict:
+    return {
+        "contract_version": "evaluation.target_snapshot.v1",
+        "target_kind": "semantic_model",
+        "target_ref": "semantic_model:sales",
+        "app": {
+            "git_sha": "abc123",
+            "image_digest": "sha256:image",
+            "migration_revision": "add_evaluation_authoritative_model",
+        },
+        "source": {"snapshot_id": "source-1", "snapshot_hash": "sha256:source"},
+        "semantic_model": {"version_id": "semver-1", "version_hash": "sha256:semantic"},
+        "principal": {"tenant_id": tenant_id, "actor_type": "agent", "actor_id": "agent-1", "scopes": []},
+        "dataset": {"snapshot_id": "dataset-1", "snapshot_hash": "sha256:dataset"},
+        "feature_flags": {"evaluation_governance": True},
+        "time_fixture": {"now": "2026-08-16T00:00:00Z", "timezone": "UTC"},
+    }
+
+
+def _import_case_payload(case_key: str = "imported-case-one") -> dict:
+    return {
+        "case_key": case_key,
+        "title": "Imported case one",
+        "target_kinds": ["semantic_model"],
+        "operation": "answer_question",
+        "question": "What is governed revenue?",
+        "expected_contract": {
+            "answer": {"must_include_all": ["revenue"]},
+            "policy": {"security_hard_fail": True},
+        },
+        "provenance": {"source": "import", "principal": {"source": "rest-test"}},
+        "tags": ["imported", "release-gate"],
+    }
+
+
+async def _seed_completed_run(
+    test_session: AsyncSession,
+    *,
+    tenant_id,
+    suite_version_id,
+    gate_decision: str,
+) -> EvaluationRun:
+    snapshot = EvaluationTargetSnapshot(
+        tenant_id=tenant_id,
+        target_kind="semantic_model",
+        target_ref=f"semantic_model:{gate_decision}",
+        contract_version="evaluation.target_snapshot.v1",
+        snapshot_json={"target_ref": f"semantic_model:{gate_decision}"},
+        pin_digest=f"sha256:{gate_decision}",
+        blockers_json=[],
+    )
+    test_session.add(snapshot)
+    await test_session.flush()
+    run = EvaluationRun(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_snapshot_id=snapshot.id,
+        status="passed" if gate_decision == "passed" else "failed",
+        actor_type="agent",
+        actor_id="agent-1",
+        preflight_blockers_json=[],
+        summary_json={"gate_decision": gate_decision},
+    )
+    test_session.add(run)
+    await test_session.flush()
+    return run
+
+
+async def _seed_case_result(
+    test_session: AsyncSession,
+    *,
+    tenant_id,
+    run_id,
+    case_id,
+    status: str,
+    hard_fail: bool = False,
+) -> EvaluationCaseRun:
+    case_run = EvaluationCaseRun(
+        tenant_id=tenant_id,
+        run_id=run_id,
+        case_id=case_id,
+        status=status,
+        attempt=1,
+        input_digest=f"sha256:input-{status}",
+        output_digest=f"sha256:output-{status}",
+        result_json={"answer": status, "token": "super-secret-token"},
+        error_json={"sql": "select * from restricted_table"} if status != "passed" else {},
+        immutable=True,
+    )
+    test_session.add(case_run)
+    await test_session.flush()
+    test_session.add(
+        EvaluationAssessment(
+            tenant_id=tenant_id,
+            case_run_id=case_run.id,
+            category="security" if hard_fail else "answer",
+            status=status,
+            score="0.0" if status != "passed" else "1.0",
+            hard_fail=hard_fail,
+            details_json={"reason": "contains token=super-secret-token"},
+            immutable=True,
+        )
+    )
+    await test_session.flush()
+    return case_run
+
+
+async def test_evaluation_rest_read_surfaces_and_compare(test_client, test_session: AsyncSession) -> None:
+    tenant, _owner, suite_version = await _seed_suite_version(test_session)
+    suite = await test_session.get(EvaluationSuite, suite_version.suite_id)
+    assert suite is not None
+    cases = (
+        await test_session.execute(
+            select(EvaluationCase)
+            .where(EvaluationCase.suite_version_id == suite_version.id)
+            .order_by(EvaluationCase.case_key)
+        )
+    ).scalars().all()
+    baseline_run = await _seed_completed_run(
+        test_session,
+        tenant_id=tenant.id,
+        suite_version_id=suite_version.id,
+        gate_decision="passed",
+    )
+    candidate_run = await _seed_completed_run(
+        test_session,
+        tenant_id=tenant.id,
+        suite_version_id=suite_version.id,
+        gate_decision="failed",
+    )
+    await _seed_case_result(test_session, tenant_id=tenant.id, run_id=baseline_run.id, case_id=cases[0].id, status="passed")
+    await _seed_case_result(
+        test_session,
+        tenant_id=tenant.id,
+        run_id=candidate_run.id,
+        case_id=cases[0].id,
+        status="failed",
+        hard_fail=True,
+    )
+    await test_session.commit()
+
+    suites_response = await test_client.get("/api/evaluation/suites?query=REST&target_kind=semantic_model")
+    assert suites_response.status_code == 200
+    suites_payload = suites_response.json()["data"]
+    assert suites_payload["total"] == 1
+    assert suites_payload["items"][0]["id"] == str(suite.id)
+
+    suite_response = await test_client.get(f"/api/evaluation/suites/{suite.id}?include_manifests=true")
+    assert suite_response.status_code == 200
+    assert suite_response.json()["data"]["suite"]["versions"][0]["manifest"]["suite_id"] == "rest"
+
+    run_response = await test_client.get(f"/api/evaluation/runs/{candidate_run.id}")
+    assert run_response.status_code == 200
+    run_payload = run_response.json()["data"]
+    assert run_payload["run"]["id"] == str(candidate_run.id)
+    assert run_payload["case_runs"][0]["assessments"][0]["hard_fail"] is True
+    assert "super-secret-token" not in json.dumps(run_payload)
+    assert "restricted_table" not in json.dumps(run_payload)
+
+    failures_response = await test_client.get(f"/api/evaluation/runs/{candidate_run.id}/failures")
+    assert failures_response.status_code == 200
+    assert failures_response.json()["data"]["total"] == 1
+
+    compare_response = await test_client.get(
+        f"/api/evaluation/runs/compare?baseline_run_id={baseline_run.id}&candidate_run_id={candidate_run.id}"
+    )
+    assert compare_response.status_code == 200
+    comparison = compare_response.json()["data"]["comparison"]
+    assert comparison["summary"]["regression_count"] == 1
+    assert comparison["regressions"][0]["case_id"] == str(cases[0].id)
+
+
+async def test_evaluation_rest_create_import_publish_and_run_closed_loop(test_client, test_session: AsyncSession) -> None:
+    tenant = (await test_session.execute(select(Tenant))).scalars().first()
+    assert tenant is not None
+
+    create_response = await test_client.post(
+        "/api/evaluation/suites",
+        json={
+            "slug": f"commercial-loop-{uuid4().hex[:8]}",
+            "name": "Commercial Evaluation Loop",
+            "description": "Explicit non-production acceptance fixture",
+            "target_kinds": ["semantic_model"],
+            "gate_policy": {"security_hard_fail": True, "min_overall_pass_rate": 1.0},
+        },
+    )
+    assert create_response.status_code == 201
+    suite = create_response.json()["data"]["suite"]
+    draft_version_id = suite["versions"][0]["id"]
+
+    import_response = await test_client.post(
+        f"/api/evaluation/suite-versions/{draft_version_id}/cases/import",
+        json={"format": "json", "cases": [_import_case_payload("case-one"), _import_case_payload("case-two")]},
+    )
+    assert import_response.status_code == 201
+    assert import_response.json()["data"]["created_count"] == 2
+
+    publish_response = await test_client.post(f"/api/evaluation/suite-versions/{draft_version_id}/publish")
+    assert publish_response.status_code == 200
+    assert publish_response.json()["data"]["version"]["status"] == "published"
+
+    import_after_publish = await test_client.post(
+        f"/api/evaluation/suite-versions/{draft_version_id}/cases",
+        json=_import_case_payload("case-after-publish"),
+    )
+    assert import_after_publish.status_code == 409
+
+    preflight_response = await test_client.post(
+        "/api/evaluation/runs/preflight",
+        json={
+            "suite_version_id": draft_version_id,
+            "target_snapshot": _complete_snapshot(str(tenant.id)),
+            "idempotency_key": "commercial-loop",
+            "actor_type": "agent",
+            "actor_id": "agent-release-gate",
+        },
+    )
+    assert preflight_response.status_code == 202
+    run_id = preflight_response.json()["data"]["id"]
+
+    claim_response = await test_client.post(
+        "/api/evaluation/runs/claim",
+        json={"worker_id": "commercial-loop-worker", "lease_seconds": 60},
+    )
+    assert claim_response.status_code == 200
+    assert claim_response.json()["data"]["id"] == run_id
+
+    artifact_response = await test_client.post(
+        f"/api/evaluation/runs/{run_id}/artifacts",
+        json={"artifact_type": "runner.log", "uri": "memory://runner-log", "content": {"token": "super-secret-token"}},
+    )
+    assert artifact_response.status_code == 201
+    assert "super-secret-token" not in json.dumps(artifact_response.json())
+
+    complete_response = await test_client.post(
+        f"/api/evaluation/runs/{run_id}/complete",
+        json={
+            "worker_id": "commercial-loop-worker",
+            "case_results": [
+                {
+                    "case_key": "case-one",
+                    "status": "passed",
+                    "assessments": [{"category": "answer", "status": "passed", "score": "1.0", "hard_fail": False}],
+                    "result": {"answer": "revenue is governed"},
+                },
+                {
+                    "case_key": "case-two",
+                    "status": "failed",
+                    "assessments": [{"category": "answer", "status": "failed", "score": "0", "hard_fail": True}],
+                    "result": {"answer": "incorrect"},
+                    "error": {"token": "super-secret-token", "sql": "select * from private_table"},
+                },
+            ],
+        },
+    )
+    assert complete_response.status_code == 200
+    completed = complete_response.json()["data"]
+    assert completed["status"] == "failed"
+    assert completed["summary"]["gate_decision"] == "failed"
+
+    saved_artifacts = (
+        await test_session.execute(select(EvaluationArtifact).where(EvaluationArtifact.run_id == run_id))
+    ).scalars().all()
+    assert len(saved_artifacts) == 1
+    assert "private_table" not in json.dumps((await test_client.get(f"/api/evaluation/runs/{run_id}/failures")).json())
+
+
+async def test_evaluation_advisor_review_gate_and_apply(test_client, test_session: AsyncSession) -> None:
+    tenant, _owner, suite_version = await _seed_suite_version(test_session)
+    verification_run = await _seed_completed_run(
+        test_session,
+        tenant_id=tenant.id,
+        suite_version_id=suite_version.id,
+        gate_decision="passed",
+    )
+    regression_run = await _seed_completed_run(
+        test_session,
+        tenant_id=tenant.id,
+        suite_version_id=suite_version.id,
+        gate_decision="failed",
+    )
+    change_set = AdvisorChangeSet(
+        tenant_id=tenant.id,
+        suite_version_id=suite_version.id,
+        target_ref="semantic_model:sales",
+        base_version_ref="semantic_model:sales:v1",
+        base_etag="sha256:base",
+        status="draft",
+        evidence_json={"token": "super-secret-token", "summary": "Review this staged patch"},
+        verification_run_id=verification_run.id,
+        regression_run_id=regression_run.id,
+        created_by="advisor-1",
+    )
+    test_session.add(change_set)
+    await test_session.commit()
+    change_set_id = change_set.id
+
+    review_response = await test_client.get(f"/api/evaluation/advisor-change-sets/{change_set_id}/review")
+    assert review_response.status_code == 200
+    review = review_response.json()["data"]
+    assert review["gate_summary"]["ready_to_apply"] is False
+    assert "super-secret-token" not in json.dumps(review)
+
+    verify_response = await test_client.post(
+        f"/api/evaluation/advisor-change-sets/{change_set_id}/verification",
+        json={"target_snapshot": _complete_snapshot(str(tenant.id)), "idempotency_key": "advisor-rest-verify"},
+    )
+    assert verify_response.status_code == 202
+
+    test_session.expire_all()
+    latest_change_set = await test_session.get(AdvisorChangeSet, change_set_id)
+    assert latest_change_set is not None
+    queued_gate = await test_session.get(EvaluationRun, latest_change_set.verification_run_id)
+    assert queued_gate is not None
+    queued_gate.status = "passed"
+    queued_gate.summary_json = {"gate_decision": "passed"}
+    latest_change_set.regression_run_id = queued_gate.id
+    await test_session.commit()
+
+    apply_response = await test_client.post(f"/api/evaluation/advisor-change-sets/{change_set_id}/apply")
+    assert apply_response.status_code == 200
+    assert apply_response.json()["data"]["promotion"]["decision"] == "accepted"

--- a/server/tests/test_evaluation_rest_api.py
+++ b/server/tests/test_evaluation_rest_api.py
@@ -202,12 +202,16 @@ async def test_evaluation_rest_read_surfaces_and_compare(test_client, test_sessi
     suite = await test_session.get(EvaluationSuite, suite_version.suite_id)
     assert suite is not None
     cases = (
-        await test_session.execute(
-            select(EvaluationCase)
-            .where(EvaluationCase.suite_version_id == suite_version.id)
-            .order_by(EvaluationCase.case_key)
+        (
+            await test_session.execute(
+                select(EvaluationCase)
+                .where(EvaluationCase.suite_version_id == suite_version.id)
+                .order_by(EvaluationCase.case_key)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     baseline_run = await _seed_completed_run(
         test_session,
         tenant_id=tenant.id,
@@ -220,7 +224,9 @@ async def test_evaluation_rest_read_surfaces_and_compare(test_client, test_sessi
         suite_version_id=suite_version.id,
         gate_decision="failed",
     )
-    await _seed_case_result(test_session, tenant_id=tenant.id, run_id=baseline_run.id, case_id=cases[0].id, status="passed")
+    await _seed_case_result(
+        test_session, tenant_id=tenant.id, run_id=baseline_run.id, case_id=cases[0].id, status="passed"
+    )
     await _seed_case_result(
         test_session,
         tenant_id=tenant.id,
@@ -262,7 +268,9 @@ async def test_evaluation_rest_read_surfaces_and_compare(test_client, test_sessi
     assert comparison["regressions"][0]["case_id"] == str(cases[0].id)
 
 
-async def test_evaluation_rest_create_import_publish_and_run_closed_loop(test_client, test_session: AsyncSession) -> None:
+async def test_evaluation_rest_create_import_publish_and_run_closed_loop(
+    test_client, test_session: AsyncSession
+) -> None:
     tenant = (await test_session.execute(select(Tenant))).scalars().first()
     assert tenant is not None
 
@@ -351,8 +359,10 @@ async def test_evaluation_rest_create_import_publish_and_run_closed_loop(test_cl
     assert completed["summary"]["gate_decision"] == "failed"
 
     saved_artifacts = (
-        await test_session.execute(select(EvaluationArtifact).where(EvaluationArtifact.run_id == run_id))
-    ).scalars().all()
+        (await test_session.execute(select(EvaluationArtifact).where(EvaluationArtifact.run_id == run_id)))
+        .scalars()
+        .all()
+    )
     assert len(saved_artifacts) == 1
     assert "private_table" not in json.dumps((await test_client.get(f"/api/evaluation/runs/{run_id}/failures")).json())
 

--- a/server/tests/test_evaluation_service.py
+++ b/server/tests/test_evaluation_service.py
@@ -158,7 +158,9 @@ async def test_evaluation_preflight_blocks_missing_required_target_pins(test_ses
     assert "semantic_model.version_hash" in run.preflight_blockers_json
     audit_actions = (
         await test_session.execute(
-            select(EvaluationAuditEvent.action, EvaluationAuditEvent.outcome).where(EvaluationAuditEvent.run_id == run.id)
+            select(EvaluationAuditEvent.action, EvaluationAuditEvent.outcome).where(
+                EvaluationAuditEvent.run_id == run.id
+            )
         )
     ).all()
     assert audit_actions == [("evaluation.run.preflight", "blocked")]
@@ -208,16 +210,24 @@ async def test_runner_claims_run_persists_results_and_hard_fail_gate(test_sessio
     assert completed.summary_json["hard_failures"] == 1
     assert completed.summary_json["gate_decision"] == "failed"
     case_runs = (
-        await test_session.execute(select(EvaluationCaseRun).where(EvaluationCaseRun.run_id == run.id))
-    ).scalars().all()
+        (await test_session.execute(select(EvaluationCaseRun).where(EvaluationCaseRun.run_id == run.id)))
+        .scalars()
+        .all()
+    )
     assert {case_run.status for case_run in case_runs} == {"passed", "failed"}
     assert all(case_run.immutable for case_run in case_runs)
     serialized = str([case_run.result_json | case_run.error_json for case_run in case_runs])
     assert "raw-token" not in serialized
     assert "private_table" not in serialized
     assessments = (
-        await test_session.execute(select(EvaluationAssessment).join(EvaluationCaseRun).where(EvaluationCaseRun.run_id == run.id))
-    ).scalars().all()
+        (
+            await test_session.execute(
+                select(EvaluationAssessment).join(EvaluationCaseRun).where(EvaluationCaseRun.run_id == run.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert any(assessment.category == "security" and assessment.hard_fail for assessment in assessments)
 
 
@@ -246,7 +256,9 @@ async def test_preflight_idempotency_reclaim_stop_artifact_and_promotion(test_se
     reclaimed = await service.claim_next_run(tenant_id=tenant_id, worker_id="worker-b", lease_seconds=60)
     assert reclaimed is not None and reclaimed.attempt == 2
     await service.request_run_stop(tenant_id=tenant_id, run_id=str(first.id), actor_id="owner")
-    stopped = await service.heartbeat_run(tenant_id=tenant_id, run_id=str(first.id), worker_id="worker-b", lease_seconds=60)
+    stopped = await service.heartbeat_run(
+        tenant_id=tenant_id, run_id=str(first.id), worker_id="worker-b", lease_seconds=60
+    )
     assert stopped.status == "canceled"
 
     artifact = await service.record_run_artifact(
@@ -301,6 +313,8 @@ async def test_preflight_idempotency_reclaim_stop_artifact_and_promotion(test_se
     accepted = await service.decide_promotion(tenant_id=tenant_id, change_set_id=str(change_set.id), actor_id="owner")
     assert accepted.decision == "accepted"
     decisions = (
-        await test_session.execute(select(PromotionDecision).where(PromotionDecision.change_set_id == change_set.id))
-    ).scalars().all()
+        (await test_session.execute(select(PromotionDecision).where(PromotionDecision.change_set_id == change_set.id)))
+        .scalars()
+        .all()
+    )
     assert {decision.decision for decision in decisions} == {"rejected", "accepted"}

--- a/server/tests/test_evaluation_service.py
+++ b/server/tests/test_evaluation_service.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.evaluation import (
+    AdvisorChangeSet,
+    EvaluationArtifact,
+    EvaluationAssessment,
+    EvaluationAuditEvent,
+    EvaluationCase,
+    EvaluationCaseRun,
+    EvaluationRun,
+    EvaluationSuite,
+    EvaluationSuiteVersion,
+    PromotionDecision,
+)
+from server.models.tenant import Tenant
+from server.models.user import User
+from server.repositories.evaluation import _has_no_preflight_blockers
+from server.services.evaluation import EvaluationService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_published_suite_version_with_cases(test_session: AsyncSession) -> tuple[str, str]:
+    owner = User(
+        id=uuid4(),
+        email=f"evaluation-runner-owner-{uuid4()}@example.test",
+        hashed_password="fakehash",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    test_session.add(owner)
+    await test_session.flush()
+    tenant = Tenant(
+        id=uuid4(),
+        name="Evaluation Runner Tenant",
+        slug=f"evaluation-runner-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+        is_personal=True,
+    )
+    test_session.add(tenant)
+    await test_session.flush()
+    suite = EvaluationSuite(
+        tenant_id=tenant.id,
+        slug=f"eval-runner-suite-{uuid4()}",
+        name="Runner suite",
+        description="Evaluation runner smoke suite",
+        owner_id=owner.id,
+        lifecycle="published",
+    )
+    test_session.add(suite)
+    await test_session.flush()
+    version = EvaluationSuiteVersion(
+        tenant_id=tenant.id,
+        suite_id=suite.id,
+        version_num=1,
+        status="published",
+        contract_version="evaluation.suite_version.v1",
+        manifest_json={"contract_version": "evaluation.suite_version.v1", "suite_id": "runner", "version": 1},
+        gate_policy_json={"version": "gate-policy.v1", "security_hard_fail": True, "min_overall_pass_rate": 1.0},
+        case_count=2,
+        content_hash="sha256:published",
+        created_by=owner.id,
+    )
+    test_session.add(version)
+    await test_session.flush()
+    test_session.add_all(
+        [
+            EvaluationCase(
+                tenant_id=tenant.id,
+                suite_version_id=version.id,
+                case_key="case-pass",
+                title="Passing case",
+                target_kinds_json=["semantic_model"],
+                operation="answer_question",
+                question="What is revenue?",
+                expected_contract_json={"policy": {"security_hard_fail": True}},
+                provenance_json={"source": "manual"},
+                tags_json=["runner"],
+                content_hash="sha256:case-pass",
+                immutable=True,
+            ),
+            EvaluationCase(
+                tenant_id=tenant.id,
+                suite_version_id=version.id,
+                case_key="case-security-fail",
+                title="Security failure case",
+                target_kinds_json=["semantic_model"],
+                operation="answer_question",
+                question="Read restricted text",
+                expected_contract_json={"policy": {"security_hard_fail": True}},
+                provenance_json={"source": "manual"},
+                tags_json=["runner"],
+                content_hash="sha256:case-fail",
+                immutable=True,
+            ),
+        ]
+    )
+    await test_session.commit()
+    return str(tenant.id), str(version.id)
+
+
+def _complete_snapshot() -> dict:
+    return {
+        "contract_version": "evaluation.target_snapshot.v1",
+        "target_kind": "semantic_model",
+        "target_ref": "semantic_model:sales",
+        "app": {
+            "git_sha": "abc123",
+            "image_digest": "sha256:image",
+            "migration_revision": "add_evaluation_authoritative_model",
+        },
+        "source": {"snapshot_id": "source-1", "snapshot_hash": "sha256:source"},
+        "semantic_model": {"version_id": "semver-1", "version_hash": "sha256:semantic"},
+        "principal": {"tenant_id": "tenant-1", "actor_type": "agent", "actor_id": "agent-1", "scopes": []},
+        "dataset": {"snapshot_id": "dataset-1", "snapshot_hash": "sha256:dataset"},
+        "feature_flags": {"evaluation_governance": True},
+        "time_fixture": {"now": "2026-08-16T00:00:00Z", "timezone": "UTC"},
+    }
+
+
+def test_claimable_run_filter_compiles_for_postgres_json_columns() -> None:
+    from sqlalchemy.dialects import postgresql
+
+    compiled = str(select(EvaluationRun).where(_has_no_preflight_blockers()).compile(dialect=postgresql.dialect()))
+
+    assert "json_array_length" in compiled
+    assert "preflight_blockers_json =" not in compiled
+
+
+async def test_evaluation_preflight_blocks_missing_required_target_pins(test_session: AsyncSession) -> None:
+    tenant_id, suite_version_id = await _seed_published_suite_version_with_cases(test_session)
+
+    run = await EvaluationService(test_session).create_preflight_run(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_snapshot_payload={
+            "contract_version": "evaluation.target_snapshot.v1",
+            "target_kind": "semantic_model",
+            "target_ref": "semantic_model:sales",
+            "app": {"git_sha": "abc123"},
+            "principal": {"tenant_id": "tenant-1", "actor_type": "human", "actor_id": "user-1", "scopes": []},
+            "feature_flags": {},
+            "time_fixture": {"timezone": "UTC"},
+        },
+        actor_id="agent-1",
+        idempotency_key="preflight-missing-pins",
+    )
+
+    assert run.status == "blocked"
+    assert "source.snapshot_hash" in run.preflight_blockers_json
+    assert "semantic_model.version_hash" in run.preflight_blockers_json
+    audit_actions = (
+        await test_session.execute(
+            select(EvaluationAuditEvent.action, EvaluationAuditEvent.outcome).where(EvaluationAuditEvent.run_id == run.id)
+        )
+    ).all()
+    assert audit_actions == [("evaluation.run.preflight", "blocked")]
+
+
+async def test_runner_claims_run_persists_results_and_hard_fail_gate(test_session: AsyncSession) -> None:
+    tenant_id, suite_version_id = await _seed_published_suite_version_with_cases(test_session)
+    service = EvaluationService(test_session)
+    run = await service.create_preflight_run(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_snapshot_payload=_complete_snapshot(),
+        actor_id="agent-1",
+        idempotency_key="runner-hard-fail",
+    )
+
+    claimed = await service.claim_next_run(tenant_id=tenant_id, worker_id="worker-a", lease_seconds=60)
+    assert claimed is not None and claimed.id == run.id
+    assert await service.claim_next_run(tenant_id=tenant_id, worker_id="worker-b", lease_seconds=60) is None
+
+    completed = await service.complete_run_with_case_results(
+        tenant_id=tenant_id,
+        run_id=str(run.id),
+        worker_id="worker-a",
+        case_results=[
+            {
+                "case_key": "case-pass",
+                "status": "passed",
+                "assessments": [
+                    {"category": "answer", "status": "passed", "score": "1.0", "hard_fail": False},
+                ],
+                "result": {"answer": "Revenue is 10"},
+            },
+            {
+                "case_key": "case-security-fail",
+                "status": "failed",
+                "assessments": [
+                    {"category": "security", "status": "failed", "score": "0.0", "hard_fail": True},
+                ],
+                "result": {"answer": "restricted free text count", "token": "raw-token"},
+                "error": {"sql": "select * from private_table"},
+            },
+        ],
+    )
+
+    assert completed.status == "failed"
+    assert completed.summary_json["hard_failures"] == 1
+    assert completed.summary_json["gate_decision"] == "failed"
+    case_runs = (
+        await test_session.execute(select(EvaluationCaseRun).where(EvaluationCaseRun.run_id == run.id))
+    ).scalars().all()
+    assert {case_run.status for case_run in case_runs} == {"passed", "failed"}
+    assert all(case_run.immutable for case_run in case_runs)
+    serialized = str([case_run.result_json | case_run.error_json for case_run in case_runs])
+    assert "raw-token" not in serialized
+    assert "private_table" not in serialized
+    assessments = (
+        await test_session.execute(select(EvaluationAssessment).join(EvaluationCaseRun).where(EvaluationCaseRun.run_id == run.id))
+    ).scalars().all()
+    assert any(assessment.category == "security" and assessment.hard_fail for assessment in assessments)
+
+
+async def test_preflight_idempotency_reclaim_stop_artifact_and_promotion(test_session: AsyncSession) -> None:
+    tenant_id, suite_version_id = await _seed_published_suite_version_with_cases(test_session)
+    service = EvaluationService(test_session)
+
+    first = await service.create_preflight_run(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_snapshot_payload=_complete_snapshot(),
+        actor_id="agent-1",
+        idempotency_key="same-key",
+    )
+    second = await service.create_preflight_run(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_snapshot_payload=_complete_snapshot(),
+        actor_id="agent-1",
+        idempotency_key="same-key",
+    )
+    assert second.id == first.id
+
+    first_claim = await service.claim_next_run(tenant_id=tenant_id, worker_id="worker-a", lease_seconds=-1)
+    assert first_claim is not None and first_claim.lease_holder == "worker-a"
+    reclaimed = await service.claim_next_run(tenant_id=tenant_id, worker_id="worker-b", lease_seconds=60)
+    assert reclaimed is not None and reclaimed.attempt == 2
+    await service.request_run_stop(tenant_id=tenant_id, run_id=str(first.id), actor_id="owner")
+    stopped = await service.heartbeat_run(tenant_id=tenant_id, run_id=str(first.id), worker_id="worker-b", lease_seconds=60)
+    assert stopped.status == "canceled"
+
+    artifact = await service.record_run_artifact(
+        tenant_id=tenant_id,
+        run_id=str(first.id),
+        artifact_type="runner.log",
+        uri="memory://runner-log",
+        content={"events": ["claimed", "stopped"]},
+    )
+    assert artifact.immutable is True
+    assert (await test_session.get(EvaluationArtifact, artifact.id)).content_hash.startswith("sha256:")
+
+    verification_run = await service.create_preflight_run(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_snapshot_payload=_complete_snapshot(),
+        actor_id="agent-1",
+        idempotency_key=f"verification-{uuid4()}",
+    )
+    regression_run = await service.create_preflight_run(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_snapshot_payload=_complete_snapshot(),
+        actor_id="agent-1",
+        idempotency_key=f"regression-{uuid4()}",
+    )
+    verification_run.status = "passed"
+    verification_run.summary_json = {"gate_decision": "passed"}
+    regression_run.status = "failed"
+    regression_run.summary_json = {"gate_decision": "failed"}
+    change_set = AdvisorChangeSet(
+        tenant_id=tenant_id,
+        suite_version_id=suite_version_id,
+        target_ref="semantic_model:sales",
+        base_version_ref="semantic_model:sales@1",
+        base_etag="etag-1",
+        status="verified",
+        evidence_json={},
+        verification_run_id=verification_run.id,
+        regression_run_id=regression_run.id,
+        created_by="advisor",
+    )
+    test_session.add(change_set)
+    await test_session.commit()
+
+    rejected = await service.decide_promotion(tenant_id=tenant_id, change_set_id=str(change_set.id), actor_id="owner")
+    assert rejected.decision == "rejected"
+    regression_run.status = "passed"
+    regression_run.summary_json = {"gate_decision": "passed"}
+    change_set.status = "verified"
+    await test_session.commit()
+    accepted = await service.decide_promotion(tenant_id=tenant_id, change_set_id=str(change_set.id), actor_id="owner")
+    assert accepted.decision == "accepted"
+    decisions = (
+        await test_session.execute(select(PromotionDecision).where(PromotionDecision.change_set_id == change_set.id))
+    ).scalars().all()
+    assert {decision.decision for decision in decisions} == {"rejected", "accepted"}

--- a/server/tests/test_semantic_model_beta_api.py
+++ b/server/tests/test_semantic_model_beta_api.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from server.models.semantic_models import SemanticModel, SemanticModelAuditEvent
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_source_resource(test_client) -> dict:
+    response = await test_client.post(
+        "/api/source-resources",
+        json={
+            "resource_type": "web",
+            "name": "Metric contract source",
+            "source_url": "https://example.test/metrics",
+            "content": "Gross revenue is net paid order amount.",
+            "external_revision": "rev-semantic-1",
+            "metadata": {"source": "semantic-beta-test"},
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["data"]
+
+
+async def test_semantic_model_beta_lifecycle_keeps_partial_and_blocks_execution(test_client, test_session) -> None:
+    source = await _create_source_resource(test_client)
+    snapshot_id = source["latest_snapshot"]["id"]
+
+    create_response = await test_client.post(
+        "/api/data-models",
+        json={
+            "slug": "sales-beta",
+            "name": "Sales Beta",
+            "domain": "Sales",
+            "owner": "Revenue Analytics",
+            "datasource_id": source["id"],
+            "datasource_name": source["name"],
+            "datasource_kind": "source_resource",
+            "source_resource_ids": [source["id"]],
+            "source_snapshot_ids": [snapshot_id],
+            "manifest": {
+                "entities": [{"id": "orders", "table": "orders"}],
+                "metrics": [{"id": "gross_revenue", "formula": "SUM(orders.net_amount)"}],
+                "dimensions": [{"id": "region", "entityId": "orders", "field": "region"}],
+                "provenance": {"source": "unit-test"},
+            },
+        },
+    )
+
+    assert create_response.status_code == 201
+    created = create_response.json()["data"]
+    assert created["commercialStatus"] == "PARTIAL"
+    assert created["runtimeStatus"] == "not_certified"
+    assert created["publishedVersion"] is None
+    assert created["readinessDetail"]["status"] == "PARTIAL"
+    assert created["readinessDetail"]["blockers"]
+
+    list_response = await test_client.get("/api/semantic-models")
+    assert list_response.status_code == 200
+    assert list_response.json()["data"]["total"] == 1
+
+    validate_response = await test_client.post("/api/data-models/sales-beta/validate")
+    assert validate_response.status_code == 200
+    validated = validate_response.json()["data"]
+    assert validated["status"] == "beta"
+    assert validated["readinessLevel"] == "partial"
+    assert validated["readinessDetail"]["valid"] is False
+    assert validated["readinessDetail"]["blockers"]
+
+    publish_response = await test_client.post("/api/data-models/sales-beta/publish")
+    assert publish_response.status_code == 409
+    assert "beta" in publish_response.json()["message"].lower()
+
+    query_response = await test_client.post(
+        "/api/data-models/sales-beta/mcp/query_metric",
+        json={"metric": "gross_revenue"},
+    )
+    assert query_response.status_code == 409
+    assert "beta-blocked" in query_response.json()["message"]
+
+    model = (await test_session.execute(select(SemanticModel).where(SemanticModel.slug == "sales-beta"))).scalar_one()
+    assert model.published_version is None
+    audit_actions = (
+        (
+            await test_session.execute(
+                select(SemanticModelAuditEvent.action).where(SemanticModelAuditEvent.model_id == model.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert "semantic_model.beta.create" in audit_actions
+    assert "semantic_model.beta.validate" in audit_actions
+
+
+async def test_semantic_model_patch_requires_revision_and_source_provenance(test_client) -> None:
+    source = await _create_source_resource(test_client)
+    snapshot_id = source["latest_snapshot"]["id"]
+    create_response = await test_client.post(
+        "/api/data-models",
+        json={
+            "slug": "support-beta",
+            "name": "Support Beta",
+            "source_resource_ids": [source["id"]],
+            "source_snapshot_ids": [snapshot_id],
+            "manifest": {"entities": [], "metrics": []},
+        },
+    )
+    assert create_response.status_code == 201
+
+    missing_revision_response = await test_client.patch(
+        "/api/data-models/support-beta",
+        json={"name": "Support Beta Updated"},
+    )
+    assert missing_revision_response.status_code == 400
+    assert "expected_revision" in missing_revision_response.json()["message"]
+
+    stale_response = await test_client.patch(
+        "/api/data-models/support-beta",
+        json={"expected_revision": 99, "name": "Support Beta Updated"},
+    )
+    assert stale_response.status_code == 409
+    assert "revision" in stale_response.json()["message"]
+
+    bad_source_response = await test_client.patch(
+        "/api/data-models/support-beta",
+        json={"expected_revision": 1, "source_snapshot_ids": ["00000000-0000-0000-0000-000000000000"]},
+    )
+    assert bad_source_response.status_code == 404
+
+    patch_response = await test_client.patch(
+        "/api/data-models/support-beta",
+        json={
+            "expected_revision": 1,
+            "name": "Support Beta Updated",
+            "manifest": {
+                "entities": [{"id": "tickets", "table": "tickets"}],
+                "metrics": [{"id": "ticket_count", "formula": "COUNT(*)"}],
+            },
+        },
+    )
+    assert patch_response.status_code == 200
+    patched = patch_response.json()["data"]
+    assert patched["revision"] == 2
+    assert patched["name"] == "Support Beta Updated"
+    assert patched["commercialStatus"] == "PARTIAL"

--- a/server/tests/test_semantic_model_beta_persistence_migration.py
+++ b/server/tests/test_semantic_model_beta_persistence_migration.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Column, ForeignKey, MetaData, String, Table, create_engine, inspect
+
+from server.db.base import Base
+from server.migrations.versions import add_semantic_model_beta_foundation
+from server.models.semantic_models import SemanticModel, SemanticModelAuditEvent, SemanticModelVersion
+
+
+def _create_minimal_semantic_schema(engine) -> None:
+    metadata = MetaData()
+    Table("users", metadata, Column("id", String(36), primary_key=True))
+    Table(
+        "tenants",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("owner_id", String(36), ForeignKey("users.id"), nullable=False),
+    )
+    metadata.create_all(engine)
+
+
+def test_semantic_model_beta_models_are_registered() -> None:
+    assert SemanticModel.__tablename__ in Base.metadata.tables
+    assert SemanticModelVersion.__tablename__ in Base.metadata.tables
+    assert SemanticModelAuditEvent.__tablename__ in Base.metadata.tables
+
+
+def test_semantic_model_beta_migration_upgrade_and_downgrade_sqlite() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    _create_minimal_semantic_schema(engine)
+
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        operations = Operations(context)
+        original_op = add_semantic_model_beta_foundation.op
+        add_semantic_model_beta_foundation.op = operations
+        try:
+            add_semantic_model_beta_foundation.upgrade()
+            inspector = inspect(connection)
+            assert "semantic_models" in inspector.get_table_names()
+            assert "semantic_model_versions" in inspector.get_table_names()
+            assert "semantic_model_audit_events" in inspector.get_table_names()
+
+            model_columns = {column["name"] for column in inspector.get_columns("semantic_models")}
+            assert {"manifest_json", "source_snapshot_ids_json", "validation_result_json"}.issubset(model_columns)
+
+            add_semantic_model_beta_foundation.downgrade()
+            inspector = inspect(connection)
+            assert "semantic_models" not in inspector.get_table_names()
+            assert "semantic_model_versions" not in inspector.get_table_names()
+            assert "semantic_model_audit_events" not in inspector.get_table_names()
+        finally:
+            add_semantic_model_beta_foundation.op = original_op

--- a/server/tests/test_semantic_model_mcp_contract.py
+++ b/server/tests/test_semantic_model_mcp_contract.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+from fastmcp import FastMCP
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from server.mcp import tool_wrappers
+from server.mcp.tool_wrappers import (
+    create_semantic_model_wrapper,
+    create_source_resource_wrapper,
+    describe_semantic_model_wrapper,
+    list_semantic_models_wrapper,
+    publish_semantic_model_wrapper,
+    query_semantic_metric_wrapper,
+    update_semantic_model_wrapper,
+    validate_semantic_model_wrapper,
+)
+from server.mcp.tools import register_all_tools
+from server.models.semantic_models import SemanticModel
+from server.models.tenant import Tenant
+from server.models.tenant_member import TenantMember, TenantRole
+from server.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _patch_mcp_session_factory(test_engine, monkeypatch: pytest.MonkeyPatch):
+    test_session_factory = async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(tool_wrappers, "AsyncSessionFactory", test_session_factory)
+
+
+async def _seed_owner(test_session: AsyncSession) -> tuple[Tenant, User]:
+    owner = User(
+        id=uuid4(),
+        email=f"semantic-mcp-owner-{uuid4()}@example.test",
+        hashed_password="fakehash",
+        is_active=True,
+        is_verified=True,
+    )
+    test_session.add(owner)
+    await test_session.flush()
+    tenant = Tenant(
+        id=uuid4(),
+        name="Semantic MCP Tenant",
+        slug=f"semantic-mcp-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+        is_personal=True,
+    )
+    test_session.add(tenant)
+    await test_session.flush()
+    test_session.add(TenantMember(user_id=owner.id, tenant_id=tenant.id, role=TenantRole.OWNER.value))
+    await test_session.commit()
+    return tenant, owner
+
+
+async def _create_source_with_snapshot(tenant: Tenant, owner: User) -> dict:
+    payload = json.loads(
+        await create_source_resource_wrapper(
+            json.dumps(
+                {
+                    "resource_type": "web",
+                    "name": "Metric contract source",
+                    "source_url": "https://example.test/metrics",
+                    "content": "Gross revenue is net paid order amount.",
+                    "external_revision": "rev-semantic-mcp-1",
+                    "metadata": {"source": "semantic-mcp-test"},
+                }
+            ),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert payload["success"] is True
+    return payload["resource"]
+
+
+async def test_semantic_model_mcp_tools_are_registered() -> None:
+    async def get_session():
+        return {"session_id": "test", "tenant_id": uuid4(), "user_id": uuid4(), "notebook_id": None}
+
+    mcp = FastMCP("semantic-registration-test")
+    register_all_tools(mcp, get_session)
+
+    names = {tool.name for tool in await mcp.list_tools()}
+
+    assert {
+        "list_semantic_models",
+        "describe_semantic_model",
+        "create_semantic_model",
+        "update_semantic_model",
+        "validate_semantic_model",
+        "publish_semantic_model",
+        "query_semantic_metric",
+    }.issubset(names)
+
+
+async def test_semantic_model_mcp_beta_lifecycle_and_blocked_runtime(
+    test_session: AsyncSession,
+) -> None:
+    tenant, owner = await _seed_owner(test_session)
+    source = await _create_source_with_snapshot(tenant, owner)
+
+    created_payload = json.loads(
+        await create_semantic_model_wrapper(
+            json.dumps(
+                {
+                    "slug": "sales-mcp-beta",
+                    "name": "Sales MCP Beta",
+                    "domain": "Sales",
+                    "owner": "Revenue Analytics",
+                    "datasource_id": source["id"],
+                    "datasource_name": source["name"],
+                    "datasource_kind": "source_resource",
+                    "source_resource_ids": [source["id"]],
+                    "source_snapshot_ids": [source["latest_snapshot"]["id"]],
+                    "manifest": {
+                        "entities": [{"id": "orders", "table": "orders"}],
+                        "metrics": [{"id": "gross_revenue", "formula": "SUM(orders.net_amount)"}],
+                        "dimensions": [{"id": "region", "entityId": "orders", "field": "region"}],
+                        "provenance": {"source": "mcp-test"},
+                    },
+                }
+            ),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert created_payload["success"] is True
+    created = created_payload["model"]
+    assert created["commercialStatus"] == "PARTIAL"
+    assert created["runtimeStatus"] == "not_certified"
+    assert created["publishedVersion"] is None
+    assert created["readinessDetail"]["status"] == "PARTIAL"
+    assert created["readinessDetail"]["valid"] is False
+
+    listed = json.loads(await list_semantic_models_wrapper(tenant.id, owner.id, query="sales"))
+    assert listed["success"] is True
+    assert listed["items"][0]["slug"] == "sales-mcp-beta"
+    assert listed["commercial_status"] == "PARTIAL"
+
+    described = json.loads(await describe_semantic_model_wrapper("sales-mcp-beta", tenant.id, owner.id))
+    assert described["success"] is True
+    assert described["model"]["sourceSnapshotIds"] == [source["latest_snapshot"]["id"]]
+
+    stale_patch = json.loads(
+        await update_semantic_model_wrapper(
+            "sales-mcp-beta",
+            json.dumps({"expected_revision": 99, "name": "stale"}),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert stale_patch["success"] is False
+    assert stale_patch["status_code"] == 409
+
+    patched = json.loads(
+        await update_semantic_model_wrapper(
+            "sales-mcp-beta",
+            json.dumps(
+                {
+                    "expected_revision": 1,
+                    "name": "Sales MCP Beta Reviewed",
+                    "manifest": {
+                        "entities": [{"id": "orders", "table": "orders"}],
+                        "metrics": [{"id": "gross_revenue", "formula": "SUM(orders.net_amount)"}],
+                    },
+                }
+            ),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert patched["success"] is True
+    assert patched["model"]["revision"] == 2
+    assert patched["model"]["name"] == "Sales MCP Beta Reviewed"
+
+    validated = json.loads(await validate_semantic_model_wrapper("sales-mcp-beta", tenant.id, owner.id))
+    assert validated["success"] is True
+    assert validated["model"]["readinessLevel"] == "partial"
+    assert validated["model"]["readinessDetail"]["blockers"]
+
+    publish = json.loads(await publish_semantic_model_wrapper("sales-mcp-beta", tenant.id, owner.id))
+    assert publish["success"] is False
+    assert publish["status_code"] == 409
+    assert "beta" in publish["error"].lower()
+
+    metric = json.loads(await query_semantic_metric_wrapper("sales-mcp-beta", tenant.id, owner.id))
+    assert metric["success"] is False
+    assert metric["status_code"] == 409
+    assert "beta-blocked" in metric["error"]
+
+    model = (
+        await test_session.execute(select(SemanticModel).where(SemanticModel.slug == "sales-mcp-beta"))
+    ).scalar_one()
+    assert model.published_version is None

--- a/server/tests/test_sharing_canonical_service.py
+++ b/server/tests/test_sharing_canonical_service.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.dashboard import Dashboard
+from server.models.notebooks import Notebook
+from server.models.sharing import SharingAuditEvent, SharingGrant, SharingSecret
+from server.models.tenant import Tenant
+from server.models.user import User
+from server.services.sharing import SharingService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_dashboard(test_session: AsyncSession) -> tuple[UUID, UUID, UUID, str]:
+    owner = User(
+        id=uuid4(),
+        email=f"sharing-owner-{uuid4().hex[:8]}@example.test",
+        hashed_password="fakehash",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    test_session.add(owner)
+    await test_session.flush()
+    tenant = Tenant(
+        id=uuid4(),
+        name="Sharing Tenant",
+        slug=f"sharing-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+        is_personal=True,
+    )
+    test_session.add(tenant)
+    await test_session.flush()
+    notebook = Notebook(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        created_by=owner.id,
+        notebook_name="Sharing notebook",
+        description="Canonical sharing fixture",
+    )
+    html_content = "<section>sharing</section>"
+    dashboard = Dashboard(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        notebook_id=notebook.id,
+        version_num=3,
+        html_content=html_content,
+    )
+    test_session.add(notebook)
+    await test_session.flush()
+    test_session.add(dashboard)
+    await test_session.commit()
+    return tenant.id, owner.id, dashboard.id, "sha256:" + hashlib.sha256(html_content.encode()).hexdigest()
+
+
+async def test_canonical_dashboard_share_pins_version_and_never_reads_secret(test_session: AsyncSession) -> None:
+    tenant_id, owner_id, dashboard_id, version_hash = await _seed_dashboard(test_session)
+    service = SharingService(test_session)
+
+    grant = await service.create_dashboard_public_link(
+        tenant_id=tenant_id,
+        actor_id=owner_id,
+        dashboard_id=dashboard_id,
+        password="plain-password",
+        metadata={"password": "plain-password", "sql": "select * from restricted_table"},
+    )
+
+    assert grant.object_type == "dashboard"
+    assert grant.object_id == dashboard_id
+    assert grant.object_version_id == dashboard_id
+    assert grant.object_version_digest == version_hash
+    assert grant.mode == "immutable_version"
+    assert grant.status == "active"
+
+    secret = (await test_session.execute(select(SharingSecret).where(SharingSecret.grant_id == grant.id))).scalar_one()
+    assert secret.secret_type == "password"
+    assert secret.verifier_hash != "plain-password"
+    assert secret.salt
+    serialized_secret = json.dumps(
+        {
+            "hash": secret.verifier_hash,
+            "salt": secret.salt,
+            "algorithm": secret.algorithm,
+        }
+    )
+    assert "plain-password" not in serialized_secret
+    assert await service.verify_grant_secret(grant_id=grant.id, secret="plain-password") is True
+    assert await service.verify_grant_secret(grant_id=grant.id, secret="wrong-password") is False
+
+    audit_details = (
+        await test_session.execute(
+            select(SharingAuditEvent.details_json).where(SharingAuditEvent.action == "sharing.grant.create")
+        )
+    ).scalar_one()
+    assert "plain-password" not in json.dumps(audit_details)
+    assert "restricted_table" not in json.dumps(audit_details)
+
+
+async def test_viewer_session_binds_grant_object_version_and_revocation(test_session: AsyncSession) -> None:
+    tenant_id, owner_id, dashboard_id, _ = await _seed_dashboard(test_session)
+    service = SharingService(test_session)
+    grant = await service.create_dashboard_public_link(
+        tenant_id=tenant_id,
+        actor_id=owner_id,
+        dashboard_id=dashboard_id,
+    )
+
+    token, viewer_session = await service.issue_viewer_session(
+        tenant_id=tenant_id,
+        grant_id=grant.id,
+        viewer_user_id=owner_id,
+        principal={"email": "viewer@example.test", "token": "raw-token"},
+    )
+
+    assert viewer_session.grant_id == grant.id
+    assert viewer_session.object_type == "dashboard"
+    assert viewer_session.object_id == dashboard_id
+    assert viewer_session.object_version_id == dashboard_id
+    assert viewer_session.issued_at.tzinfo is None
+    assert viewer_session.expires_at.tzinfo is None
+    assert viewer_session.token_digest.startswith("sha256:")
+    assert token not in viewer_session.token_digest
+    assert "raw-token" not in json.dumps(viewer_session.viewer_principal_json)
+
+    resolved = await service.require_viewer_session(
+        token=token,
+        grant_id=grant.id,
+        object_id=dashboard_id,
+        object_version_id=dashboard_id,
+    )
+    assert resolved is not None and resolved.id == viewer_session.id
+
+    wrong_version = await service.require_viewer_session(
+        token=token,
+        grant_id=grant.id,
+        object_id=dashboard_id,
+        object_version_id=uuid4(),
+    )
+    assert wrong_version is None
+
+    await service.revoke_grant(
+        tenant_id=tenant_id,
+        grant_id=grant.id,
+        actor_id=owner_id,
+        reason="Owner rotated public link",
+    )
+    revoked = await test_session.get(SharingGrant, grant.id)
+    assert revoked is not None and revoked.status == "revoked"
+    assert revoked.revoked_at is not None
+    assert revoked.revoked_at.tzinfo is None
+    assert (
+        await service.require_viewer_session(
+            token=token,
+            grant_id=grant.id,
+            object_id=dashboard_id,
+            object_version_id=dashboard_id,
+        )
+        is None
+    )
+
+    audit_actions = (
+        await test_session.execute(
+            select(SharingAuditEvent.action, SharingAuditEvent.outcome).where(SharingAuditEvent.grant_id == grant.id)
+        )
+    ).all()
+    assert ("sharing.viewer_session.issue", "issued") in audit_actions
+    assert ("sharing.grant.revoke", "revoked") in audit_actions
+
+
+def test_sharing_service_uses_naive_utc_timestamps_for_database_columns() -> None:
+    assert SharingService._now().tzinfo is None

--- a/server/tests/test_sharing_folder_integration.py
+++ b/server/tests/test_sharing_folder_integration.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from server.models.dashboard import Dashboard
+from server.models.folder import Folder
+from server.models.notebooks import Notebook
+from server.models.sharing import SharingCompatibilityLink, SharingGrant
+from server.models.tenant import Tenant
+from server.models.user import User
+from server.services.folder_service import FolderService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_workspace(test_session: AsyncSession) -> tuple[UUID, UUID, UUID, UUID, UUID]:
+    owner = User(
+        id=uuid4(),
+        email=f"folder-sharing-owner-{uuid4().hex[:8]}@example.test",
+        hashed_password="fakehash",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    test_session.add(owner)
+    await test_session.flush()
+    tenant = Tenant(
+        id=uuid4(),
+        name="Folder Sharing Tenant",
+        slug=f"folder-sharing-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+        is_personal=True,
+    )
+    test_session.add(tenant)
+    await test_session.flush()
+    folder = Folder(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        created_by=owner.id,
+        name="Shared folder",
+        description="Canonical sharing integration",
+    )
+    notebook = Notebook(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        created_by=owner.id,
+        notebook_name="Shared notebook",
+        description="Notebook share fixture",
+    )
+    dashboard = Dashboard(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        notebook_id=notebook.id,
+        version_num=1,
+        html_content="<main>dashboard</main>",
+    )
+    test_session.add_all([folder, notebook])
+    await test_session.flush()
+    test_session.add(dashboard)
+    await test_session.commit()
+    return tenant.id, owner.id, folder.id, notebook.id, dashboard.id
+
+
+async def test_folder_notebook_share_creates_and_revokes_canonical_grant(test_session: AsyncSession) -> None:
+    tenant_id, owner_id, folder_id, notebook_id, _dashboard_id = await _seed_workspace(test_session)
+
+    folder_notebook = await FolderService.share_notebook_to_folder(
+        folder_id=folder_id,
+        notebook_id=notebook_id,
+        shared_by=owner_id,
+        is_snapshot=False,
+        session=test_session,
+    )
+
+    grant = (
+        await test_session.execute(
+            select(SharingGrant)
+            .join(SharingCompatibilityLink, SharingCompatibilityLink.grant_id == SharingGrant.id)
+            .where(
+                SharingGrant.tenant_id == tenant_id,
+                SharingCompatibilityLink.legacy_surface == "folder_notebook",
+                SharingCompatibilityLink.legacy_id == str(folder_notebook.id),
+            )
+        )
+    ).scalar_one()
+    assert grant.object_type == "notebook"
+    assert grant.object_id == notebook_id
+    assert grant.channel == "folder"
+    assert grant.status == "active"
+
+    removed = await FolderService.unshare_notebook_from_folder(
+        folder_id=folder_id,
+        notebook_id=notebook_id,
+        user_id=owner_id,
+        session=test_session,
+    )
+    assert removed is True
+    revoked = await test_session.get(SharingGrant, grant.id)
+    assert revoked is not None
+    assert revoked.status == "revoked"
+    assert revoked.revoked_at is not None
+
+
+async def test_folder_dashboard_share_creates_and_revokes_canonical_grant(test_session: AsyncSession) -> None:
+    tenant_id, owner_id, folder_id, _notebook_id, dashboard_id = await _seed_workspace(test_session)
+
+    folder_dashboard = await FolderService.share_dashboard_to_folder(
+        folder_id=folder_id,
+        dashboard_id=dashboard_id,
+        shared_by=owner_id,
+        is_snapshot=False,
+        session=test_session,
+    )
+
+    grant = (
+        await test_session.execute(
+            select(SharingGrant)
+            .join(SharingCompatibilityLink, SharingCompatibilityLink.grant_id == SharingGrant.id)
+            .where(
+                SharingGrant.tenant_id == tenant_id,
+                SharingCompatibilityLink.legacy_surface == "folder_dashboard",
+                SharingCompatibilityLink.legacy_id == str(folder_dashboard.id),
+            )
+        )
+    ).scalar_one()
+    assert grant.object_type == "dashboard"
+    assert grant.object_id == dashboard_id
+    assert grant.object_version_id == dashboard_id
+    assert grant.channel == "folder"
+    assert grant.status == "active"
+
+    removed = await FolderService.unshare_dashboard_from_folder(
+        folder_id=folder_id,
+        dashboard_id=dashboard_id,
+        user_id=owner_id,
+        session=test_session,
+    )
+    assert removed is True
+    revoked = await test_session.get(SharingGrant, grant.id)
+    assert revoked is not None
+    assert revoked.status == "revoked"
+    assert revoked.revoked_at is not None

--- a/server/tests/test_sharing_persistence_migration.py
+++ b/server/tests/test_sharing_persistence_migration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Column, ForeignKey, MetaData, String, Table, create_engine, inspect
+
+from server.db.base import Base
+from server.migrations.versions import add_canonical_sharing_model
+from server.models.sharing import (
+    SharingAuditEvent,
+    SharingCompatibilityLink,
+    SharingGrant,
+    SharingSecret,
+    SharingViewerSession,
+)
+
+
+def _create_minimal_legacy_schema(engine) -> None:
+    metadata = MetaData()
+    Table("users", metadata, Column("id", String(36), primary_key=True))
+    Table(
+        "tenants",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("owner_id", String(36), ForeignKey("users.id"), nullable=False),
+    )
+    Table("folder_notebooks", metadata, Column("id", String(36), primary_key=True))
+    Table("folder_dashboards", metadata, Column("id", String(36), primary_key=True))
+    metadata.create_all(engine)
+
+
+def test_canonical_sharing_models_are_registered() -> None:
+    for model in (
+        SharingGrant,
+        SharingSecret,
+        SharingViewerSession,
+        SharingAuditEvent,
+        SharingCompatibilityLink,
+    ):
+        assert model.__tablename__ in Base.metadata.tables
+
+
+def test_canonical_sharing_migration_upgrade_and_downgrade_sqlite() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    _create_minimal_legacy_schema(engine)
+
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        operations = Operations(context)
+        original_op = add_canonical_sharing_model.op
+        add_canonical_sharing_model.op = operations
+        try:
+            add_canonical_sharing_model.upgrade()
+            inspector = inspect(connection)
+            table_names = set(inspector.get_table_names())
+            assert {
+                "sharing_grants",
+                "sharing_secrets",
+                "sharing_viewer_sessions",
+                "sharing_audit_events",
+                "sharing_compatibility_links",
+            }.issubset(table_names)
+            assert "folder_notebooks" in table_names
+            assert "folder_dashboards" in table_names
+
+            grant_columns = {column["name"] for column in inspector.get_columns("sharing_grants")}
+            assert {"object_type", "object_id", "object_version_id", "object_version_digest", "status"}.issubset(
+                grant_columns
+            )
+            secret_columns = {column["name"] for column in inspector.get_columns("sharing_secrets")}
+            assert {"salt", "verifier_hash", "algorithm"}.issubset(secret_columns)
+            session_columns = {column["name"] for column in inspector.get_columns("sharing_viewer_sessions")}
+            assert {"grant_id", "object_id", "object_version_id", "token_digest"}.issubset(session_columns)
+
+            add_canonical_sharing_model.downgrade()
+            table_names = set(inspect(connection).get_table_names())
+            assert "sharing_grants" not in table_names
+            assert "folder_notebooks" in table_names
+            assert "folder_dashboards" in table_names
+        finally:
+            add_canonical_sharing_model.op = original_op

--- a/server/tests/test_sharing_read_surface.py
+++ b/server/tests/test_sharing_read_surface.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from server.mcp import tool_wrappers
+from server.mcp.tool_wrappers import describe_sharing_grant_wrapper, list_sharing_grants_wrapper
+from server.models.notebooks import Notebook
+from server.models.sharing import SharingAuditEvent, SharingCompatibilityLink, SharingGrant, SharingSecret
+from server.models.tenant import Tenant
+from server.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_notebook_grant(test_session: AsyncSession) -> tuple[Tenant, User, SharingGrant]:
+    tenant = (await test_session.execute(select(Tenant))).scalars().first()
+    if tenant is None:
+        owner = User(
+            id=uuid4(),
+            email=f"sharing-read-owner-{uuid4().hex[:8]}@example.test",
+            hashed_password="fakehash",
+            is_active=True,
+            is_verified=True,
+        )
+        test_session.add(owner)
+        await test_session.flush()
+        tenant = Tenant(
+            id=uuid4(),
+            name="Sharing read tenant",
+            slug=f"sharing-read-{uuid4().hex[:8]}",
+            owner_id=owner.id,
+            is_personal=True,
+        )
+        test_session.add(tenant)
+        await test_session.flush()
+    owner = await test_session.get(User, tenant.owner_id)
+    assert owner is not None
+    notebook = Notebook(
+        id=uuid4(),
+        tenant_id=tenant.id,
+        created_by=owner.id,
+        notebook_name="Sharing read surface notebook",
+        description="Notebook grant fixture",
+    )
+    grant = SharingGrant(
+        tenant_id=tenant.id,
+        object_type="notebook",
+        object_id=notebook.id,
+        object_version_id=None,
+        object_version_digest="",
+        mode="live_notebook",
+        channel="folder",
+        audience="folder_member",
+        status="active",
+        created_by=owner.id,
+        metadata_json={
+            "legacy_surface": "folder_notebook",
+            "legacy_id": "legacy-folder-notebook-1",
+            "password": "plain-password",
+            "token": "raw-token",
+        },
+    )
+    test_session.add(notebook)
+    test_session.add(grant)
+    await test_session.flush()
+    test_session.add(
+        SharingCompatibilityLink(
+            tenant_id=tenant.id,
+            grant_id=grant.id,
+            legacy_surface="folder_notebook",
+            legacy_id="legacy-folder-notebook-1",
+            metadata_json={"notebook_id": str(notebook.id), "verifier": "raw-verifier"},
+        )
+    )
+    test_session.add(
+        SharingSecret(
+            tenant_id=tenant.id,
+            grant_id=grant.id,
+            secret_type="password",
+            algorithm="pbkdf2_sha256:210000",
+            salt="raw-salt",
+            verifier_hash="sha256:raw-verifier-hash",
+            status="active",
+            created_by=owner.id,
+        )
+    )
+    test_session.add(
+        SharingAuditEvent(
+            tenant_id=tenant.id,
+            grant_id=grant.id,
+            object_type="notebook",
+            object_id=notebook.id,
+            object_version_id=None,
+            actor_type="human",
+            actor_id=str(owner.id),
+            action="sharing.test",
+            outcome="active",
+            details_json={"sql": "select * from restricted_table", "password": "plain-password"},
+        )
+    )
+    await test_session.commit()
+    return tenant, owner, grant
+
+
+async def test_sharing_rest_read_surface_is_tenant_scoped_and_redacted(test_client, test_session: AsyncSession) -> None:
+    tenant, _owner, grant = await _seed_notebook_grant(test_session)
+
+    list_response = await test_client.get("/api/sharing/grants?legacy_surface=folder_notebook")
+    assert list_response.status_code == 200
+    list_payload = list_response.json()["data"]
+    assert list_payload["total"] == 1
+    assert list_payload["items"][0]["id"] == str(grant.id)
+    assert list_payload["items"][0]["tenant_id"] == str(tenant.id)
+
+    describe_response = await test_client.get(f"/api/sharing/grants/{grant.id}")
+    assert describe_response.status_code == 200
+    evidence = describe_response.json()["data"]
+    assert evidence["grant"]["id"] == str(grant.id)
+    assert evidence["compatibility_links"][0]["legacy_surface"] == "folder_notebook"
+    assert evidence["has_secret"] is True
+    assert evidence["secret_counts"] == [{"secret_type": "password", "status": "active", "count": 1}]
+    assert evidence["audit_events"][0]["action"] == "sharing.test"
+
+    serialized = json.dumps(evidence)
+    assert "plain-password" not in serialized
+    assert "raw-token" not in serialized
+    assert "raw-verifier" not in serialized
+    assert "raw-salt" not in serialized
+    assert "raw-verifier-hash" not in serialized
+    assert "restricted_table" not in serialized
+
+    other_user = User(
+        id=uuid4(),
+        email=f"sharing-read-other-{uuid4().hex[:8]}@example.test",
+        hashed_password="fakehash",
+        is_active=True,
+        is_verified=True,
+    )
+    other_tenant = Tenant(
+        id=uuid4(),
+        name="Other sharing tenant",
+        slug=f"other-sharing-{uuid4().hex[:8]}",
+        owner_id=other_user.id,
+        is_personal=True,
+    )
+    test_session.add(other_user)
+    await test_session.flush()
+    test_session.add(other_tenant)
+    await test_session.commit()
+    not_found = await test_client.get(
+        f"/api/sharing/grants/{grant.id}",
+        headers={"x-tenant-id": str(other_tenant.id), "X-Local-User-ID": str(other_user.id)},
+    )
+    assert not_found.status_code == 404
+
+
+@pytest.fixture(autouse=True)
+def _patch_mcp_session_factory(test_engine, monkeypatch: pytest.MonkeyPatch):
+    test_session_factory = async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(tool_wrappers, "AsyncSessionFactory", test_session_factory)
+
+
+async def test_sharing_mcp_read_surface_matches_rest_redaction(test_session: AsyncSession) -> None:
+    tenant, owner, grant = await _seed_notebook_grant(test_session)
+
+    list_payload = json.loads(
+        await list_sharing_grants_wrapper(
+            tenant.id,
+            owner.id,
+            legacy_surface="folder_notebook",
+        )
+    )
+    assert list_payload["success"] is True
+    assert list_payload["total"] == 1
+    assert list_payload["items"][0]["id"] == str(grant.id)
+
+    evidence = json.loads(await describe_sharing_grant_wrapper(str(grant.id), tenant.id, owner.id))
+    assert evidence["success"] is True
+    assert evidence["grant"]["id"] == str(grant.id)
+    assert evidence["compatibility_links"][0]["legacy_surface"] == "folder_notebook"
+    assert evidence["has_secret"] is True
+
+    serialized = json.dumps(evidence)
+    assert "plain-password" not in serialized
+    assert "raw-token" not in serialized
+    assert "raw-verifier" not in serialized
+    assert "raw-salt" not in serialized
+    assert "raw-verifier-hash" not in serialized
+    assert "restricted_table" not in serialized

--- a/server/tests/test_source_connector_contract.py
+++ b/server/tests/test_source_connector_contract.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from server.services.connector_catalog import get_connector_definition, list_connector_definitions
+
+
+def test_connector_catalog_is_partial_beta_not_available() -> None:
+    payloads = list_connector_definitions()
+    by_id = {item["id"]: item for item in payloads}
+
+    for connector_id in ("local_files", "web", "feishu", "sql_databases", "volcengine_tos", "databricks"):
+        definition = by_id[connector_id]
+        assert definition["availability"] == "beta"
+        assert definition["status"] == "beta"
+        assert definition["readiness_gates"]
+        assert {gate["status"] for gate in definition["readiness_gates"]}.issubset(
+            {"partial", "missing", "not_applicable"}
+        )
+
+    assert get_connector_definition("feishu") is not None
+    assert by_id["aliyun_oss"]["availability"] == "planned"
+    assert "available" not in {item["availability"] for item in payloads}

--- a/server/tests/test_source_connector_mcp_contract.py
+++ b/server/tests/test_source_connector_mcp_contract.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+from fastmcp import FastMCP
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from server.mcp import tool_wrappers
+from server.mcp.tool_wrappers import (
+    create_source_connection_wrapper,
+    create_source_resource_wrapper,
+    describe_source_resource_wrapper,
+    disconnect_source_connection_wrapper,
+    list_connector_definitions_wrapper,
+    list_source_connections_wrapper,
+    list_source_resources_wrapper,
+    sync_source_resource_wrapper,
+)
+from server.mcp.tools import register_all_tools
+from server.models.source_connections import SourceConnection
+from server.models.tenant import Tenant
+from server.models.tenant_member import TenantMember, TenantRole
+from server.models.user import User
+from server.services.crypto_service import CryptoService
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _patch_mcp_session_factory(test_engine, monkeypatch: pytest.MonkeyPatch):
+    test_session_factory = async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    monkeypatch.setattr(tool_wrappers, "AsyncSessionFactory", test_session_factory)
+
+
+async def _seed_owner(test_session: AsyncSession) -> tuple[Tenant, User]:
+    owner = User(
+        id=uuid4(),
+        email=f"source-mcp-owner-{uuid4()}@example.test",
+        hashed_password="fakehash",
+        is_active=True,
+        is_verified=True,
+    )
+    test_session.add(owner)
+    await test_session.flush()
+    tenant = Tenant(
+        id=uuid4(),
+        name="Source MCP Tenant",
+        slug=f"source-mcp-{uuid4().hex[:8]}",
+        owner_id=owner.id,
+        is_personal=True,
+    )
+    test_session.add(tenant)
+    await test_session.flush()
+    test_session.add(TenantMember(user_id=owner.id, tenant_id=tenant.id, role=TenantRole.OWNER.value))
+    await test_session.commit()
+    return tenant, owner
+
+
+async def test_source_connector_mcp_tools_are_registered() -> None:
+    async def get_session():
+        return {"session_id": "test", "tenant_id": uuid4(), "user_id": uuid4(), "notebook_id": None}
+
+    mcp = FastMCP("source-registration-test")
+    register_all_tools(mcp, get_session)
+
+    names = {tool.name for tool in await mcp.list_tools()}
+
+    assert {
+        "list_connector_definitions",
+        "create_source_connection",
+        "list_source_connections",
+        "disconnect_source_connection",
+        "create_source_resource",
+        "list_source_resources",
+        "describe_source_resource",
+        "sync_source_resource",
+    }.issubset(names)
+
+
+async def test_source_connector_mcp_control_plane_lifecycle_and_redaction(
+    test_session: AsyncSession,
+) -> None:
+    tenant, owner = await _seed_owner(test_session)
+
+    catalog_payload = json.loads(
+        await list_connector_definitions_wrapper(
+            tenant.id,
+            owner.id,
+            provider="volcengine_tos",
+            include_planned=False,
+        )
+    )
+    assert catalog_payload["success"] is True
+    assert catalog_payload["summary"]["overall_status"] == "PARTIAL"
+    assert catalog_payload["items"][0]["availability"] == "beta"
+
+    connection_payload = json.loads(
+        await create_source_connection_wrapper(
+            json.dumps(
+                {
+                    "provider": "volcengine_tos",
+                    "auth_mode": "access_key",
+                    "display_name": "TOS MCP beta account",
+                    "external_account_id": "tos-mcp-account",
+                    "credentials": {
+                        "endpoint": "https://tos.example.test",
+                        "access_key_id": "AKIA_MCP_TEST_ONLY",
+                        "secret_access_key": "super-secret-mcp",
+                    },
+                }
+            ),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert connection_payload["success"] is True
+    assert connection_payload["connection"]["status"] == "beta"
+    serialized_connection_payload = json.dumps(connection_payload)
+    assert "credentials" not in serialized_connection_payload
+    assert "super-secret-mcp" not in serialized_connection_payload
+
+    connection = (
+        await test_session.execute(
+            select(SourceConnection).where(SourceConnection.id == connection_payload["connection"]["id"])
+        )
+    ).scalar_one()
+    assert "super-secret-mcp" not in connection.encrypted_credentials
+    decrypted = await CryptoService.decrypt_config(connection.encrypted_credentials, test_session)
+    assert decrypted["secret_access_key"] == "super-secret-mcp"
+
+    list_payload = json.loads(await list_source_connections_wrapper(tenant.id, owner.id, "volcengine_tos"))
+    assert list_payload["success"] is True
+    assert list_payload["total"] == 1
+    assert "super-secret-mcp" not in json.dumps(list_payload)
+
+    resource_payload = json.loads(
+        await create_source_resource_wrapper(
+            json.dumps(
+                {
+                    "resource_type": "tos_object",
+                    "name": "Revenue object",
+                    "external_id": "bucket/revenue.csv",
+                    "source_connection_id": connection_payload["connection"]["id"],
+                    "content": "region,revenue\nAMER,42\n",
+                    "external_revision": "etag-1",
+                    "metadata": {"source": "mcp-test", "token": "raw-token"},
+                }
+            ),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert resource_payload["success"] is True
+    assert resource_payload["resource"]["status"] == "ready"
+    assert resource_payload["resource"]["latest_snapshot"]["content_hash"].startswith("sha256:")
+    assert "raw-token" not in json.dumps(resource_payload)
+
+    resources = json.loads(await list_source_resources_wrapper(tenant.id, owner.id, query="revenue"))
+    assert resources["success"] is True
+    assert resources["items"][0]["name"] == "Revenue object"
+
+    described = json.loads(
+        await describe_source_resource_wrapper(resource_payload["resource"]["id"], tenant.id, owner.id)
+    )
+    assert described["success"] is True
+    assert described["snapshots"]["total"] == 1
+
+    synced = json.loads(
+        await sync_source_resource_wrapper(
+            resource_payload["resource"]["id"],
+            json.dumps({"content": "region,revenue\nEMEA,43\n", "external_revision": "etag-2"}),
+            tenant.id,
+            owner.id,
+        )
+    )
+    assert synced["success"] is True
+    assert synced["resource"]["latest_snapshot"]["external_revision"] == "etag-2"
+
+    disconnected = json.loads(
+        await disconnect_source_connection_wrapper(connection_payload["connection"]["id"], tenant.id, owner.id)
+    )
+    assert disconnected["success"] is True
+    assert disconnected["affected_resource_count"] == 1

--- a/server/tests/test_source_connector_persistence_migration.py
+++ b/server/tests/test_source_connector_persistence_migration.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import Column, ForeignKey, MetaData, String, Table, create_engine, inspect
+
+from server.db.base import Base
+from server.migrations.versions import add_source_connector_foundation
+from server.models.source_connections import SourceConnection
+from server.models.source_resources import SourceResource
+from server.models.source_snapshots import SourceSnapshot
+
+
+def _create_minimal_source_schema(engine) -> None:
+    metadata = MetaData()
+    Table("users", metadata, Column("id", String(36), primary_key=True))
+    Table(
+        "tenants",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("owner_id", String(36), ForeignKey("users.id"), nullable=False),
+    )
+    Table("connections", metadata, Column("id", String(36), primary_key=True))
+    metadata.create_all(engine)
+
+
+def test_source_persistence_models_are_registered() -> None:
+    assert SourceConnection.__tablename__ in Base.metadata.tables
+    assert SourceResource.__tablename__ in Base.metadata.tables
+    assert SourceSnapshot.__tablename__ in Base.metadata.tables
+
+
+def test_source_connector_migration_upgrade_and_downgrade_sqlite() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    _create_minimal_source_schema(engine)
+
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        operations = Operations(context)
+        original_op = add_source_connector_foundation.op
+        add_source_connector_foundation.op = operations
+        try:
+            add_source_connector_foundation.upgrade()
+            inspector = inspect(connection)
+            assert "source_connections" in inspector.get_table_names()
+            assert "source_resources" in inspector.get_table_names()
+            assert "source_snapshots" in inspector.get_table_names()
+
+            connection_columns = {column["name"] for column in inspector.get_columns("source_connections")}
+            assert {"encrypted_credentials", "capabilities_json", "status"}.issubset(connection_columns)
+            resource_columns = {column["name"] for column in inspector.get_columns("source_resources")}
+            assert {"source_connection_id", "latest_snapshot_id", "sync_config_json"}.issubset(resource_columns)
+
+            add_source_connector_foundation.downgrade()
+            inspector = inspect(connection)
+            assert "source_connections" not in inspector.get_table_names()
+            assert "source_resources" not in inspector.get_table_names()
+            assert "source_snapshots" not in inspector.get_table_names()
+        finally:
+            add_source_connector_foundation.op = original_op

--- a/server/tests/test_source_connector_rest_api.py
+++ b/server/tests/test_source_connector_rest_api.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from server.models.source_connections import SourceConnection
+from server.models.source_resources import SourceResource
+from server.models.tenant import Tenant
+from server.models.tenant_member import TenantMember, TenantRole
+from server.models.user import User
+from server.services.crypto_service import CryptoService
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_connector_definitions_endpoint_reports_partial_summary(test_client) -> None:
+    response = await test_client.get("/api/connector-definitions")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["summary"]["overall_status"] == "PARTIAL"
+    assert data["summary"]["ready"] == 0
+    assert data["summary"]["beta"] >= 6
+    assert data["summary"]["planned"] >= 1
+    assert all(item["availability"] != "available" for item in data["items"])
+
+
+async def test_source_connection_lifecycle_encrypts_and_redacts_credentials(test_client, test_session) -> None:
+    payload = {
+        "provider": "volcengine_tos",
+        "auth_mode": "access_key",
+        "display_name": "TOS beta account",
+        "external_account_id": "tos-account-1",
+        "credentials": {
+            "endpoint": "https://tos.example.test",
+            "region": "cn-north-1",
+            "access_key_id": "AKIA_TEST_ONLY",
+            "secret_access_key": "super-secret",
+        },
+    }
+
+    create_response = await test_client.post("/api/source-connections", json=payload)
+
+    assert create_response.status_code == 201
+    connection_payload = create_response.json()["data"]
+    assert connection_payload["provider"] == "volcengine_tos"
+    assert connection_payload["status"] == "beta"
+    assert "credentials" not in connection_payload
+    assert "secret_access_key" not in str(connection_payload)
+
+    connection = (
+        await test_session.execute(select(SourceConnection).where(SourceConnection.id == connection_payload["id"]))
+    ).scalar_one()
+    assert "super-secret" not in connection.encrypted_credentials
+    decrypted = await CryptoService.decrypt_config(connection.encrypted_credentials, test_session)
+    assert decrypted["secret_access_key"] == "super-secret"
+
+    list_response = await test_client.get("/api/source-connections?provider=volcengine_tos")
+    assert list_response.status_code == 200
+    assert list_response.json()["data"]["total"] == 1
+    assert "super-secret" not in str(list_response.json())
+
+    delete_response = await test_client.delete(f"/api/source-connections/{connection_payload['id']}")
+    assert delete_response.status_code == 200
+    await test_session.refresh(connection)
+    assert connection.status == "disconnected"
+
+
+async def test_source_resource_snapshot_and_tenant_isolation(test_client, test_session) -> None:
+    connection_response = await test_client.post(
+        "/api/source-connections",
+        json={
+            "provider": "web",
+            "auth_mode": "none",
+            "display_name": "Web metadata",
+            "credentials": {},
+        },
+    )
+    assert connection_response.status_code == 201
+    source_connection_id = connection_response.json()["data"]["id"]
+
+    create_response = await test_client.post(
+        "/api/source-resources",
+        json={
+            "resource_type": "web",
+            "name": "Quarterly plan",
+            "source_url": "https://example.test/plan",
+            "source_connection_id": source_connection_id,
+            "content": "Revenue plan source text",
+            "external_revision": "rev-1",
+            "metadata": {"source": "unit-test"},
+        },
+    )
+
+    assert create_response.status_code == 201
+    resource_payload = create_response.json()["data"]
+    assert resource_payload["status"] == "ready"
+    assert resource_payload["latest_snapshot"]["external_revision"] == "rev-1"
+    assert resource_payload["latest_snapshot"]["content_hash"].startswith("sha256:")
+
+    snapshot_response = await test_client.get(f"/api/source-resources/{resource_payload['id']}/snapshots")
+    assert snapshot_response.status_code == 200
+    assert snapshot_response.json()["data"]["total"] == 1
+
+    sync_response = await test_client.post(
+        f"/api/source-resources/{resource_payload['id']}/sync",
+        json={"content": "Revenue plan source text updated", "external_revision": "rev-2"},
+    )
+    assert sync_response.status_code == 200
+    assert sync_response.json()["data"]["latest_snapshot"]["external_revision"] == "rev-2"
+
+    resource = (
+        await test_session.execute(select(SourceResource).where(SourceResource.id == resource_payload["id"]))
+    ).scalar_one()
+    assert resource.tenant_id is not None
+
+    other_tenant_id = uuid4()
+    other_user_id = uuid4()
+    other_user = User(
+        id=other_user_id,
+        email="other@test.com",
+        hashed_password="fakehash",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    test_session.add(other_user)
+    await test_session.flush()
+    other_tenant = Tenant(
+        id=other_tenant_id,
+        name="Other Tenant",
+        slug="other-tenant",
+        owner_id=other_user_id,
+        is_personal=True,
+    )
+    test_session.add(other_tenant)
+    await test_session.flush()
+    test_session.add(TenantMember(user_id=other_user_id, tenant_id=other_tenant_id, role=TenantRole.OWNER.value))
+    await test_session.commit()
+
+    isolated_response = await test_client.get(
+        f"/api/source-resources/{resource_payload['id']}",
+        headers={"x-tenant-id": str(other_tenant_id)},
+    )
+    assert isolated_response.status_code == 404

--- a/server/tools/agentic.py
+++ b/server/tools/agentic.py
@@ -85,14 +85,11 @@ async def _load_dashboard_body(
 
 
 def _ensure_legacy_html_dashboard(dashboard: Any) -> None:
-    if (
-        dashboard.asset_id
-        and (
-            dashboard.manifest_json
-            or dashboard.manifest_schema_version
-            or dashboard.status != "legacy_unstructured"
-            or dashboard.migration_state != "legacy_unstructured"
-        )
+    if dashboard.asset_id and (
+        dashboard.manifest_json
+        or dashboard.manifest_schema_version
+        or dashboard.status != "legacy_unstructured"
+        or dashboard.migration_state != "legacy_unstructured"
     ):
         raise DashboardEditError(
             "Legacy HTML tools are deprecated for structured dashboards. "

--- a/server/tools/agentic.py
+++ b/server/tools/agentic.py
@@ -53,6 +53,7 @@ async def _load_dashboard_body(
         dashboard = await dashboard_repo.get_version(notebook_id, session_version)
         if not dashboard:
             raise DashboardEditError(f"Session version {session_version} not found for notebook {notebook_id}.")
+        _ensure_legacy_html_dashboard(dashboard)
         return dashboard.html_content, session_version
 
     base_version = ctx.context.get("current_version")
@@ -60,10 +61,12 @@ async def _load_dashboard_body(
         dashboard = await dashboard_repo.get_version(notebook_id, base_version)
         if not dashboard:
             raise DashboardEditError(f"Base version {base_version} not found for notebook {notebook_id}.")
+        _ensure_legacy_html_dashboard(dashboard)
         return dashboard.html_content, None
 
     latest_dashboard = await dashboard_repo.get_latest_version(notebook_id)
     if latest_dashboard:
+        _ensure_legacy_html_dashboard(latest_dashboard)
         return latest_dashboard.html_content, None
 
     BASE_TEMPLATE = """<!DOCTYPE html>
@@ -79,6 +82,22 @@ async def _load_dashboard_body(
 </body>
 </html>"""
     return BASE_TEMPLATE, None
+
+
+def _ensure_legacy_html_dashboard(dashboard: Any) -> None:
+    if (
+        dashboard.asset_id
+        and (
+            dashboard.manifest_json
+            or dashboard.manifest_schema_version
+            or dashboard.status != "legacy_unstructured"
+            or dashboard.migration_state != "legacy_unstructured"
+        )
+    ):
+        raise DashboardEditError(
+            "Legacy HTML tools are deprecated for structured dashboards. "
+            "Use governed dashboard manifest tools with base_etag JSON Patch instead."
+        )
 
 
 async def _persist_dashboard_body(
@@ -808,6 +827,8 @@ async def get_existing_html(ctx: RunContextWrapper[Any]) -> str:
                         indent=2,
                         default=str,
                     )
+
+                _ensure_legacy_html_dashboard(latest_dashboard)
 
                 # Get the HTML content from database
                 html_content = latest_dashboard.html_content

--- a/server/utils/error_sanitizer.py
+++ b/server/utils/error_sanitizer.py
@@ -1,19 +1,55 @@
 """
-Utility for sanitizing error messages to prevent credential exposure.
-
-This module provides functions to redact sensitive patterns like API keys,
-Bearer tokens, passwords, and connection strings from error messages before
-they are returned to clients.
+Utilities for sanitizing error and evidence payloads before returning them to clients.
 """
 
+from __future__ import annotations
+
 import re
+from typing import Any
+
+REDACTION_TEXT = "[REDACTED]"
+
+SENSITIVE_KEYS = {
+    "authorization",
+    "api_key",
+    "apikey",
+    "api-key",
+    "access_token",
+    "access-token",
+    "refresh_token",
+    "refresh-token",
+    "token",
+    "raw_token",
+    "raw-token",
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "verifier",
+    "credential",
+    "credentials",
+    "connection_string",
+    "connection-string",
+    "sql",
+    "query",
+}
+
+SENSITIVE_KEY_PATTERN = (
+    r"authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|raw[_-]?token|"
+    r"token|password|passwd|pwd|secret|verifier|credentials?|connection[_-]?string|sql|query"
+)
 
 SENSITIVE_PATTERNS = [
+    (re.compile(r"\bselect\b[\s\S]*?\bfrom\b[\s\S]*", re.IGNORECASE), "[REDACTED_SQL]"),
     (re.compile(r"(Authorization:\s*)(Bearer\s+)?[\w\-\.]+", re.IGNORECASE), r"\1[REDACTED]"),
-    (re.compile(r"(api[_-]?key[\"']?\s*[:=]\s*[\"']?)[\w\-]+", re.IGNORECASE), r"\1[REDACTED]"),
-    (re.compile(r"(token[\"']?\s*[:=]\s*[\"']?)[\w\-]+", re.IGNORECASE), r"\1[REDACTED]"),
-    (re.compile(r"(password[\"']?\s*[:=]\s*[\"']?)[\w\-]+", re.IGNORECASE), r"\1[REDACTED]"),
-    (re.compile(r"(secret[\"']?\s*[:=]\s*[\"']?)[\w\-]+", re.IGNORECASE), r"\1[REDACTED]"),
+    (
+        re.compile(rf"((?:\"|')?(?:{SENSITIVE_KEY_PATTERN})(?:\"|')?\s*[:=]\s*)([\"'])(.*?)(\2)", re.IGNORECASE),
+        rf"\1\2{REDACTION_TEXT}\4",
+    ),
+    (
+        re.compile(rf"((?:\"|')?(?:{SENSITIVE_KEY_PATTERN})(?:\"|')?\s*[:=]\s*)[^\s,}}\]\n]+", re.IGNORECASE),
+        rf"\1{REDACTION_TEXT}",
+    ),
     (re.compile(r"Bearer\s+[\w\-\.]+", re.IGNORECASE), "Bearer [REDACTED]"),
     (re.compile(r"mongodb://[^@]+@", re.IGNORECASE), "mongodb://[REDACTED]@"),
     (re.compile(r"postgres://[^@]+@", re.IGNORECASE), "postgres://[REDACTED]@"),
@@ -21,17 +57,31 @@ SENSITIVE_PATTERNS = [
 ]
 
 
-def sanitize_error_message(error: Exception) -> str:
-    """
-    Sanitize an error message by redacting sensitive patterns.
-
-    Args:
-        error: The exception to sanitize
-
-    Returns:
-        A sanitized string representation of the error
-    """
-    message = str(error)
+def sanitize_text(message: str) -> str:
+    sanitized = message
     for pattern, replacement in SENSITIVE_PATTERNS:
-        message = pattern.sub(replacement, message)
-    return message
+        sanitized = pattern.sub(replacement, sanitized)
+    return sanitized
+
+
+def sanitize_error_message(error: Exception | str) -> str:
+    return sanitize_text(str(error))
+
+
+def sanitize_error_payload(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        sanitized: dict[Any, Any] = {}
+        for key, value in payload.items():
+            key_text = str(key).lower()
+            if key_text in SENSITIVE_KEYS or any(sensitive in key_text for sensitive in SENSITIVE_KEYS):
+                sanitized[key] = REDACTION_TEXT
+            else:
+                sanitized[key] = sanitize_error_payload(value)
+        return sanitized
+    if isinstance(payload, list):
+        return [sanitize_error_payload(item) for item in payload]
+    if isinstance(payload, tuple):
+        return tuple(sanitize_error_payload(item) for item in payload)
+    if isinstance(payload, str):
+        return sanitize_text(payload)
+    return payload


### PR DESCRIPTION
## Summary

Selective official-history landing of the Data Studio commercial backend foundations from the staging evidence branch, without merging unrelated staging history or wholesale copying the staging tree.

This PR currently lands:

- landing manifest and migration plan
- canonical Sharing grants/read surfaces
- authoritative Evaluation backend contracts and APIs
- governed Dashboard assets/runs/audit backend and MCP wrappers
- Source Connector control-plane foundation
- Semantic Modeling beta control-plane foundation
- Source Connector MCP control-plane coverage
- Semantic Modeling beta MCP coverage
- minimal Playwright browser smoke gate for the authenticated community home page at desktop and mobile viewports
- client TypeScript/build compatibility fixes needed for the official `pnpm run build:check` gate

## Important readiness notes

Connector and Modeling remain beta/PARTIAL in this PR. The official branch does not claim live connector runtime, external credential execution, semantic model publishing, or metric query execution as production-ready.

Source Connector MCP tools register and inspect encrypted control-plane metadata only. They do not run external connector fetch/parser runtime.

Semantic Modeling MCP publish/query paths are intentionally beta-blocked with 409-style responses until runtime credentials, source provenance, and maintainer-reviewed validation are certified.

## Safety constraints followed

- No push to `origin`.
- No force push.
- No staging branch merge and no `--allow-unrelated-histories`.
- No `.github/workflows/**` edits.
- No screenshot/tmp image artifacts or lockfile replacement.
- No plaintext GitHub token use; relied only on existing `gh` keyring auth.

## Validation run locally

- Staging evidence checks: `STAGING_FINAL_SHA` exists remotely; `C_HEAD` and `D_HEAD` are ancestors; staging and official `origin/main` have no common ancestor.
- Official branch checks: worktree clean, `HEAD == @{u} == official-fork/integration/data-studio-commercial-official-p0`.
- Client typecheck: `pnpm exec tsc -b --pretty false` passed.
- Client build gate: `pnpm run build:check` passed.
- Playwright smoke: `pnpm run e2e` passed, `2 passed` across `chromium-desktop-1440x900` and `chromium-mobile-390x844`.
- Backend focused regression across Sharing/Evaluation/Dashboard/Source/Semantic surfaces: `60 passed, 59 warnings`.
- Alembic single head: `add_semantic_model_beta_foundation`.
- Fresh temporary SQLite Alembic upgrade to head: passed.
- Existing temporary SQLite upgrade from official pre-landing head `add_skill_loop_lease` to head: passed.
- Ruff format/check on the focused landed backend files/tests: passed.
- `git diff --check`: passed.
- Outgoing diff scans: no `.github/workflows/**`, screenshot/tmp/test-result artifacts, or obvious credential material.

Known non-gating note: Vite emits existing warnings about escaped arbitrary CSS selectors, static/dynamic import chunking, stale Browserslist data, and large bundle size, but `pnpm run build:check` exits 0.

## Current candidate

- Official candidate SHA: `3e9a3e5ebbbdcb909934d3c8fb014d7c754f9d9b`
- Previous candidate SHA: `845c210ed6244fdfbc0992daa6ff581f6b816983`
- Official base SHA: `1e3410fd29c09eb2dd01f88d31650120dd1aeb84`
- Staging evidence SHA: `082f209c476b26c4d5c891849532a7018a42a1f4`
